### PR TITLE
(Update) Faster random media loading

### DIFF
--- a/app/Console/Commands/AutoCacheRandomMediaIds.php
+++ b/app/Console/Commands/AutoCacheRandomMediaIds.php
@@ -13,10 +13,10 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Movie;
-use App\Models\Tv;
+use App\Models\Torrent;
 use Illuminate\Console\Command;
 use Exception;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Redis;
 
 class AutoCacheRandomMediaIds extends Command
@@ -42,15 +42,15 @@ class AutoCacheRandomMediaIds extends Command
      */
     public function handle(): void
     {
-        $movieIds = Movie::query()
+        $movieIds = DB::table('movies')
             ->select('id')
-            ->whereHas('torrents')
+            ->whereIn('id', Torrent::select('id'))
             ->whereNotNull('backdrop')
             ->pluck('id');
 
-        $tvIds = Tv::query()
+        $tvIds = DB::table('tv')
             ->select('id')
-            ->whereHas('torrents')
+            ->whereIn('id', Torrent::select('id'))
             ->whereNotNull('backdrop')
             ->pluck('id');
 


### PR DESCRIPTION
Before:

/var/www # php artisan auto:cache_random_media
41148 movie ids and 10164 tv ids cached. Movie query time: 897 ms. Movie cache time: 15 ms. /var/www # php artisan auto:cache_random_media
41148 movie ids and 10164 tv ids cached. Movie query time: 842 ms. Movie cache time: 14 ms. /var/www # php artisan auto:cache_random_media
41148 movie ids and 10164 tv ids cached. Movie query time: 842 ms. Movie cache time: 13 ms.

After:

/var/www # php artisan auto:cache_random_media
13948 movie ids and 10164 tv ids cached. Movie query time: 155 ms. Movie cache time: 8 ms. /var/www # php artisan auto:cache_random_media
13948 movie ids and 10164 tv ids cached. Movie query time: 192 ms. Movie cache time: 6 ms.