### PR TITLE
(Fix) HTML inside wikis and pages being escaped

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -58,6 +58,6 @@ class Page extends Model
      */
     public function getContentHtml(): string
     {
-        return Markdown::convert((new Bbcode())->parse($this->content, false))->getContent();
+        return Markdown::convert(htmlspecialchars_decode((new Bbcode())->parse($this->content, false)))->getContent();
     }
 }

--- a/app/Models/Wiki.php
+++ b/app/Models/Wiki.php
@@ -52,6 +52,6 @@ class Wiki extends Model
      */
     public function getContentHtml(): string
     {
-        return Markdown::convert((new Bbcode())->parse($this->content, false))->getContent();
+        return Markdown::convert(htmlspecialchars_decode((new Bbcode())->parse($this->content, false)))->getContent();
     }
 }


### PR DESCRIPTION
Staff are trusted and should be allowed to add custom html/styles/scripts to site pages and wikis, as they were before. Regression from #3222.