### PR TITLE
Update _footer.scss Flex Layout for Tablets/Mobiles

### DIFF
--- a/resources/sass/layout/_footer.scss
+++ b/resources/sass/layout/_footer.scss
@@ -18,6 +18,20 @@ html, body {
     gap: 4rem;
 }
 
+@media only screen and (max-width: 867px) {
+    .footer__section {
+        flex-basis: calc(50% - 2rem);
+        text-align: center;
+    }
+}
+
+@media only screen and (max-width: 1038px) and (min-width: 868px) {
+    .footer__section {
+        flex-basis: calc(32% - 2rem);
+        text-align: center;
+    }
+}
+
 .footer__section-title {
     font-size: 22px;
 }


### PR DESCRIPTION
Improve flex layout on Tables and Smartphones. Will split footer into 3x3 and 3x2 (vertical/horizontal). Breakpoints set to same as mobile for 867px. Breakpoint for 3x3 layout is set to kick in, once the full footer does not fit anymore.