### PR TITLE
(Update) Use lower level data structures for announce

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -425,7 +425,7 @@ class AnnounceController extends Controller
         // If we use eager loading, then laravel will use `where torrent_id in (123)` instead of `where torrent_id = ?`
         $torrent->setRelation(
             'peers',
-            Peer::select(['id', 'torrent_id', 'peer_id', 'user_id', 'left', 'seeder', 'port', 'updated_at'])
+            Peer::select(['id', 'torrent_id', 'peer_id', 'user_id', 'left', 'seeder', 'port', 'agent', 'updated_at'])
                 ->selectRaw('INET6_NTOA(ip) as ip')
                 ->where('torrent_id', '=', $torrent->id)
                 ->get()
@@ -567,7 +567,7 @@ class AnnounceController extends Controller
      */
     private function processAnnounceJob($queries, $user, $group, $torrent): void
     {
-        ProcessAnnounce::dispatch($queries, serialize($user), serialize($group), serialize($torrent));
+        ProcessAnnounce::dispatch($queries, $user->toArray(), $group->toArray(), $torrent->toArray(), $torrent->peers->toArray());
     }
 
     protected function generateFailedAnnounceResponse(TrackerException $trackerException): array

--- a/app/Models/History.php
+++ b/app/Models/History.php
@@ -31,17 +31,19 @@ class History extends Model
     /**
      * The Attributes That Are Mass Assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $guarded = [];
 
     /**
      * The Attributes That Should Be Mutated To Dates.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'completed_at' => 'datetime',
+        'immune'       => 'boolean',
+        'seeder'       => 'boolean',
     ];
 
     /**

--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -24,6 +24,13 @@ class Peer extends Model
     use HasFactory;
 
     /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]
+     */
+    protected $guarded = [];
+
+    /**
      * The attributes that should be cast.
      *
      * @var array<string, string>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1526,21 +1526,6 @@ parameters:
 			path: app/Http/Resources/UserEchoResource.php
 
 		-
-			message: "#^Property App\\\\Models\\\\History\\:\\:\\$active \\(bool\\) does not accept int\\.$#"
-			count: 4
-			path: app/Jobs/ProcessAnnounce.php
-
-		-
-			message: "#^Property App\\\\Models\\\\History\\:\\:\\$immune \\(bool\\) does not accept int\\.$#"
-			count: 1
-			path: app/Jobs/ProcessAnnounce.php
-
-		-
-			message: "#^Property App\\\\Models\\\\History\\:\\:\\$seeder \\(bool\\) does not accept int\\.$#"
-			count: 1
-			path: app/Jobs/ProcessAnnounce.php
-
-		-
 			message: "#^Called 'pluck' on Laravel collection, but could have been retrieved as a query\\.$#"
 			count: 1
 			path: app/Jobs/ProcessMovieJob.php
@@ -1609,16 +1594,6 @@ parameters:
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/Models/Forum.php
-
-		-
-			message: "#^PHPDoc type array of property App\\\\Models\\\\History\\:\\:\\$casts is not covariant with PHPDoc type array\\<string, string\\> of overridden property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$casts\\.$#"
-			count: 1
-			path: app/Models/History.php
-
-		-
-			message: "#^PHPDoc type array of property App\\\\Models\\\\History\\:\\:\\$guarded is not covariant with PHPDoc type array\\<string\\>\\|bool of overridden property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$guarded\\.$#"
-			count: 1
-			path: app/Models/History.php
 
 		-
 			message: "#^PHPDoc type array of property App\\\\Models\\\\Keyword\\:\\:\\$fillable is not covariant with PHPDoc type array\\<string\\> of overridden property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$fillable\\.$#"


### PR DESCRIPTION
We can't pass Models or collections into a job, as Laravel will apply their own custom serialization format that errors when trying to deserialize. So, we now use basic arrays. Logic relying on Eloquent Collections is now done manually. Reducing the extra overhead might be good for performance too. Also combined the case statement as many of the steps were the same and they would become much longer with the extra code required.