### PR TITLE
(Fix) Auto Nerd Stat

### DIFF
--- a/app/Console/Commands/AutoNerdStat.php
+++ b/app/Console/Commands/AutoNerdStat.php
@@ -76,19 +76,19 @@ class AutoNerdStat extends Command
 
             // Most Snatched Torrent
             $snatched = Torrent::latest('times_completed')->firstOrNew([
-                'id' => null,
+                'id'   => null,
                 'name' => 'No torrent found',
             ]);
 
             // Most Seeded Torrent
             $seeded = Torrent::latest('seeders')->firstOrNew([
-                'id' => null,
+                'id'   => null,
                 'name' => 'No torrent found',
             ]);
 
             // Most Leeched Torrent
             $leeched = Torrent::latest('leechers')->firstOrNew([
-                'id' => null,
+                'id'   => null,
                 'name' => 'No torrent found',
             ]);
 


### PR DESCRIPTION
On a fresh install of the system, this command prints a log entry with an error every time it's executed. This creates a temporary model (new instead of create) that can be passed to the helper functions. This is a quick and dirty fix which should be thought about a little bit more, but it does its job for now.