### PR TITLE
(Update) Disable meilisearch facet search

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -236,6 +236,7 @@ return [
                     'typo',
                     'proximity',
                 ],
+                'facetSearch' => false,
             ],
         ],
     ],


### PR DESCRIPTION
It takes up extra resources to index facets, but we don't ever search for facets. So, we can disable indexing facets and save on resources.

Requires meilisearch 1.12.

Run `sudo php artisan scout:sync-index-settings` after update.