### PR TITLE
(Update) Make donations transparent

### DIFF
--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -255,7 +255,7 @@
                         ->sum(function ($donation) {
                             return $donation->package->cost;
                         });
-                    $percentage = $sum ? min(100, number_format(($sum / config('donation.monthly_goal')) * 100)) : 0;
+                    $percentage = $sum ? number_format(($sum / config('donation.monthly_goal')) * 100) : 0;
                 @endphp
 
                 <a tabindex="0" title="{{ $percentage }}% filled">


### PR DESCRIPTION
Allow users to see a more transparent donation count, there should be no issue with users knowing this information and it helps them knowing how sustainable the tracker is.