### PR TITLE
(Add) Config to Disable / Enable Client Connectable Check

### DIFF
--- a/app/Jobs/ProcessBasicAnnounceRequest.php
+++ b/app/Jobs/ProcessBasicAnnounceRequest.php
@@ -126,7 +126,7 @@ class ProcessBasicAnnounceRequest implements ShouldQueue
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
-        //$peer->updateConnectableStateIfNeeded();
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Jobs/ProcessCompletedAnnounceRequest.php
+++ b/app/Jobs/ProcessCompletedAnnounceRequest.php
@@ -128,7 +128,7 @@ class ProcessCompletedAnnounceRequest implements ShouldQueue
         $peer->left = 0;
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
-        //$peer->updateConnectableStateIfNeeded();
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Jobs/ProcessStartedAnnounceRequest.php
+++ b/app/Jobs/ProcessStartedAnnounceRequest.php
@@ -87,7 +87,7 @@ class ProcessStartedAnnounceRequest implements ShouldQueue
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
-        //$peer->updateConnectableStateIfNeeded();
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Jobs/ProcessStoppedAnnounceRequest.php
+++ b/app/Jobs/ProcessStoppedAnnounceRequest.php
@@ -128,7 +128,7 @@ class ProcessStoppedAnnounceRequest implements ShouldQueue
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
-        //$peer->updateConnectableStateIfNeeded();
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/config/announce.php
+++ b/config/announce.php
@@ -48,6 +48,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Client Connectable Check
+    |--------------------------------------------------------------------------
+    |
+    | This option toggles Client connectivity check
+    | !!! Attention: Will result in leaking the server IP !!!
+    | It will result in higher disc / DB IO
+    |
+    */
+
+    'connectable_check' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Connectable check interval
     |--------------------------------------------------------------------------
     |
@@ -55,6 +68,6 @@ return [
     |
     */
 
-    'connectable_check_interval' => 60 * 20,
+    'connectable_check_interval' => 60 * 30,
 
 ];

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -547,7 +547,9 @@
                             <th>@lang('torrent.started')</th>
                             <th>@lang('torrent.last-update')</th>
                             <th>@lang('torrent.torrents')</th>
-                            {{--<th>Connectable</th>--}}
+                            @if (\config('announce.connectable_check') == true)
+                            <th>Connectable</th>
+                            @endif
                         </tr>
                     </thead>
                     <tbody>
@@ -568,7 +570,9 @@
                                         <span itemprop="title" class="l-breadcrumb-item-link-title">{{ $count }}</span>
                                     </a>
                                 </td>
-                                {{--<td>@choice('user.client-connectable-state', $p->connectable)</td>--}}
+                                @if (\config('announce.connectable_check') == true)
+                                <td>@choice('user.client-connectable-state', $p->connectable)</td>
+                                @endif
                             </tr>
 			                @php array_push($peer_array, [$p->ip, $p->port]); @endphp
 			            @endif


### PR DESCRIPTION
- Fix Eloquent updating "updated_at" in Connectable Check resulting in incorrect seed time.
    -> Reference: https://laracasts.com/discuss/channels/eloquent/use-update-without-updating-timestamps?page=1&replyId=680133
- Fix Connectable Check for IPv6
