### PR TITLE
(Update) Only delete upsert data after successful upsertion

### DIFF
--- a/.cspell/redis.txt
+++ b/.cspell/redis.txt
@@ -1,6 +1,7 @@
 llen
 lpop
 lpush
+lrange
 rpush
 sadd
 srandmember

--- a/app/Console/Commands/AutoUpdateUserLastActions.php
+++ b/app/Console/Commands/AutoUpdateUserLastActions.php
@@ -49,7 +49,7 @@ class AutoUpdateUserLastActions extends Command
 
         $userIdCount = Redis::command('LLEN', [$key]);
 
-        $userIds = Redis::command('LPOP', [$key, $userIdCount]);
+        $userIds = Redis::command('LRANGE', [$key, 0, $userIdCount - 1]);
 
         if ($userIds !== false) {
             DB::transaction(static function () use ($userIds): void {
@@ -60,6 +60,8 @@ class AutoUpdateUserLastActions extends Command
                     ]);
             }, 5);
         }
+
+        Redis::command('LTRIM', [$key, $userIdCount, -1]);
 
         $this->comment('Automated upsert histories command complete');
     }

--- a/app/Console/Commands/AutoUpsertHistories.php
+++ b/app/Console/Commands/AutoUpsertHistories.php
@@ -73,7 +73,7 @@ class AutoUpsertHistories extends Command
         $historyCount = Redis::connection('announce')->command('LLEN', [$key]);
 
         for ($historiesLeft = $historyCount; $historiesLeft > 0; $historiesLeft -= $historiesPerCycle) {
-            $histories = Redis::connection('announce')->command('LPOP', [$key, $historiesPerCycle]);
+            $histories = Redis::connection('announce')->command('LRANGE', [$key, 0, $historiesPerCycle - 1]);
 
             if ($histories === false) {
                 break;
@@ -103,6 +103,8 @@ class AutoUpsertHistories extends Command
                     ],
                 );
             }, 5);
+
+            Redis::connection('announce')->command('LTRIM', [$key, $historiesPerCycle, -1]);
         }
 
         $this->comment('Automated upsert histories command complete');

--- a/app/Console/Commands/AutoUpsertPeers.php
+++ b/app/Console/Commands/AutoUpsertPeers.php
@@ -57,7 +57,7 @@ class AutoUpsertPeers extends Command
         $peerCount = Redis::connection('announce')->command('LLEN', [$key]);
 
         for ($peersLeft = $peerCount; $peersLeft > 0; $peersLeft -= $peerPerCycle) {
-            $peers = Redis::connection('announce')->command('LPOP', [$key, $peerPerCycle]);
+            $peers = Redis::connection('announce')->command('LRANGE', [$key, 0, $peerPerCycle - 1]);
 
             if ($peers === false) {
                 break;
@@ -86,6 +86,8 @@ class AutoUpsertPeers extends Command
                     ],
                 );
             }, 5);
+
+            Redis::connection('announce')->command('LTRIM', [$key, $peerPerCycle, -1]);
         }
 
         $this->comment('Automated insert peers command complete');

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,9 +27,9 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule): void
     {
         if (! config('announce.external_tracker.is_enabled')) {
-            $schedule->command('auto:upsert_peers')->everyFiveSeconds();
-            $schedule->command('auto:upsert_histories')->everyFiveSeconds();
-            $schedule->command('auto:upsert_announces')->everyFiveSeconds();
+            $schedule->command('auto:upsert_peers')->everyFiveSeconds()->withoutOverlapping(2);
+            $schedule->command('auto:upsert_histories')->everyFiveSeconds()->withoutOverlapping(2);
+            $schedule->command('auto:upsert_announces')->everyFiveSeconds()->withoutOverlapping(2);
             $schedule->command('auto:cache_user_leech_counts')->everyThirtyMinutes();
             $schedule->command('auto:sync_peers')->everyFiveMinutes();
             $schedule->command('auto:torrent_balance')->hourly();


### PR DESCRIPTION
~~TODO: need to ensure the next upsert isn't started before the previous upsert finishes. (Does laravel's scheduler allow only one at a time when it's more frequently than a minute?)~~

The laravel scheduler repeats the job as many times as needed waiting 5 seconds in between each time. Once the minute finishes, it doesn't run anymore: https://github.com/laravel/framework/blob/966a22ac8f7a5191e17818ce5eb5d0df2543e114/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php#L228.
It needed `->withoutOverlapping(2)` to ensure the next upsert is skipped if previous upsert is still running. I chose a 2 minute cache lock ttl which provides an extra minute after the run of the previous minute has finished to wait for any deadlocks to finish erroring (max of 5 times is specified in the transaction).