### PR TITLE
(Update) Announce Job

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -586,11 +586,19 @@ class AnnounceController extends Controller
      */
     private function processAnnounceJob($queries, $user, $group, $torrent): void
     {
+        $peer = $torrent
+            ->peers
+            ->where('peer_id', '=', base64_decode($queries['peer_id']))
+            ->where('user_id', '=', $user->id)
+            ->first()
+            ?->only(['uploaded', 'downloaded', 'left']);
+
         ProcessAnnounce::dispatch(
             $queries,
             $user->id,
             $group->only(['is_freeleech', 'is_double_upload', 'is_immune']),
-            $torrent
+            $torrent,
+            $peer
         );
     }
 

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -586,7 +586,7 @@ class AnnounceController extends Controller
      */
     private function processAnnounceJob($queries, $user, $group, $torrent): void
     {
-        ProcessAnnounce::dispatch($queries, $user, $group, $torrent);
+        ProcessAnnounce::dispatch($queries, $user->id, $group, $torrent);
     }
 
     protected function generateFailedAnnounceResponse(TrackerException $trackerException): array

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -597,7 +597,7 @@ class AnnounceController extends Controller
             $queries,
             $user->id,
             $group->only(['is_freeleech', 'is_double_upload', 'is_immune']),
-            $torrent,
+            $torrent->only('id', 'free', 'doubleup'),
             $peer
         );
     }

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -586,7 +586,12 @@ class AnnounceController extends Controller
      */
     private function processAnnounceJob($queries, $user, $group, $torrent): void
     {
-        ProcessAnnounce::dispatch($queries, $user->id, $group, $torrent);
+        ProcessAnnounce::dispatch(
+            $queries,
+            $user->id,
+            $group->only(['is_freeleech', 'is_double_upload', 'is_immune']),
+            $torrent
+        );
     }
 
     protected function generateFailedAnnounceResponse(TrackerException $trackerException): array

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -36,9 +36,19 @@ class ProcessAnnounce implements ShouldQueue
 
     /**
      * Create a new job instance.
+     *
+     * @param array{
+     *     is_freeleech: boolean,
+     *     is_double_upload: boolean,
+     *     is_immune: boolean
+     * } $group
      */
-    public function __construct(protected $queries, protected $userId, protected $group, protected $torrent)
-    {
+    public function __construct(
+        protected $queries,
+        protected $userId,
+        protected array $group,
+        protected $torrent
+    ) {
     }
 
     /**
@@ -105,7 +115,7 @@ class ProcessAnnounce implements ShouldQueue
 
         if (
             $personalFreeleech
-            || $this->group->is_freeleech
+            || $this->group['is_freeleech']
             || $freeleechToken
             || config('other.freeleech')
         ) {
@@ -121,7 +131,7 @@ class ProcessAnnounce implements ShouldQueue
 
         if (
             $this->torrent->doubleup
-            || $this->group->is_double_upload
+            || $this->group['is_double_upload']
             || config('other.doubleup')
         ) {
             $creditedUploadedDelta = $uploadedDelta * 2;
@@ -184,7 +194,7 @@ class ProcessAnnounce implements ShouldQueue
                 'seeder'            => $this->queries['left'] == 0,
                 'active'            => $event !== 'stopped',
                 'seedtime'          => 0,
-                'immune'            => $this->group->is_immune,
+                'immune'            => $this->group['is_immune'],
                 'completed_at'      => $event === 'completed' ? now() : null,
             ])
         ]);

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -127,10 +127,13 @@ class ProcessAnnounce implements ShouldQueue
         ) {
             $creditedDownloadedDelta = 0;
         } elseif ($this->torrent['free'] >= 1) {
-            // FL value in DB are from 0% to 100%.
-            // Divide it by 100 and multiply it with "downloaded" to get discount download.
-            $fl_discount = $downloadedDelta * $this->torrent['free'] / 100;
-            $creditedDownloadedDelta = $downloadedDelta - $fl_discount;
+            // Freeleech values in the database are from 0 to 100
+            // 0 means 0% of the bytes are freeleech, i.e. 100% of the bytes are counted.
+            // 100 means 100% of the bytes are freeleech, i.e. 0% of the bytes are counted.
+            // This means we have to subtract the value stored in the database from 100 before multiplying.
+            // Also make sure that 100% is the highest value of freeleech possible
+            // in order to not subtract download from an account.
+            $creditedDownloadedDelta = $downloadedDelta * (100 - min(100, $this->torrent['free'])) / 100;
         } else {
             $creditedDownloadedDelta = $downloadedDelta;
         }

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -23,7 +23,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Redis;
 
@@ -32,7 +31,6 @@ class ProcessAnnounce implements ShouldQueue
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
-    use SerializesModels;
 
     /**
      * Create a new job instance.

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -80,17 +80,14 @@ class ProcessAnnounce implements ShouldQueue
     public function handle(): void
     {
         // Set Variables
-        $realUploaded = $this->queries['uploaded'];
-        $realDownloaded = $this->queries['downloaded'];
         $event = $this->queries['event'];
-        $peerId = base64_decode($this->queries['peer_id']);
         $ipAddress = base64_decode($this->queries['ip-address']);
 
         $isNewPeer = $this->peer === null;
 
         // Calculate the change in upload/download compared to the last announce
-        $uploadedDelta = max($realUploaded - ($this->peer['uploaded'] ?? 0), 0);
-        $downloadedDelta = max($realDownloaded - ($this->peer['downloaded'] ?? 0), 0);
+        $uploadedDelta = max($this->queries['uploaded'] - ($this->peer['uploaded'] ?? 0), 0);
+        $downloadedDelta = max($this->queries['downloaded'] - ($this->peer['downloaded'] ?? 0), 0);
 
         // If no peer record found then set deltas to 0 and change to `started` event
         if ($isNewPeer) {
@@ -202,12 +199,12 @@ class ProcessAnnounce implements ShouldQueue
         Redis::connection('announce')->command('RPUSH', [
             config('cache.prefix').':peers:batch',
             serialize([
-                'peer_id'     => $peerId,
+                'peer_id'     => base64_decode($this->queries['peer_id']),
                 'ip'          => $ipAddress,
                 'port'        => $this->queries['port'],
                 'agent'       => $this->queries['user-agent'],
-                'uploaded'    => $realUploaded,
-                'downloaded'  => $realDownloaded,
+                'uploaded'    => $this->queries['uploaded'],
+                'downloaded'  => $this->queries['downloaded'],
                 'left'        => $this->queries['left'],
                 'seeder'      => $this->queries['left'] == 0,
                 'torrent_id'  => $this->torrent['id'],
@@ -230,10 +227,10 @@ class ProcessAnnounce implements ShouldQueue
                 'agent'             => $this->queries['user-agent'],
                 'uploaded'          => $event === 'started' ? 0 : $creditedUploadedDelta,
                 'actual_uploaded'   => $event === 'started' ? 0 : $uploadedDelta,
-                'client_uploaded'   => $realUploaded,
+                'client_uploaded'   => $this->queries['uploaded'],
                 'downloaded'        => $event === 'started' ? 0 : $creditedDownloadedDelta,
                 'actual_downloaded' => $event === 'started' ? 0 : $downloadedDelta,
-                'client_downloaded' => $realDownloaded,
+                'client_downloaded' => $this->queries['downloaded'],
                 'seeder'            => $this->queries['left'] == 0,
                 'active'            => $event !== 'stopped',
                 'seedtime'          => 0,

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -151,7 +151,6 @@ class ProcessAnnounce implements ShouldQueue
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->userId;
         $peer->updateConnectableStateIfNeeded();
-        $peer->updated_at = now();
         $peer->active = $event !== 'stopped';
 
         if (($creditedUploadedDelta > 0 || $creditedDownloadedDelta > 0) && $event !== 'stopped') {

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -139,19 +139,7 @@ class ProcessAnnounce implements ShouldQueue
             $creditedUploadedDelta = $uploadedDelta;
         }
 
-        // Common Parts Extracted From Switch
-        $peer->peer_id = $peerId;
-        $peer->ip = $ipAddress;
-        $peer->port = $this->queries['port'];
-        $peer->agent = $this->queries['user-agent'];
-        $peer->uploaded = $realUploaded;
-        $peer->downloaded = $realDownloaded;
-        $peer->seeder = $this->queries['left'] == 0;
-        $peer->left = $this->queries['left'];
-        $peer->torrent_id = $this->torrent->id;
-        $peer->user_id = $this->userId;
         $peer->updateConnectableStateIfNeeded();
-        $peer->active = $event !== 'stopped';
 
         if (($creditedUploadedDelta > 0 || $creditedDownloadedDelta > 0) && $event !== 'stopped') {
             User::whereKey($this->userId)->update([
@@ -162,20 +150,20 @@ class ProcessAnnounce implements ShouldQueue
 
         Redis::connection('announce')->command('RPUSH', [
             config('cache.prefix').':peers:batch',
-            serialize($peer->only([
-                'peer_id',
-                'ip',
-                'port',
-                'agent',
-                'uploaded',
-                'downloaded',
-                'left',
-                'seeder',
-                'torrent_id',
-                'user_id',
-                'connectable',
-                'active'
-            ]))
+            serialize([
+                'peer_id'     => $peerId,
+                'ip'          => $ipAddress,
+                'port'        => $this->queries['port'],
+                'agent'       => $this->queries['user-agent'],
+                'uploaded'    => $realUploaded,
+                'downloaded'  => $realDownloaded,
+                'left'        => $this->queries['left'],
+                'seeder'      => $this->queries['left'] == 0,
+                'torrent_id'  => $this->torrent->id,
+                'user_id'     => $this->userId,
+                'connectable' => $peer->connectable,
+                'active'      => $event !== 'stopped',
+            ])
         ]);
 
         Redis::connection('announce')->command('RPUSH', [

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -103,10 +103,12 @@ class ProcessAnnounce implements ShouldQueue
                 ->exists(),
         );
 
-        if ($personalFreeleech ||
-            $this->group->is_freeleech == 1 ||
-            $freeleechToken ||
-            config('other.freeleech') == 1) {
+        if (
+            $personalFreeleech
+            || $this->group->is_freeleech
+            || $freeleechToken
+            || config('other.freeleech')
+        ) {
             $modDownloaded = 0;
         } elseif ($this->torrent->free >= 1) {
             // FL value in DB are from 0% to 100%.
@@ -117,9 +119,11 @@ class ProcessAnnounce implements ShouldQueue
             $modDownloaded = $downloaded;
         }
 
-        if ($this->torrent->doubleup == 1 ||
-            $this->group->is_double_upload == 1 ||
-            config('other.doubleup') == 1) {
+        if (
+            $this->torrent->doubleup
+            || $this->group->is_double_upload
+            || config('other.doubleup')
+        ) {
             $modUploaded = $uploaded * 2;
         } else {
             $modUploaded = $uploaded;

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -73,15 +73,15 @@ class ProcessAnnounce implements ShouldQueue
 
         $isNewPeer = $peer === null;
 
-        $uploaded = max($realUploaded - ($peer?->uploaded ?? 0), 0);
-        $downloaded = max($realDownloaded - ($peer?->downloaded ?? 0), 0);
+        $uploadedDelta = max($realUploaded - ($peer?->uploaded ?? 0), 0);
+        $downloadedDelta = max($realDownloaded - ($peer?->downloaded ?? 0), 0);
 
         // If no Peer record found then create one
         if ($isNewPeer) {
             if ($this->queries['uploaded'] > 0 || $this->queries['downloaded'] > 0) {
                 $event = 'started';
-                $uploaded = 0;
-                $downloaded = 0;
+                $uploadedDelta = 0;
+                $downloadedDelta = 0;
             }
 
             $peer = new Peer();
@@ -109,14 +109,14 @@ class ProcessAnnounce implements ShouldQueue
             || $freeleechToken
             || config('other.freeleech')
         ) {
-            $modDownloaded = 0;
+            $creditedDownloadedDelta = 0;
         } elseif ($this->torrent->free >= 1) {
             // FL value in DB are from 0% to 100%.
             // Divide it by 100 and multiply it with "downloaded" to get discount download.
-            $fl_discount = $downloaded * $this->torrent->free / 100;
-            $modDownloaded = $downloaded - $fl_discount;
+            $fl_discount = $downloadedDelta * $this->torrent->free / 100;
+            $creditedDownloadedDelta = $downloadedDelta - $fl_discount;
         } else {
-            $modDownloaded = $downloaded;
+            $creditedDownloadedDelta = $downloadedDelta;
         }
 
         if (
@@ -124,9 +124,9 @@ class ProcessAnnounce implements ShouldQueue
             || $this->group->is_double_upload
             || config('other.doubleup')
         ) {
-            $modUploaded = $uploaded * 2;
+            $creditedUploadedDelta = $uploadedDelta * 2;
         } else {
-            $modUploaded = $uploaded;
+            $creditedUploadedDelta = $uploadedDelta;
         }
 
         // Common Parts Extracted From Switch
@@ -144,10 +144,10 @@ class ProcessAnnounce implements ShouldQueue
         $peer->updated_at = now();
         $peer->active = $event !== 'stopped';
 
-        if (($modUploaded > 0 || $modDownloaded > 0) && $event !== 'stopped') {
+        if (($creditedUploadedDelta > 0 || $creditedDownloadedDelta > 0) && $event !== 'stopped') {
             User::whereKey($this->userId)->update([
-                'uploaded'   => DB::raw('uploaded + '.(int) $modUploaded),
-                'downloaded' => DB::raw('downloaded + '.(int) $modDownloaded),
+                'uploaded'   => DB::raw('uploaded + '.(int) $creditedUploadedDelta),
+                'downloaded' => DB::raw('downloaded + '.(int) $creditedDownloadedDelta),
             ]);
         }
 
@@ -175,11 +175,11 @@ class ProcessAnnounce implements ShouldQueue
                 'user_id'           => $this->userId,
                 'torrent_id'        => $this->torrent->id,
                 'agent'             => $this->queries['user-agent'],
-                'uploaded'          => $event === 'started' ? 0 : $modUploaded,
-                'actual_uploaded'   => $event === 'started' ? 0 : $uploaded,
+                'uploaded'          => $event === 'started' ? 0 : $creditedUploadedDelta,
+                'actual_uploaded'   => $event === 'started' ? 0 : $uploadedDelta,
                 'client_uploaded'   => $realUploaded,
-                'downloaded'        => $event === 'started' ? 0 : $modDownloaded,
-                'actual_downloaded' => $event === 'started' ? 0 : $downloaded,
+                'downloaded'        => $event === 'started' ? 0 : $creditedDownloadedDelta,
+                'actual_downloaded' => $event === 'started' ? 0 : $downloadedDelta,
                 'client_downloaded' => $realDownloaded,
                 'seeder'            => $this->queries['left'] == 0,
                 'active'            => $event !== 'stopped',

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -135,52 +135,16 @@ class ProcessAnnounce implements ShouldQueue
         $peer->user_id = $this->user->id;
         $peer->updateConnectableStateIfNeeded();
         $peer->updated_at = now();
+        $peer->active = $event !== 'stopped';
 
-        switch ($event) {
-            case 'started':
-                $peer->active = true;
-
-                break;
-            case 'completed':
-                $peer->active = true;
-
-                // User Update
-                if ($modUploaded > 0 || $modDownloaded > 0) {
-                    $this->user->update([
-                        'uploaded'   => DB::raw('uploaded + '.(int) $modUploaded),
-                        'downloaded' => DB::raw('downloaded + '.(int) $modDownloaded),
-                    ]);
-                }
-                // End User Update
-
-                // Torrent Completed Update
-                $this->torrent->times_completed += 1;
-
-                break;
-            case 'stopped':
-                $peer->active = false;
-
-                // User Update
-                if ($modUploaded > 0 || $modDownloaded > 0) {
-                    $this->user->update([
-                        'uploaded'   => DB::raw('uploaded + '.(int) $modUploaded),
-                        'downloaded' => DB::raw('downloaded + '.(int) $modDownloaded),
-                    ]);
-                }
-                // End User Update
-                break;
-            default:
-                $peer->active = true;
-
-                // User Update
-                if ($modUploaded > 0 || $modDownloaded > 0) {
-                    $this->user->update([
-                        'uploaded'   => DB::raw('uploaded + '.(int) $modUploaded),
-                        'downloaded' => DB::raw('downloaded + '.(int) $modDownloaded),
-                    ]);
-                }
-                // End User Update
+        if (($modUploaded > 0 || $modDownloaded > 0) && $event !== 'stopped') {
+            $this->user->update([
+                'uploaded'   => DB::raw('uploaded + '.(int) $modUploaded),
+                'downloaded' => DB::raw('downloaded + '.(int) $modDownloaded),
+            ]);
         }
+
+        $this->torrent->times_completed += (int) ($event === 'completed');
 
         Redis::connection('announce')->command('RPUSH', [
             config('cache.prefix').':peers:batch',

--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -16,8 +16,6 @@ namespace App\Models;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Redis;
-use Exception;
 
 class Peer extends Model
 {
@@ -67,45 +65,5 @@ class Peer extends Model
     public function seed(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(Torrent::class, 'torrents.id', 'torrent_id');
-    }
-
-    /**
-     * Updates Connectable State If Needed.
-     *
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     * @throws Exception
-     */
-    public function updateConnectableStateIfNeeded(): void
-    {
-        if (config('announce.connectable_check')) {
-            $tmp_ip = inet_ntop(pack('A'.\strlen($this->ip), $this->ip));
-            // IPv6 Check
-            if (filter_var($tmp_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
-                $tmp_ip = '['.$tmp_ip.']';
-            }
-
-            $key = config('cache.prefix').':peers:connectable:'.$tmp_ip.'-'.$this->port.'-'.$this->agent;
-            $cache = Redis::connection('cache')->get($key);
-            $ttl = 0;
-
-            if ($cache) {
-                $ttl = Redis::connection('cache')->command('TTL', [$key]);
-            }
-
-            if ($ttl < config('announce.connectable_check_interval')) {
-                $con = @fsockopen($tmp_ip, $this->port, $_, $_, 1);
-                $this->connectable = \is_resource($con);
-                Redis::connection('cache')->set($key, serialize($this->connectable));
-                Redis::connection('cache')->expire($key, config('announce.connectable_check_interval') + 3600);
-
-                if (\is_resource($con)) {
-                    fclose($con);
-                }
-            } else {
-                $this->connectable = $cache == null ? false : unserialize($cache);
-            }
-        } else {
-            $this->connectable = false;
-        }
     }
 }


### PR DESCRIPTION
Big refactor to the announce job.

We now pass in array with only the keys we need instead of passing in the entire model. This will prevent duplicate queries, because otherwise if we use models, Laravel will refresh the model from the database when the job is ran.

Also cleaned up a number of other things.

Unfortunately, we can't inline the job into the announce itself due to the peer connectivity timeout which could cause backlog.

Replaces #3040.