### PR TITLE
(Fix) Validation on updating group autogroup

### DIFF
--- a/resources/views/Staff/group/edit.blade.php
+++ b/resources/views/Staff/group/edit.blade.php
@@ -22,7 +22,7 @@
 @section('page', 'page__groups--edit')
 
 @section('main')
-    <section class="panelV2" x-data="{ autogroup: {{ $group->autogroup }} }">
+    <section class="panelV2" x-data="{ autogroup: {{ Js::from($group->autogroup) }} }">
         <h2 class="panel__heading">Edit Group: {{ $group->name }}</h2>
         <div class="panel__body">
             <form


### PR DESCRIPTION
When `autogroup` was false, blade doesn't render anything (empty string). By rendering it as `false` using the `Js` facade, the value of `autogroup` is set. The value is synced with the checkbox in the form. When it was blank, the checkbox value was errored. With the error fixed, the correct value is submitted and the validation passes. Fixes #4401