### PR TITLE
(Fix) Double escape in link content

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -291,7 +291,7 @@ class Bbcode
         );
         $source = preg_replace_callback(
             '/\[url=(.*?)](.*?)\[\/url]/i',
-            fn ($matches) => '<a href="'.$this->sanitizeUrl($matches[1]).'">'.e($matches[2]).'</a>',
+            fn ($matches) => '<a href="'.$this->sanitizeUrl($matches[1]).'">'.$matches[2].'</a>',
             $source ?? ''
         );
         $source = preg_replace_callback(


### PR DESCRIPTION
We already escape the entire content and don't need to escape the link content a second time. Otherwise, when a link contains, for example, an apostrophe, it's double encoded to `&amp;pos;` before being displayed on the page.

Regression from #3222