### PR TITLE
(Refactor) Swap magic RedirectResponse `withX('Y')` to `with('X', 'Y')`

### DIFF
--- a/app/Http/Controllers/ApprovedRequestFillController.php
+++ b/app/Http/Controllers/ApprovedRequestFillController.php
@@ -79,7 +79,7 @@ class ApprovedRequestFillController extends Controller
         }
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])
-            ->withSuccess(\sprintf(trans('request.approved-user'), $torrentRequest->name, $torrentRequest->filled_anon ? 'Anonymous' : $filler->username));
+            ->with('success', \sprintf(trans('request.approved-user'), $torrentRequest->name, $torrentRequest->filled_anon ? 'Anonymous' : $filler->username));
     }
 
     /**
@@ -102,6 +102,6 @@ class ApprovedRequestFillController extends Controller
         $filler->decrement('seedbonus', (float) $refunded);
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])
-            ->withSuccess(trans('request.request-reset'));
+            ->with('success', trans('request.request-reset'));
     }
 }

--- a/app/Http/Controllers/Auth/ApplicationController.php
+++ b/app/Http/Controllers/Auth/ApplicationController.php
@@ -45,6 +45,6 @@ class ApplicationController extends Controller
         $application->urlProofs()->createMany($request->validated('links'));
 
         return to_route('login')
-            ->withSuccess(trans('auth.application-submitted'));
+            ->with('success', trans('auth.application-submitted'));
     }
 }

--- a/app/Http/Controllers/BountyController.php
+++ b/app/Http/Controllers/BountyController.php
@@ -83,7 +83,7 @@ class BountyController extends Controller
         }
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])
-            ->withSuccess(trans('request.added-bonus'));
+            ->with('success', trans('request.added-bonus'));
     }
 
     public function update(UpdateTorrentRequestBountyRequest $request, TorrentRequest $torrentRequest, TorrentRequestBounty $torrentRequestBounty): \Illuminate\Http\RedirectResponse

--- a/app/Http/Controllers/ClaimController.php
+++ b/app/Http/Controllers/ClaimController.php
@@ -52,7 +52,7 @@ class ClaimController extends Controller
         }
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])
-            ->withSuccess(trans('request.claimed-success'));
+            ->with('success', trans('request.claimed-success'));
     }
 
     /**
@@ -78,6 +78,6 @@ class ClaimController extends Controller
         }
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])
-            ->withSuccess(trans('request.unclaimed-success'));
+            ->with('success', trans('request.unclaimed-success'));
     }
 }

--- a/app/Http/Controllers/ClaimedPrizeController.php
+++ b/app/Http/Controllers/ClaimedPrizeController.php
@@ -86,7 +86,7 @@ class ClaimedPrizeController extends Controller
                 'fl_tokens' => $fl_tokens_won,
             ]);
 
-            return to_route('events.show', ['event' => $event])->withSuccess('Congrats! You have won a prize!');
+            return to_route('events.show', ['event' => $event])->with('success', 'Congrats! You have won a prize!');
         });
     }
 }

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -45,6 +45,6 @@ class ContactController extends Controller
         Mail::to($user->email)->send(new Contact($request->string('email')));
 
         return to_route('home.index')
-            ->withSuccess('Your Message Was Successfully Sent');
+            ->with('success', 'Your Message Was Successfully Sent');
     }
 }

--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -47,6 +47,6 @@ class DonationController extends Controller
         ]);
 
         return redirect()->route('donations.index')
-            ->withSuccess('Thank You For Supporting Us! Please allow for up to 48 hours for staff to confirm the transaction.');
+            ->with('success', 'Thank You For Supporting Us! Please allow for up to 48 hours for staff to confirm the transaction.');
     }
 }

--- a/app/Http/Controllers/PlaylistController.php
+++ b/app/Http/Controllers/PlaylistController.php
@@ -86,7 +86,7 @@ class PlaylistController extends Controller
         }
 
         return to_route('playlists.show', ['playlist' => $playlist])
-            ->withSuccess(trans('playlist.published-success'));
+            ->with('success', trans('playlist.published-success'));
     }
 
     /**
@@ -162,7 +162,7 @@ class PlaylistController extends Controller
         }
 
         return to_route('playlists.show', ['playlist' => $playlist])
-            ->withSuccess(trans('playlist.update-success'));
+            ->with('success', trans('playlist.update-success'));
     }
 
     /**
@@ -179,6 +179,6 @@ class PlaylistController extends Controller
         $playlist->delete();
 
         return to_route('playlists.index')
-            ->withSuccess(trans('playlist.deleted'));
+            ->with('success', trans('playlist.deleted'));
     }
 }

--- a/app/Http/Controllers/PlaylistTorrentController.php
+++ b/app/Http/Controllers/PlaylistTorrentController.php
@@ -44,7 +44,7 @@ class PlaylistTorrentController extends Controller
         $playlistTorrent->torrent()->searchable();
 
         return to_route('playlists.show', ['playlist' => $playlist])
-            ->withSuccess(trans('playlist.attached-success'));
+            ->with('success', trans('playlist.attached-success'));
     }
 
     /**
@@ -74,7 +74,7 @@ class PlaylistTorrentController extends Controller
         $playlist->torrents()->searchable();
 
         return to_route('playlists.show', ['playlist' => $playlist])
-            ->withSuccess(trans('playlist.attached-success'));
+            ->with('success', trans('playlist.attached-success'));
     }
 
     /**
@@ -91,6 +91,6 @@ class PlaylistTorrentController extends Controller
         $playlistTorrent->torrent()->searchable();
 
         return to_route('playlists.show', ['playlist' => $playlistTorrent->playlist])
-            ->withSuccess(trans('playlist.detached-success'));
+            ->with('success', trans('playlist.detached-success'));
     }
 }

--- a/app/Http/Controllers/PollVoteController.php
+++ b/app/Http/Controllers/PollVoteController.php
@@ -53,7 +53,7 @@ class PollVoteController extends Controller
         );
 
         return to_route('polls.votes.index', ['poll' => $poll])
-            ->withSuccess(trans('poll.vote-counted'));
+            ->with('success', trans('poll.vote-counted'));
     }
 
     /**

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -162,7 +162,7 @@ class PostController extends Controller
         Notification::send($users, new NewPostTag($post));
 
         return redirect()->to($realUrl)
-            ->withSuccess(trans('forum.reply-topic-success'));
+            ->with('success', trans('forum.reply-topic-success'));
     }
 
     /**
@@ -211,7 +211,7 @@ class PostController extends Controller
         ]);
 
         return redirect()->to($postUrl)
-            ->withSuccess(trans('forum.edit-post-success'));
+            ->with('success', trans('forum.edit-post-success'));
     }
 
     /**
@@ -262,10 +262,10 @@ class PostController extends Controller
 
         if ($isTopicDeleted === true) {
             return to_route('forums.show', ['id' => $forum->id])
-                ->withSuccess(trans('forum.delete-post-success'));
+                ->with('success', trans('forum.delete-post-success'));
         }
 
         return to_route('topics.show', ['id' => $post->topic->id])
-            ->withSuccess(trans('forum.delete-post-success'));
+            ->with('success', trans('forum.delete-post-success'));
     }
 }

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -55,7 +55,7 @@ class ReportController extends Controller
         ]);
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])
-            ->withSuccess(trans('user.report-sent'));
+            ->with('success', trans('user.report-sent'));
     }
 
     /**
@@ -86,7 +86,7 @@ class ReportController extends Controller
         ]);
 
         return to_route('torrents.show', ['id' => $id])
-            ->withSuccess(trans('user.report-sent'));
+            ->with('success', trans('user.report-sent'));
     }
 
     /**
@@ -116,6 +116,6 @@ class ReportController extends Controller
         ]);
 
         return to_route('users.show', ['user' => $reportedUser])
-            ->withSuccess(trans('user.report-sent'));
+            ->with('success', trans('user.report-sent'));
     }
 }

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -173,7 +173,7 @@ class RequestController extends Controller
         }
 
         return to_route('requests.index')
-            ->withSuccess(trans('request.added-request'));
+            ->with('success', trans('request.added-request'));
     }
 
     /**
@@ -229,7 +229,7 @@ class RequestController extends Controller
         }
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])
-            ->withSuccess(trans('request.edited-request'));
+            ->with('success', trans('request.edited-request'));
     }
 
     /**
@@ -259,6 +259,6 @@ class RequestController extends Controller
         $torrentRequest->delete();
 
         return to_route('requests.index')
-            ->withSuccess(\sprintf(trans('request.deleted'), $torrentRequest->name));
+            ->with('success', \sprintf(trans('request.deleted'), $torrentRequest->name));
     }
 }

--- a/app/Http/Controllers/RequestFillController.php
+++ b/app/Http/Controllers/RequestFillController.php
@@ -57,7 +57,7 @@ class RequestFillController extends Controller
         }
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])
-            ->withSuccess(trans('request.pending-approval'));
+            ->with('success', trans('request.pending-approval'));
     }
 
     /**
@@ -82,6 +82,6 @@ class RequestFillController extends Controller
         }
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])
-            ->withSuccess(trans('request.request-reset'));
+            ->with('success', trans('request.request-reset'));
     }
 }

--- a/app/Http/Controllers/ReseedController.php
+++ b/app/Http/Controllers/ReseedController.php
@@ -55,7 +55,7 @@ class ReseedController extends Controller
             );
 
             return to_route('torrents.show', ['id' => $torrent->id])
-                ->withSuccess('A notification has been sent to all users that downloaded this torrent along with original uploader!');
+                ->with('success', 'A notification has been sent to all users that downloaded this torrent along with original uploader!');
         }
 
         return to_route('torrents.show', ['id' => $torrent->id])

--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -119,7 +119,7 @@ class RssController extends Controller
             $rss->save();
 
             return to_route('rss.index', ['hash' => 'private'])
-                ->withSuccess(trans('rss.created'));
+                ->with('success', trans('rss.created'));
         }
 
         return to_route('rss.create')
@@ -290,7 +290,7 @@ class RssController extends Controller
             $rss->save();
 
             return to_route('rss.index', ['hash' => 'private'])
-                ->withSuccess(trans('rss.created'));
+                ->with('success', trans('rss.created'));
         }
 
         return to_route('rss.create', ['id' => $id])
@@ -312,6 +312,6 @@ class RssController extends Controller
         $rss->delete();
 
         return to_route('rss.index', ['hash' => 'private'])
-            ->withSuccess(trans('rss.deleted'));
+            ->with('success', trans('rss.deleted'));
     }
 }

--- a/app/Http/Controllers/SimilarTorrentController.php
+++ b/app/Http/Controllers/SimilarTorrentController.php
@@ -156,6 +156,6 @@ class SimilarTorrentController extends Controller
                 break;
         }
 
-        return back()->withSuccess('Metadata update queued successfully.');
+        return back()->with('success', 'Metadata update queued successfully.');
     }
 }

--- a/app/Http/Controllers/Staff/ApplicationController.php
+++ b/app/Http/Controllers/Staff/ApplicationController.php
@@ -76,7 +76,7 @@ class ApplicationController extends Controller
         Mail::to($application->email)->send(new InviteUser($invite));
 
         return to_route('staff.applications.index')
-            ->withSuccess('Application Approved');
+            ->with('success', 'Application Approved');
     }
 
     /**
@@ -94,6 +94,6 @@ class ApplicationController extends Controller
         Mail::to($application->email)->send(new DenyApplication($request->deny));
 
         return to_route('staff.applications.index')
-            ->withSuccess('Application Rejected');
+            ->with('success', 'Application Rejected');
     }
 }

--- a/app/Http/Controllers/Staff/ArticleController.php
+++ b/app/Http/Controllers/Staff/ArticleController.php
@@ -67,7 +67,7 @@ class ArticleController extends Controller
         Article::create(['user_id' => $request->user()->id, 'image' => $filename ?? null] + $request->validated());
 
         return to_route('staff.articles.index')
-            ->withSuccess('Your article has successfully published!');
+            ->with('success', 'Your article has successfully published!');
     }
 
     /**
@@ -98,7 +98,7 @@ class ArticleController extends Controller
         $article->update(['image' => $filename ?? null,] + $request->validated());
 
         return to_route('staff.articles.index')
-            ->withSuccess('Your article changes have successfully published!');
+            ->with('success', 'Your article changes have successfully published!');
     }
 
     /**
@@ -112,6 +112,6 @@ class ArticleController extends Controller
         $article->delete();
 
         return to_route('staff.articles.index')
-            ->withSuccess('Article has successfully been deleted');
+            ->with('success', 'Article has successfully been deleted');
     }
 }

--- a/app/Http/Controllers/Staff/AuditController.php
+++ b/app/Http/Controllers/Staff/AuditController.php
@@ -58,6 +58,6 @@ class AuditController extends Controller
         $audit->delete();
 
         return to_route('staff.audits.index')
-            ->withSuccess('Audit Record Has Successfully Been Deleted');
+            ->with('success', 'Audit Record Has Successfully Been Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/AutomaticTorrentFreeleechController.php
+++ b/app/Http/Controllers/Staff/AutomaticTorrentFreeleechController.php
@@ -47,7 +47,7 @@ class AutomaticTorrentFreeleechController extends Controller
         AutomaticTorrentFreeleech::create($request->validated());
 
         return to_route('staff.automatic_torrent_freeleeches.index')
-            ->withSuccess('Resolution Successfully Added');
+            ->with('success', 'Resolution Successfully Added');
     }
 
     public function edit(AutomaticTorrentFreeleech $automaticTorrentFreeleech): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
@@ -65,7 +65,7 @@ class AutomaticTorrentFreeleechController extends Controller
         $automaticTorrentFreeleech->update($request->validated());
 
         return to_route('staff.automatic_torrent_freeleeches.index')
-            ->withSuccess('Resolution Successfully Modified');
+            ->with('success', 'Resolution Successfully Modified');
     }
 
     public function destroy(AutomaticTorrentFreeleech $automaticTorrentFreeleech): \Illuminate\Http\RedirectResponse
@@ -73,6 +73,6 @@ class AutomaticTorrentFreeleechController extends Controller
         $automaticTorrentFreeleech->delete();
 
         return to_route('staff.automatic_torrent_freeleeches.index')
-            ->withSuccess('Resolution Successfully Deleted');
+            ->with('success', 'Resolution Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/BanController.php
+++ b/app/Http/Controllers/Staff/BanController.php
@@ -67,6 +67,6 @@ class BanController extends Controller
         $user->notify(new UserBan($ban));
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess('User Is Now Banned!');
+            ->with('success', 'User Is Now Banned!');
     }
 }

--- a/app/Http/Controllers/Staff/BlacklistClientController.php
+++ b/app/Http/Controllers/Staff/BlacklistClientController.php
@@ -64,7 +64,7 @@ class BlacklistClientController extends Controller
         cache()->forget('client_blacklist');
 
         return to_route('staff.blacklisted_clients.index')
-            ->withSuccess('Blacklisted Client Was Updated Successfully!');
+            ->with('success', 'Blacklisted Client Was Updated Successfully!');
     }
 
     /**
@@ -90,7 +90,7 @@ class BlacklistClientController extends Controller
         cache()->forget('client_blacklist');
 
         return to_route('staff.blacklisted_clients.index')
-            ->withSuccess('Blacklisted Client Stored Successfully!');
+            ->with('success', 'Blacklisted Client Stored Successfully!');
     }
 
     /**
@@ -105,6 +105,6 @@ class BlacklistClientController extends Controller
         cache()->forget('client_blacklist');
 
         return to_route('staff.blacklisted_clients.index')
-            ->withSuccess('Blacklisted Client Destroyed Successfully!');
+            ->with('success', 'Blacklisted Client Destroyed Successfully!');
     }
 }

--- a/app/Http/Controllers/Staff/BonEarningController.php
+++ b/app/Http/Controllers/Staff/BonEarningController.php
@@ -53,7 +53,7 @@ class BonEarningController extends Controller
         $bonEarning->conditions()->upsert($request->validated('conditions'), ['id']);
 
         return to_route('staff.bon_earnings.index')
-            ->withSuccess('Bon Exchange Successfully Added');
+            ->with('success', 'Bon Exchange Successfully Added');
     }
 
     /**
@@ -80,7 +80,7 @@ class BonEarningController extends Controller
         $bonEarning->conditions()->upsert($request->validated('conditions'), ['id']);
 
         return to_route('staff.bon_earnings.index')
-            ->withSuccess('Bon Exchange Successfully Modified');
+            ->with('success', 'Bon Exchange Successfully Modified');
     }
 
     /**
@@ -93,6 +93,6 @@ class BonEarningController extends Controller
         $bonEarning->delete();
 
         return to_route('staff.bon_earnings.index')
-            ->withSuccess('Bon Exchange Successfully Deleted');
+            ->with('success', 'Bon Exchange Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/BonExchangeController.php
+++ b/app/Http/Controllers/Staff/BonExchangeController.php
@@ -56,7 +56,7 @@ class BonExchangeController extends Controller
         + $request->validated());
 
         return to_route('staff.bon_exchanges.index')
-            ->withSuccess('Bon Exchange Successfully Added');
+            ->with('success', 'Bon Exchange Successfully Added');
     }
 
     /**
@@ -83,7 +83,7 @@ class BonExchangeController extends Controller
         + $request->validated());
 
         return to_route('staff.bon_exchanges.index')
-            ->withSuccess('Bon Exchange Successfully Modified');
+            ->with('success', 'Bon Exchange Successfully Modified');
     }
 
     /**
@@ -96,6 +96,6 @@ class BonExchangeController extends Controller
         BonExchange::findOrFail($id)->delete();
 
         return to_route('staff.bon_exchanges.index')
-            ->withSuccess('Bon Exchange Successfully Deleted');
+            ->with('success', 'Bon Exchange Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/CategoryController.php
+++ b/app/Http/Controllers/Staff/CategoryController.php
@@ -71,7 +71,7 @@ class CategoryController extends Controller
         ] + $request->validated());
 
         return to_route('staff.categories.index')
-            ->withSuccess('Category Successfully Added');
+            ->with('success', 'Category Successfully Added');
     }
 
     /**
@@ -109,7 +109,7 @@ class CategoryController extends Controller
         ] + $request->validated());
 
         return to_route('staff.categories.index')
-            ->withSuccess('Category Successfully Modified');
+            ->with('success', 'Category Successfully Modified');
     }
 
     /**
@@ -122,6 +122,6 @@ class CategoryController extends Controller
         $category->delete();
 
         return to_route('staff.categories.index')
-            ->withSuccess('Category Successfully Deleted');
+            ->with('success', 'Category Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/ChatBotController.php
+++ b/app/Http/Controllers/Staff/ChatBotController.php
@@ -56,7 +56,7 @@ class ChatBotController extends Controller
         $bot->update($request->validated());
 
         return to_route('staff.bots.index')
-            ->withSuccess("The Bot Has Been Updated");
+            ->with('success', "The Bot Has Been Updated");
     }
 
     /**
@@ -71,7 +71,7 @@ class ChatBotController extends Controller
         $bot->delete();
 
         return to_route('staff.bots.index')
-            ->withSuccess('The Humans Vs Machines War Has Begun! Humans: 1 and Bots: 0');
+            ->with('success', 'The Humans Vs Machines War Has Begun! Humans: 1 and Bots: 0');
     }
 
     /**
@@ -84,7 +84,7 @@ class ChatBotController extends Controller
         ]);
 
         return to_route('staff.bots.index')
-            ->withSuccess('The Bot Has Been Disabled');
+            ->with('success', 'The Bot Has Been Disabled');
     }
 
     /**
@@ -97,6 +97,6 @@ class ChatBotController extends Controller
         ]);
 
         return to_route('staff.bots.index')
-            ->withSuccess('The Bot Has Been Enabled');
+            ->with('success', 'The Bot Has Been Enabled');
     }
 }

--- a/app/Http/Controllers/Staff/ChatRoomController.php
+++ b/app/Http/Controllers/Staff/ChatRoomController.php
@@ -54,7 +54,7 @@ class ChatRoomController extends Controller
         Chatroom::create($request->validated());
 
         return to_route('staff.chatrooms.index')
-            ->withSuccess('Chatroom Successfully Added');
+            ->with('success', 'Chatroom Successfully Added');
     }
 
     /**
@@ -75,7 +75,7 @@ class ChatRoomController extends Controller
         $chatroom->update($request->validated());
 
         return to_route('staff.chatrooms.index')
-            ->withSuccess('Chatroom Successfully Modified');
+            ->with('success', 'Chatroom Successfully Modified');
     }
 
     /**
@@ -98,6 +98,6 @@ class ChatRoomController extends Controller
         $chatroom->delete();
 
         return to_route('staff.chatrooms.index')
-            ->withSuccess('Chatroom Successfully Deleted');
+            ->with('success', 'Chatroom Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/ChatStatusController.php
+++ b/app/Http/Controllers/Staff/ChatStatusController.php
@@ -53,7 +53,7 @@ class ChatStatusController extends Controller
         ChatStatus::create($request->validated());
 
         return to_route('staff.statuses.index')
-            ->withSuccess('Chat Status Successfully Added');
+            ->with('success', 'Chat Status Successfully Added');
     }
 
     /**
@@ -74,7 +74,7 @@ class ChatStatusController extends Controller
         $chatStatus->update($request->validated());
 
         return to_route('staff.statuses.index')
-            ->withSuccess('Chat Status Successfully Modified');
+            ->with('success', 'Chat Status Successfully Modified');
     }
 
     /**
@@ -87,6 +87,6 @@ class ChatStatusController extends Controller
         $chatStatus->delete();
 
         return to_route('staff.statuses.index')
-            ->withSuccess('Chat Status Successfully Deleted');
+            ->with('success', 'Chat Status Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/CheatedTorrentController.php
+++ b/app/Http/Controllers/Staff/CheatedTorrentController.php
@@ -80,7 +80,7 @@ class CheatedTorrentController extends Controller
         ]);
 
         return to_route('staff.cheated_torrents.index')
-            ->withSuccess('Balance successfully reset');
+            ->with('success', 'Balance successfully reset');
     }
 
     /**
@@ -93,6 +93,6 @@ class CheatedTorrentController extends Controller
         ]);
 
         return to_route('staff.cheated_torrents.index')
-            ->withSuccess('All balances successfully reset');
+            ->with('success', 'All balances successfully reset');
     }
 }

--- a/app/Http/Controllers/Staff/CommandController.php
+++ b/app/Http/Controllers/Staff/CommandController.php
@@ -40,7 +40,7 @@ class CommandController extends Controller
         Artisan::call('down');
 
         return to_route('staff.commands.index')
-            ->withInfo(trim(Artisan::output()));
+            ->with('info', trim(Artisan::output()));
     }
 
     /**
@@ -51,7 +51,7 @@ class CommandController extends Controller
         Artisan::call('up');
 
         return to_route('staff.commands.index')
-            ->withInfo(trim(Artisan::output()));
+            ->with('info', trim(Artisan::output()));
     }
 
     /**
@@ -62,7 +62,7 @@ class CommandController extends Controller
         Artisan::call('cache:clear');
 
         return to_route('staff.commands.index')
-            ->withInfo(trim(Artisan::output()));
+            ->with('info', trim(Artisan::output()));
     }
 
     /**
@@ -73,7 +73,7 @@ class CommandController extends Controller
         Artisan::call('view:clear');
 
         return to_route('staff.commands.index')
-            ->withInfo(trim(Artisan::output()));
+            ->with('info', trim(Artisan::output()));
     }
 
     /**
@@ -84,7 +84,7 @@ class CommandController extends Controller
         Artisan::call('route:clear');
 
         return to_route('staff.commands.index')
-            ->withInfo(trim(Artisan::output()));
+            ->with('info', trim(Artisan::output()));
     }
 
     /**
@@ -95,7 +95,7 @@ class CommandController extends Controller
         Artisan::call('config:clear');
 
         return to_route('staff.commands.index')
-            ->withInfo(trim(Artisan::output()));
+            ->with('info', trim(Artisan::output()));
     }
 
     /**
@@ -106,7 +106,7 @@ class CommandController extends Controller
         Artisan::call('clear:all_cache');
 
         return to_route('staff.commands.index')
-            ->withInfo(trim(Artisan::output()));
+            ->with('info', trim(Artisan::output()));
     }
 
     /**
@@ -117,7 +117,7 @@ class CommandController extends Controller
         Artisan::call('set:all_cache');
 
         return to_route('staff.commands.index')
-            ->withInfo(trim(Artisan::output()));
+            ->with('info', trim(Artisan::output()));
     }
 
     /**
@@ -130,6 +130,6 @@ class CommandController extends Controller
         ]);
 
         return to_route('staff.commands.index')
-            ->withInfo(trim(str_replace(["\r", "\n", '*'], '', Artisan::output())));
+            ->with('info', trim(str_replace(["\r", "\n", '*'], '', Artisan::output())));
     }
 }

--- a/app/Http/Controllers/Staff/DistributorController.php
+++ b/app/Http/Controllers/Staff/DistributorController.php
@@ -51,7 +51,7 @@ class DistributorController extends Controller
         Distributor::create($request->validated());
 
         return to_route('staff.distributors.index')
-            ->withSuccess('Distributor Successfully Added');
+            ->with('success', 'Distributor Successfully Added');
     }
 
     /**
@@ -72,7 +72,7 @@ class DistributorController extends Controller
         $distributor->update($request->validated());
 
         return to_route('staff.distributors.index')
-            ->withSuccess('Distributor Successfully Modified');
+            ->with('success', 'Distributor Successfully Modified');
     }
 
     /**
@@ -97,6 +97,6 @@ class DistributorController extends Controller
         $distributor->delete();
 
         return to_route('staff.distributors.index')
-            ->withSuccess('Distributor Successfully Deleted');
+            ->with('success', 'Distributor Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/DonationController.php
+++ b/app/Http/Controllers/Staff/DonationController.php
@@ -103,7 +103,7 @@ class DonationController extends Controller
         Unit3dAnnounce::addUser($donation->user);
 
         return redirect()->route('staff.donations.index')
-            ->withSuccess('Donation Approved!');
+            ->with('success', 'Donation Approved!');
     }
 
     /**
@@ -128,6 +128,6 @@ class DonationController extends Controller
         $donation->save();
 
         return redirect()->route('staff.donations.index')
-            ->withSuccess('Donation Rejected!');
+            ->with('success', 'Donation Rejected!');
     }
 }

--- a/app/Http/Controllers/Staff/DonationGatewayController.php
+++ b/app/Http/Controllers/Staff/DonationGatewayController.php
@@ -54,7 +54,7 @@ class DonationGatewayController extends Controller
         DonationGateway::create($request->validated());
 
         return redirect()->route('staff.gateways.index')
-            ->withSuccess('Donation Gateway Added Successfully!');
+            ->with('success', 'Donation Gateway Added Successfully!');
     }
 
     /**
@@ -77,7 +77,7 @@ class DonationGatewayController extends Controller
         $gateway->update($request->validated());
 
         return redirect()->route('staff.gateways.index')
-            ->withSuccess('Donation Gateway Edited Successfully!');
+            ->with('success', 'Donation Gateway Edited Successfully!');
     }
 
     /**
@@ -90,6 +90,6 @@ class DonationGatewayController extends Controller
         $gateway->delete();
 
         return redirect()->route('staff.gateways.index')
-            ->withSuccess('Donation Gateway Deleted Successfully!');
+            ->with('success', 'Donation Gateway Deleted Successfully!');
     }
 }

--- a/app/Http/Controllers/Staff/DonationPackageController.php
+++ b/app/Http/Controllers/Staff/DonationPackageController.php
@@ -48,7 +48,7 @@ class DonationPackageController extends Controller
         DonationPackage::create($request->validated());
 
         return redirect()->route('staff.packages.index')
-            ->withSuccess('Donation Package Added Successfully!');
+            ->with('success', 'Donation Package Added Successfully!');
     }
 
     /**
@@ -67,7 +67,7 @@ class DonationPackageController extends Controller
         $package->update($request->validated());
 
         return redirect()->route('staff.packages.index')
-            ->withSuccess('Donation Package Edited Successfully!');
+            ->with('success', 'Donation Package Edited Successfully!');
     }
 
     /**
@@ -78,6 +78,6 @@ class DonationPackageController extends Controller
         $package->delete();
 
         return redirect()->route('staff.packages.index')
-            ->withSuccess('Donation Package Deleted Successfully!');
+            ->with('success', 'Donation Package Deleted Successfully!');
     }
 }

--- a/app/Http/Controllers/Staff/FlushController.php
+++ b/app/Http/Controllers/Staff/FlushController.php
@@ -65,7 +65,7 @@ class FlushController extends Controller
         }
 
         return to_route('staff.dashboard.index')
-            ->withSuccess('Ghost Peers Have Been Flushed');
+            ->with('success', 'Ghost Peers Have Been Flushed');
     }
 
     /**
@@ -85,6 +85,6 @@ class FlushController extends Controller
         );
 
         return to_route('staff.dashboard.index')
-            ->withSuccess('Chatbox Has Been Flushed');
+            ->with('success', 'Chatbox Has Been Flushed');
     }
 }

--- a/app/Http/Controllers/Staff/ForumCategoryController.php
+++ b/app/Http/Controllers/Staff/ForumCategoryController.php
@@ -43,7 +43,7 @@ class ForumCategoryController extends Controller
         ForumCategory::create($request->validated());
 
         return to_route('staff.forum_categories.index')
-            ->withSuccess('Forum has been created successfully');
+            ->with('success', 'Forum has been created successfully');
     }
 
     public function edit(ForumCategory $forumCategory): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
@@ -58,7 +58,7 @@ class ForumCategoryController extends Controller
         $forumCategory->update($request->validated());
 
         return to_route('staff.forum_categories.index')
-            ->withSuccess('Forum has been edited successfully');
+            ->with('success', 'Forum has been edited successfully');
     }
 
     public function destroy(ForumCategory $forumCategory): \Illuminate\Http\RedirectResponse
@@ -66,6 +66,6 @@ class ForumCategoryController extends Controller
         $forumCategory->delete();
 
         return to_route('staff.forum_categories.index')
-            ->withSuccess('Forum has been deleted successfully');
+            ->with('success', 'Forum has been deleted successfully');
     }
 }

--- a/app/Http/Controllers/Staff/ForumController.php
+++ b/app/Http/Controllers/Staff/ForumController.php
@@ -52,7 +52,7 @@ class ForumController extends Controller
         $forum->permissions()->upsert($request->validated('permissions'), ['forum_id', 'group_id']);
 
         return to_route('staff.forum_categories.index')
-            ->withSuccess('Forum has been created successfully');
+            ->with('success', 'Forum has been created successfully');
     }
 
     /**
@@ -77,7 +77,7 @@ class ForumController extends Controller
         $forum->permissions()->upsert($request->validated('permissions'), ['forum_id', 'group_id']);
 
         return to_route('staff.forum_categories.index')
-            ->withSuccess('Forum has been edited successfully');
+            ->with('success', 'Forum has been edited successfully');
     }
 
     /**
@@ -90,6 +90,6 @@ class ForumController extends Controller
         $forum->delete();
 
         return to_route('staff.forum_categories.index')
-            ->withSuccess('Forum has been deleted successfully');
+            ->with('success', 'Forum has been deleted successfully');
     }
 }

--- a/app/Http/Controllers/Staff/GroupController.php
+++ b/app/Http/Controllers/Staff/GroupController.php
@@ -66,7 +66,7 @@ class GroupController extends Controller
         Unit3dAnnounce::addGroup($group);
 
         return to_route('staff.groups.index')
-            ->withSuccess('Group Was Created Successfully!');
+            ->with('success', 'Group Was Created Successfully!');
     }
 
     /**
@@ -99,6 +99,6 @@ class GroupController extends Controller
         Unit3dAnnounce::addGroup($group);
 
         return to_route('staff.groups.index')
-            ->withSuccess('Group Was Updated Successfully!');
+            ->with('success', 'Group Was Updated Successfully!');
     }
 }

--- a/app/Http/Controllers/Staff/InternalController.php
+++ b/app/Http/Controllers/Staff/InternalController.php
@@ -84,7 +84,7 @@ class InternalController extends Controller
         $internal->update($request->validated());
 
         return to_route('staff.internals.index')
-            ->withSuccess('Internal Group Was Updated Successfully!');
+            ->with('success', 'Internal Group Was Updated Successfully!');
     }
 
     /**
@@ -103,7 +103,7 @@ class InternalController extends Controller
         Internal::create($request->validated());
 
         return to_route('staff.internals.index')
-            ->withSuccess('New Internal Group added!');
+            ->with('success', 'New Internal Group added!');
     }
 
     /**
@@ -114,6 +114,6 @@ class InternalController extends Controller
         $internal->delete();
 
         return to_route('staff.internals.index')
-            ->withSuccess('Group Has Been Removed.');
+            ->with('success', 'Group Has Been Removed.');
     }
 }

--- a/app/Http/Controllers/Staff/InternalUserController.php
+++ b/app/Http/Controllers/Staff/InternalUserController.php
@@ -35,7 +35,7 @@ class InternalUserController extends Controller
         return to_route('staff.internals.edit', [
             'internal' => $request->integer('internal_id')
         ])
-            ->withSuccess('User added to group.');
+            ->with('success', 'User added to group.');
     }
 
     public function update(UpdateInternalUserRequest $request, InternalUser $internalUser): \Illuminate\Http\RedirectResponse
@@ -45,7 +45,7 @@ class InternalUserController extends Controller
         return to_route('staff.internals.edit', [
             'internal' => $internalUser->internal_id
         ])
-            ->withSuccess('User updated.');
+            ->with('success', 'User updated.');
     }
 
     public function destroy(InternalUser $internalUser): \Illuminate\Http\RedirectResponse
@@ -55,6 +55,6 @@ class InternalUserController extends Controller
         return to_route('staff.internals.edit', [
             'internal' => $internalUser->internal_id
         ])
-            ->withSuccess('User removed from group.');
+            ->with('success', 'User removed from group.');
     }
 }

--- a/app/Http/Controllers/Staff/MassActionController.php
+++ b/app/Http/Controllers/Staff/MassActionController.php
@@ -55,7 +55,7 @@ class MassActionController extends Controller
         }
 
         return to_route('staff.mass-pm.create')
-            ->withSuccess('MassPM Sent');
+            ->with('success', 'MassPM Sent');
     }
 
     /**
@@ -82,6 +82,6 @@ class MassActionController extends Controller
         }
 
         return to_route('staff.dashboard.index')
-            ->withSuccess('Unvalidated Accounts Are Now Validated');
+            ->with('success', 'Unvalidated Accounts Are Now Validated');
     }
 }

--- a/app/Http/Controllers/Staff/MassEmailController.php
+++ b/app/Http/Controllers/Staff/MassEmailController.php
@@ -40,6 +40,6 @@ class MassEmailController extends Controller
         }
 
         return to_route('staff.dashboard.index')
-            ->withSuccess('Emails have been queued for processing to avoid spamming the mail server');
+            ->with('success', 'Emails have been queued for processing to avoid spamming the mail server');
     }
 }

--- a/app/Http/Controllers/Staff/MediaLanguageController.php
+++ b/app/Http/Controllers/Staff/MediaLanguageController.php
@@ -50,7 +50,7 @@ class MediaLanguageController extends Controller
         MediaLanguage::create($request->validated());
 
         return to_route('staff.media_languages.index')
-            ->withSuccess('Media Language Successfully Added');
+            ->with('success', 'Media Language Successfully Added');
     }
 
     /**
@@ -71,7 +71,7 @@ class MediaLanguageController extends Controller
         $mediaLanguage->update($request->validated());
 
         return to_route('staff.media_languages.index')
-            ->withSuccess('Media Language Successfully Updated');
+            ->with('success', 'Media Language Successfully Updated');
     }
 
     /**
@@ -84,6 +84,6 @@ class MediaLanguageController extends Controller
         $mediaLanguage->delete();
 
         return to_route('staff.media_languages.index')
-            ->withSuccess('Media Language Has Successfully Been Deleted');
+            ->with('success', 'Media Language Has Successfully Been Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/ModerationController.php
+++ b/app/Http/Controllers/Staff/ModerationController.php
@@ -109,7 +109,7 @@ class ModerationController extends Controller
                 TorrentHelper::approveHelper($id);
 
                 return to_route('staff.moderation.index')
-                    ->withSuccess('Torrent Approved');
+                    ->with('success', 'Torrent Approved');
 
             case Torrent::REJECTED:
                 $torrent->update([
@@ -133,7 +133,7 @@ class ModerationController extends Controller
                 Unit3dAnnounce::addTorrent($torrent);
 
                 return to_route('staff.moderation.index')
-                    ->withSuccess('Torrent Rejected');
+                    ->with('success', 'Torrent Rejected');
 
             case Torrent::POSTPONED:
                 $torrent->update([
@@ -157,7 +157,7 @@ class ModerationController extends Controller
                 Unit3dAnnounce::addTorrent($torrent);
 
                 return to_route('staff.moderation.index')
-                    ->withSuccess('Torrent Postponed');
+                    ->with('success', 'Torrent Postponed');
 
             default: // Undefined status
                 return to_route('torrents.show', ['id' => $id])

--- a/app/Http/Controllers/Staff/PageController.php
+++ b/app/Http/Controllers/Staff/PageController.php
@@ -53,7 +53,7 @@ class PageController extends Controller
         Page::create($request->validated());
 
         return to_route('staff.pages.index')
-            ->withSuccess('Page has been created successfully');
+            ->with('success', 'Page has been created successfully');
     }
 
     /**
@@ -74,7 +74,7 @@ class PageController extends Controller
         $page->update($request->validated());
 
         return to_route('staff.pages.index')
-            ->withSuccess('Page has been edited successfully');
+            ->with('success', 'Page has been edited successfully');
     }
 
     /**
@@ -87,6 +87,6 @@ class PageController extends Controller
         $page->delete();
 
         return to_route('staff.pages.index')
-            ->withSuccess('Page has been deleted successfully');
+            ->with('success', 'Page has been deleted successfully');
     }
 }

--- a/app/Http/Controllers/Staff/PollController.php
+++ b/app/Http/Controllers/Staff/PollController.php
@@ -78,7 +78,7 @@ class PollController extends Controller
         );
 
         return to_route('staff.polls.index')
-            ->withSuccess('Your poll has been created.');
+            ->with('success', 'Your poll has been created.');
     }
 
     /**
@@ -111,7 +111,7 @@ class PollController extends Controller
         );
 
         return to_route('staff.polls.index')
-            ->withSuccess('Your poll has been edited.');
+            ->with('success', 'Your poll has been edited.');
     }
 
     /**
@@ -125,6 +125,6 @@ class PollController extends Controller
         $poll->delete();
 
         return to_route('staff.polls.index')
-            ->withSuccess('Poll has successfully been deleted');
+            ->with('success', 'Poll has successfully been deleted');
     }
 }

--- a/app/Http/Controllers/Staff/PrizeController.php
+++ b/app/Http/Controllers/Staff/PrizeController.php
@@ -34,7 +34,7 @@ class PrizeController extends Controller
         return to_route('staff.events.edit', [
             'event' => $event
         ])
-            ->withSuccess('Prize added to event.');
+            ->with('success', 'Prize added to event.');
     }
 
     /**
@@ -47,7 +47,7 @@ class PrizeController extends Controller
         return to_route('staff.events.edit', [
             'event' => $event
         ])
-            ->withSuccess('Prize updated.');
+            ->with('success', 'Prize updated.');
     }
 
     /**
@@ -60,6 +60,6 @@ class PrizeController extends Controller
         return to_route('staff.events.edit', [
             'event' => $event
         ])
-            ->withSuccess('Prize removed from event.');
+            ->with('success', 'Prize removed from event.');
     }
 }

--- a/app/Http/Controllers/Staff/RegionController.php
+++ b/app/Http/Controllers/Staff/RegionController.php
@@ -51,7 +51,7 @@ class RegionController extends Controller
         Region::create($request->validated());
 
         return to_route('staff.regions.index')
-            ->withSuccess('Region Successfully Added');
+            ->with('success', 'Region Successfully Added');
     }
 
     /**
@@ -72,7 +72,7 @@ class RegionController extends Controller
         $region->update($request->validated());
 
         return to_route('staff.regions.index')
-            ->withSuccess('Region Successfully Modified');
+            ->with('success', 'Region Successfully Modified');
     }
 
     /**
@@ -86,6 +86,6 @@ class RegionController extends Controller
         $region->delete();
 
         return to_route('staff.regions.index')
-            ->withSuccess('Region Successfully Deleted');
+            ->with('success', 'Region Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/ReportController.php
+++ b/app/Http/Controllers/Staff/ReportController.php
@@ -70,6 +70,6 @@ class ReportController extends Controller
         ]);
 
         return to_route('staff.reports.index')
-            ->withSuccess('Report has been successfully resolved');
+            ->with('success', 'Report has been successfully resolved');
     }
 }

--- a/app/Http/Controllers/Staff/ResolutionController.php
+++ b/app/Http/Controllers/Staff/ResolutionController.php
@@ -50,7 +50,7 @@ class ResolutionController extends Controller
         Resolution::create($request->validated());
 
         return to_route('staff.resolutions.index')
-            ->withSuccess('Resolution Successfully Added');
+            ->with('success', 'Resolution Successfully Added');
     }
 
     /**
@@ -71,7 +71,7 @@ class ResolutionController extends Controller
         $resolution->update($request->validated());
 
         return to_route('staff.resolutions.index')
-            ->withSuccess('Resolution Successfully Modified');
+            ->with('success', 'Resolution Successfully Modified');
     }
 
     /**
@@ -84,6 +84,6 @@ class ResolutionController extends Controller
         $resolution->delete();
 
         return to_route('staff.resolutions.index')
-            ->withSuccess('Resolution Successfully Deleted');
+            ->with('success', 'Resolution Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/RssController.php
+++ b/app/Http/Controllers/Staff/RssController.php
@@ -70,7 +70,7 @@ class RssController extends Controller
         $rss->save();
 
         return to_route('staff.rss.index')
-            ->withSuccess('Public RSS Feed Created');
+            ->with('success', 'Public RSS Feed Created');
     }
 
     /**
@@ -104,7 +104,7 @@ class RssController extends Controller
         ]);
 
         return to_route('staff.rss.index')
-            ->withSuccess('Public RSS Feed Updated');
+            ->with('success', 'Public RSS Feed Updated');
     }
 
     /**
@@ -119,6 +119,6 @@ class RssController extends Controller
         $rss->delete();
 
         return to_route('staff.rss.index')
-            ->withSuccess('RSS Feed Deleted!');
+            ->with('success', 'RSS Feed Deleted!');
     }
 }

--- a/app/Http/Controllers/Staff/SeedboxController.php
+++ b/app/Http/Controllers/Staff/SeedboxController.php
@@ -45,6 +45,6 @@ class SeedboxController extends Controller
         $seedbox->delete();
 
         return to_route('staff.seedboxes.index')
-            ->withSuccess('Seedbox Record Has Successfully Been Deleted');
+            ->with('success', 'Seedbox Record Has Successfully Been Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/SnoozedReportController.php
+++ b/app/Http/Controllers/Staff/SnoozedReportController.php
@@ -30,7 +30,7 @@ class SnoozedReportController extends Controller
         $report->update($request->validated());
 
         return to_route('staff.reports.show', ['report' => $report])
-            ->withSuccess('Report has been snoozed');
+            ->with('success', 'Report has been snoozed');
     }
 
     /**
@@ -41,6 +41,6 @@ class SnoozedReportController extends Controller
         $report->update(['snoozed_until' => null]);
 
         return to_route('staff.reports.show', ['report' => $report])
-            ->withSuccess('Report has been un-snoozed');
+            ->with('success', 'Report has been un-snoozed');
     }
 }

--- a/app/Http/Controllers/Staff/TypeController.php
+++ b/app/Http/Controllers/Staff/TypeController.php
@@ -53,7 +53,7 @@ class TypeController extends Controller
         Type::create($request->validated());
 
         return to_route('staff.types.index')
-            ->withSuccess('Type Successfully Added');
+            ->with('success', 'Type Successfully Added');
     }
 
     /**
@@ -74,7 +74,7 @@ class TypeController extends Controller
         $type->update($request->validated());
 
         return to_route('staff.types.index')
-            ->withSuccess('Type Successfully Modified');
+            ->with('success', 'Type Successfully Modified');
     }
 
     /**
@@ -87,6 +87,6 @@ class TypeController extends Controller
         $type->delete();
 
         return to_route('staff.types.index')
-            ->withSuccess('Type Successfully Deleted');
+            ->with('success', 'Type Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/UnbanController.php
+++ b/app/Http/Controllers/Staff/UnbanController.php
@@ -58,6 +58,6 @@ class UnbanController extends Controller
         $user->notify(new UserBanExpire());
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess('User Is Now Relieved Of His Ban!');
+            ->with('success', 'User Is Now Relieved Of His Ban!');
     }
 }

--- a/app/Http/Controllers/Staff/UserController.php
+++ b/app/Http/Controllers/Staff/UserController.php
@@ -84,7 +84,7 @@ class UserController extends Controller
         Unit3dAnnounce::addUser($user);
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess('Account Was Updated Successfully!');
+            ->with('success', 'Account Was Updated Successfully!');
     }
 
     /**
@@ -107,7 +107,7 @@ class UserController extends Controller
         Unit3dAnnounce::addUser($user);
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess('Account Permissions Successfully Edited');
+            ->with('success', 'Account Permissions Successfully Edited');
     }
 
     /**
@@ -171,7 +171,7 @@ class UserController extends Controller
             Unit3dAnnounce::removeUser($user);
 
             return to_route('staff.dashboard.index')
-                ->withSuccess('Account Has Been Removed');
+                ->with('success', 'Account Has Been Removed');
         }
 
         return to_route('staff.dashboard.index')

--- a/app/Http/Controllers/Staff/WatchlistController.php
+++ b/app/Http/Controllers/Staff/WatchlistController.php
@@ -41,7 +41,7 @@ class WatchlistController extends Controller
     {
         Watchlist::create(['staff_id' => $request->user()->id] + $request->validated());
 
-        return back()->withSuccess('User Successfully Being Watched');
+        return back()->with('success', 'User Successfully Being Watched');
     }
 
     /**
@@ -53,6 +53,6 @@ class WatchlistController extends Controller
     {
         $watchlist->delete();
 
-        return back()->withSuccess('Successfully Stopped Watching User');
+        return back()->with('success', 'Successfully Stopped Watching User');
     }
 }

--- a/app/Http/Controllers/Staff/WhitelistedImageUrlController.php
+++ b/app/Http/Controllers/Staff/WhitelistedImageUrlController.php
@@ -37,7 +37,7 @@ class WhitelistedImageUrlController extends Controller
         cache()->forget('whitelisted-image-urls');
 
         return to_route('staff.whitelisted_image_urls.index')
-            ->withSuccess('Image url pattern updated successfully.');
+            ->with('success', 'Image url pattern updated successfully.');
     }
 
     public function store(StoreWhitelistedImageUrlRequest $request): \Illuminate\Http\RedirectResponse
@@ -47,7 +47,7 @@ class WhitelistedImageUrlController extends Controller
         cache()->forget('whitelisted-image-urls');
 
         return to_route('staff.whitelisted_image_urls.index')
-            ->withSuccess('New image url pattern whitelisted.');
+            ->with('success', 'New image url pattern whitelisted.');
     }
 
     public function destroy(WhitelistedImageUrl $whitelistedImageUrl): \Illuminate\Http\RedirectResponse
@@ -57,6 +57,6 @@ class WhitelistedImageUrlController extends Controller
         cache()->forget('whitelisted-image-urls');
 
         return to_route('staff.whitelisted_image_urls.index')
-            ->withSuccess('Image url pattern removed from whitelist.');
+            ->with('success', 'Image url pattern removed from whitelist.');
     }
 }

--- a/app/Http/Controllers/Staff/WikiCategoryController.php
+++ b/app/Http/Controllers/Staff/WikiCategoryController.php
@@ -52,7 +52,7 @@ class WikiCategoryController extends Controller
         WikiCategory::create($request->validated());
 
         return to_route('staff.wiki_categories.index')
-            ->withSuccess('Wiki Category Successfully Added');
+            ->with('success', 'Wiki Category Successfully Added');
     }
 
     /**
@@ -73,7 +73,7 @@ class WikiCategoryController extends Controller
         $wikiCategory->update($request->validated());
 
         return to_route('staff.wiki_categories.index')
-            ->withSuccess('Wiki Category Successfully Modified');
+            ->with('success', 'Wiki Category Successfully Modified');
     }
 
     /**
@@ -84,6 +84,6 @@ class WikiCategoryController extends Controller
         $wikiCategory->delete();
 
         return to_route('staff.wiki_categories.index')
-            ->withSuccess('Wiki Category Successfully Deleted');
+            ->with('success', 'Wiki Category Successfully Deleted');
     }
 }

--- a/app/Http/Controllers/Staff/WikiController.php
+++ b/app/Http/Controllers/Staff/WikiController.php
@@ -44,7 +44,7 @@ class WikiController extends Controller
         Wiki::create($request->validated());
 
         return to_route('staff.wiki_categories.index')
-            ->withSuccess('Wiki has been created successfully');
+            ->with('success', 'Wiki has been created successfully');
     }
 
     /**
@@ -66,7 +66,7 @@ class WikiController extends Controller
         $wiki->update($request->validated());
 
         return to_route('staff.wiki_categories.index')
-            ->withSuccess('Wiki has been edited successfully');
+            ->with('success', 'Wiki has been edited successfully');
     }
 
     /**
@@ -77,6 +77,6 @@ class WikiController extends Controller
         $wiki->delete();
 
         return to_route('staff.wiki_categories.index')
-            ->withSuccess('Wiki has been deleted successfully');
+            ->with('success', 'Wiki has been deleted successfully');
     }
 }

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -52,7 +52,7 @@ class SubscriptionController extends Controller
                 $request->user()->subscribedForums()->attach($request->forum_id);
 
                 return back()
-                    ->withSuccess('You are now subscribed to this forum. You will now receive site notifications when a topic is started.');
+                    ->with('success', 'You are now subscribed to this forum. You will now receive site notifications when a topic is started.');
 
             case $request->has('topic_id') === true:
                 abort_unless(
@@ -66,7 +66,7 @@ class SubscriptionController extends Controller
                 $request->user()->subscribedTopics()->attach($request->topic_id);
 
                 return back()
-                    ->withSuccess('You are now subscribed to this topic. You will now receive site notifications when a reply is left.');
+                    ->with('success', 'You are now subscribed to this topic. You will now receive site notifications when a reply is left.');
 
             default:
                 return back()->withErrors(['Failed to subscribe.']);
@@ -82,6 +82,6 @@ class SubscriptionController extends Controller
 
         $subscription->delete();
 
-        return back()->withSuccess('You are now unsubscribed.');
+        return back()->with('success', 'You are now unsubscribed.');
     }
 }

--- a/app/Http/Controllers/SubtitleController.php
+++ b/app/Http/Controllers/SubtitleController.php
@@ -138,7 +138,7 @@ class SubtitleController extends Controller
         }
 
         return to_route('torrents.show', ['id' => $request->input('torrent_id')])
-            ->withSuccess('Subtitle Successfully Added');
+            ->with('success', 'Subtitle Successfully Added');
     }
 
     /**
@@ -151,7 +151,7 @@ class SubtitleController extends Controller
         $subtitle->update($request->validated());
 
         return to_route('torrents.show', ['id' => $request->input('torrent_id')])
-            ->withSuccess('Subtitle Successfully Updated');
+            ->with('success', 'Subtitle Successfully Updated');
     }
 
     /**
@@ -172,7 +172,7 @@ class SubtitleController extends Controller
         $subtitle->delete();
 
         return to_route('torrents.show', ['id' => $request->integer('torrent_id')])
-            ->withSuccess('Subtitle Successfully Deleted');
+            ->with('success', 'Subtitle Successfully Deleted');
     }
 
     /**

--- a/app/Http/Controllers/TicketAssigneeController.php
+++ b/app/Http/Controllers/TicketAssigneeController.php
@@ -32,7 +32,7 @@ class TicketAssigneeController extends Controller
         ]);
 
         return to_route('tickets.show', ['ticket' => $ticket])
-            ->withSuccess(trans('ticket.assigned-success'));
+            ->with('success', trans('ticket.assigned-success'));
     }
 
     final public function destroy(Request $request, Ticket $ticket): \Illuminate\Http\RedirectResponse
@@ -44,6 +44,6 @@ class TicketAssigneeController extends Controller
         ]);
 
         return to_route('tickets.show', ['ticket' => $ticket])
-            ->withSuccess(trans('ticket.unassigned-success'));
+            ->with('success', trans('ticket.unassigned-success'));
     }
 }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -55,7 +55,7 @@ class TicketController extends Controller
         }
 
         return to_route('tickets.show', ['ticket' => $ticket])
-            ->withSuccess(trans('ticket.created-success'));
+            ->with('success', trans('ticket.created-success'));
     }
 
     /**
@@ -98,7 +98,7 @@ class TicketController extends Controller
         $ticket->delete();
 
         return to_route('tickets.index')
-            ->withSuccess(trans('ticket.deleted-success'));
+            ->with('success', trans('ticket.deleted-success'));
     }
 
     final public function close(Request $request, Ticket $ticket): \Illuminate\Http\RedirectResponse
@@ -110,7 +110,7 @@ class TicketController extends Controller
         ]);
 
         return to_route('tickets.index')
-            ->withSuccess(trans('ticket.closed-success'));
+            ->with('success', trans('ticket.closed-success'));
     }
 
     final public function reopen(Request $request, Ticket $ticket): \Illuminate\Http\RedirectResponse
@@ -122,6 +122,6 @@ class TicketController extends Controller
         ]);
 
         return to_route('tickets.show', ['ticket' => $ticket])
-            ->withSuccess(trans('ticket.reopened-success'));
+            ->with('success', trans('ticket.reopened-success'));
     }
 }

--- a/app/Http/Controllers/TicketNoteController.php
+++ b/app/Http/Controllers/TicketNoteController.php
@@ -34,7 +34,7 @@ class TicketNoteController extends Controller
         TicketNote::create(['ticket_id' => $ticket->id, 'user_id' => $user->id] + $request->validated());
 
         return to_route('tickets.show', ['ticket' => $ticket])
-            ->withSuccess(trans('ticket.note-create-success'));
+            ->with('success', trans('ticket.note-create-success'));
     }
 
     /**
@@ -47,6 +47,6 @@ class TicketNoteController extends Controller
         $ticket->notes()->delete();
 
         return to_route('tickets.show', ['ticket' => $ticket])
-            ->withSuccess(trans('ticket.note-destroy-success'));
+            ->with('success', trans('ticket.note-destroy-success'));
     }
 }

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -189,7 +189,7 @@ class TopicController extends Controller
         }
 
         return to_route('topics.show', ['id' => $topic->id])
-            ->withSuccess('Topic Created Successfully!');
+            ->with('success', 'Topic Created Successfully!');
     }
 
     /**
@@ -277,7 +277,7 @@ class TopicController extends Controller
         }
 
         return to_route('topics.show', ['id' => $topic->id])
-            ->withSuccess('Topic Successfully Edited');
+            ->with('success', 'Topic Successfully Edited');
     }
 
     /**
@@ -307,7 +307,7 @@ class TopicController extends Controller
         ]);
 
         return to_route('forums.show', ['id' => $forum->id])
-            ->withSuccess('This Topic Is Now Deleted!');
+            ->with('success', 'This Topic Is Now Deleted!');
     }
 
     /**
@@ -320,7 +320,7 @@ class TopicController extends Controller
         $topic->save();
 
         return to_route('topics.show', ['id' => $topic->id])
-            ->withSuccess('This Topic Is Now Closed!');
+            ->with('success', 'This Topic Is Now Closed!');
     }
 
     /**
@@ -333,7 +333,7 @@ class TopicController extends Controller
         $topic->save();
 
         return to_route('topics.show', ['id' => $topic->id])
-            ->withSuccess('This Topic Is Now Open!');
+            ->with('success', 'This Topic Is Now Open!');
     }
 
     /**
@@ -346,7 +346,7 @@ class TopicController extends Controller
         $topic->save();
 
         return to_route('topics.show', ['id' => $topic->id])
-            ->withSuccess('This Topic Is Now Pinned!');
+            ->with('success', 'This Topic Is Now Pinned!');
     }
 
     /**
@@ -359,7 +359,7 @@ class TopicController extends Controller
         $topic->save();
 
         return to_route('topics.show', ['id' => $topic->id])
-            ->withSuccess('This Topic Is Now Unpinned!');
+            ->with('success', 'This Topic Is Now Unpinned!');
     }
 
     /**

--- a/app/Http/Controllers/TopicLabelController.php
+++ b/app/Http/Controllers/TopicLabelController.php
@@ -32,6 +32,6 @@ class TopicLabelController extends Controller
         $topic->update($request->validated());
 
         return to_route('topics.show', ['id' => $topic->id])
-            ->withInfo('Label Change Has Been Applied');
+            ->with('info', 'Label Change Has Been Applied');
     }
 }

--- a/app/Http/Controllers/TopicReadController.php
+++ b/app/Http/Controllers/TopicReadController.php
@@ -66,7 +66,7 @@ class TopicReadController extends Controller
                         last_read_post_id = last_post_id
                 ', [$request->user()->id, $request->user()->id, $request->user()->group_id]);
 
-                return back()->withSuccess('All caught up!');
+                return back()->with('success', 'All caught up!');
             case 'forum':
                 $forum = Forum::authorized(canStartTopic: true)->findOrFail($request->integer('forum_id'));
 
@@ -95,7 +95,7 @@ class TopicReadController extends Controller
                 ', [$request->user()->id, $request->user()->id, $forum->id]);
 
                 return to_route('forums.show', ['id' => $request->integer('forum_id')])
-                    ->withSuccess('All caught up!');
+                    ->with('success', 'All caught up!');
 
             case 'forum_category':
                 DB::insert('
@@ -145,7 +145,7 @@ class TopicReadController extends Controller
                 ]);
 
                 return to_route('forums.categories.show', ['id' => $request->integer('forum_category_id')])
-                    ->withSuccess('All caught up!');
+                    ->with('success', 'All caught up!');
             case 'subscriptions':
                 DB::insert('
                     INSERT INTO
@@ -196,7 +196,7 @@ class TopicReadController extends Controller
                 ]);
 
                 return to_route('subscriptions.index')
-                    ->withSuccess('All caught up!');
+                    ->with('success', 'All caught up!');
             default:
                 return to_route('forums.index')
                     ->withErrors(['Failed to catchup.']);

--- a/app/Http/Controllers/TorrentBuffController.php
+++ b/app/Http/Controllers/TorrentBuffController.php
@@ -68,7 +68,7 @@ class TorrentBuffController extends Controller
         }
 
         return to_route('torrents.show', ['id' => $torrent->id])
-            ->withSuccess('Torrent Has Been Bumped To The Top Successfully!');
+            ->with('success', 'Torrent Has Been Bumped To The Top Successfully!');
     }
 
     /**
@@ -84,7 +84,7 @@ class TorrentBuffController extends Controller
         $torrent->save();
 
         return to_route('torrents.show', ['id' => $torrent->id])
-            ->withSuccess('Torrent Sticky Status Has Been Adjusted!');
+            ->with('success', 'Torrent Sticky Status Has Been Adjusted!');
     }
 
     /**
@@ -128,7 +128,7 @@ class TorrentBuffController extends Controller
         Unit3dAnnounce::addTorrent($torrent);
 
         return to_route('torrents.show', ['id' => $torrent->id])
-            ->withSuccess('Torrent FL Has Been Adjusted!');
+            ->with('success', 'Torrent FL Has Been Adjusted!');
     }
 
     /**
@@ -161,7 +161,7 @@ class TorrentBuffController extends Controller
             );
 
             return to_route('torrents.show', ['id' => $torrent->id])
-                ->withSuccess('Torrent Is Now Featured!');
+                ->with('success', 'Torrent Is Now Featured!');
         }
 
         return to_route('torrents.show', ['id' => $torrent->id])
@@ -196,7 +196,7 @@ class TorrentBuffController extends Controller
         cache()->forget('featured-torrent-ids');
 
         return to_route('torrents.show', ['id' => $torrent->id])
-            ->withSuccess('Revoked featured from Torrent!');
+            ->with('success', 'Revoked featured from Torrent!');
     }
 
     /**
@@ -238,7 +238,7 @@ class TorrentBuffController extends Controller
         Unit3dAnnounce::addTorrent($torrent);
 
         return to_route('torrents.show', ['id' => $torrent->id])
-            ->withSuccess('Torrent DoubleUpload Has Been Adjusted!');
+            ->with('success', 'Torrent DoubleUpload Has Been Adjusted!');
     }
 
     /**
@@ -267,7 +267,7 @@ class TorrentBuffController extends Controller
             $torrent->searchable();
 
             return to_route('torrents.show', ['id' => $torrent->id])
-                ->withSuccess('You Have Successfully Activated A Freeleech Token For This Torrent!');
+                ->with('success', 'You Have Successfully Activated A Freeleech Token For This Torrent!');
         }
 
         return to_route('torrents.show', ['id' => $torrent->id])
@@ -302,6 +302,6 @@ class TorrentBuffController extends Controller
         $torrent->save();
 
         return to_route('torrents.show', ['id' => $torrent->id])
-            ->withSuccess('Torrent\'s Refundable Status Has Been Adjusted!');
+            ->with('success', 'Torrent\'s Refundable Status Has Been Adjusted!');
     }
 }

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -276,7 +276,7 @@ class TorrentController extends Controller
         }
 
         return to_route('torrents.show', ['id' => $id])
-            ->withSuccess('Successfully Edited!');
+            ->with('success', 'Successfully Edited!');
     }
 
     /**
@@ -339,7 +339,7 @@ class TorrentController extends Controller
         $torrent->delete();
 
         return to_route('torrents.index')
-            ->withSuccess('Torrent Has Been Deleted!');
+            ->with('success', 'Torrent Has Been Deleted!');
     }
 
     /**
@@ -515,6 +515,6 @@ class TorrentController extends Controller
         }
 
         return to_route('download_check', ['id' => $torrent->id])
-            ->withSuccess('Your torrent file is ready to be downloaded and seeded!');
+            ->with('success', 'Your torrent file is ready to be downloaded and seeded!');
     }
 }

--- a/app/Http/Controllers/TorrentTrumpController.php
+++ b/app/Http/Controllers/TorrentTrumpController.php
@@ -34,7 +34,7 @@ class TorrentTrumpController extends Controller
         ]);
 
         return to_route('torrents.show', ['id' => $torrent->id])
-            ->withSuccess('Torrent Flagged As Trumpable!');
+            ->with('success', 'Torrent Flagged As Trumpable!');
     }
 
     public function destroy(Request $request, Torrent $torrent): \Illuminate\Http\RedirectResponse
@@ -46,6 +46,6 @@ class TorrentTrumpController extends Controller
         $torrent->trump()->delete();
 
         return to_route('torrents.show', ['id' => $torrent->id])
-            ->withSuccess('Torrent Trump Flag Removed!');
+            ->with('success', 'Torrent Trump Flag Removed!');
     }
 }

--- a/app/Http/Controllers/User/ApikeyController.php
+++ b/app/Http/Controllers/User/ApikeyController.php
@@ -53,7 +53,7 @@ class ApikeyController extends Controller
         });
 
         return to_route('users.apikeys.index', ['user' => $user])
-            ->withSuccess('Your API key was changed successfully.');
+            ->with('success', 'Your API key was changed successfully.');
     }
 
     /**

--- a/app/Http/Controllers/User/ConversationController.php
+++ b/app/Http/Controllers/User/ConversationController.php
@@ -94,7 +94,7 @@ class ConversationController extends Controller
         $conversation->users()->sync([$user->id => ['read' => true], $recipient->id]);
 
         return to_route('users.conversations.show', ['user' => $user, 'conversation' => $conversation])
-            ->withSuccess(trans('pm.sent-success'));
+            ->with('success', trans('pm.sent-success'));
     }
 
     /**
@@ -123,7 +123,7 @@ class ConversationController extends Controller
             'user'         => $user,
             'conversation' => $conversation
         ])
-            ->withSuccess(trans('pm.sent-success'));
+            ->with('success', trans('pm.sent-success'));
     }
 
     /**
@@ -138,7 +138,7 @@ class ConversationController extends Controller
         $conversation->participants()->whereBelongsTo($user)->delete();
 
         return to_route('users.conversations.index', ['user' => $user])
-            ->withSuccess(trans('pm.delete-success'));
+            ->with('success', trans('pm.delete-success'));
     }
 
     /**
@@ -151,7 +151,7 @@ class ConversationController extends Controller
         $user->participations()->delete();
 
         return to_route('users.conversations.index', ['user' => $user])
-            ->withSuccess(trans('pm.delete-success'));
+            ->with('success', trans('pm.delete-success'));
     }
 
     /**
@@ -166,6 +166,6 @@ class ConversationController extends Controller
         ]);
 
         return to_route('users.conversations.index', ['user' => $user])
-            ->withSuccess(trans('pm.all-marked-read'));
+            ->with('success', trans('pm.all-marked-read'));
     }
 }

--- a/app/Http/Controllers/User/EmailController.php
+++ b/app/Http/Controllers/User/EmailController.php
@@ -67,7 +67,7 @@ class EmailController extends Controller
         $user->sendEmailVerificationNotification();
 
         return to_route('users.email.edit', ['user' => $user])
-            ->withSuccess('Your email was updated successfully.');
+            ->with('success', 'Your email was updated successfully.');
     }
 
     /**

--- a/app/Http/Controllers/User/FollowController.php
+++ b/app/Http/Controllers/User/FollowController.php
@@ -55,7 +55,7 @@ class FollowController extends Controller
         }
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess(\sprintf(trans('user.follow-user'), $user->username));
+            ->with('success', \sprintf(trans('user.follow-user'), $user->username));
     }
 
     /**
@@ -70,6 +70,6 @@ class FollowController extends Controller
         }
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess(\sprintf(trans('user.follow-revoked'), $user->username));
+            ->with('success', \sprintf(trans('user.follow-revoked'), $user->username));
     }
 }

--- a/app/Http/Controllers/User/GeneralSettingController.php
+++ b/app/Http/Controllers/User/GeneralSettingController.php
@@ -35,7 +35,7 @@ class GeneralSettingController extends Controller
         cache()->forget('user-settings:by-user-id:'.$user->id);
 
         return to_route('users.general_settings.edit', ['user' => $user])
-            ->withSuccess('Your general settings have been successfully saved.');
+            ->with('success', 'Your general settings have been successfully saved.');
     }
 
     /**

--- a/app/Http/Controllers/User/GiftController.php
+++ b/app/Http/Controllers/User/GiftController.php
@@ -105,6 +105,6 @@ class GiftController extends Controller
             )
         );
 
-        return redirect()->back()->withSuccess(trans('bon.gift-sent'));
+        return redirect()->back()->with('success', trans('bon.gift-sent'));
     }
 }

--- a/app/Http/Controllers/User/InviteController.php
+++ b/app/Http/Controllers/User/InviteController.php
@@ -129,7 +129,7 @@ class InviteController extends Controller
         Mail::to($request->input('email'))->send(new InviteUser($invite));
 
         return to_route('users.invites.create', ['user' => $user])
-            ->withSuccess(trans('user.invite-sent-success'));
+            ->with('success', trans('user.invite-sent-success'));
     }
 
     /**
@@ -152,7 +152,7 @@ class InviteController extends Controller
         $sentInvite->delete();
 
         return to_route('users.invites.index', ['user' => $user])
-            ->withSuccess('Invite deleted successfully.');
+            ->with('success', 'Invite deleted successfully.');
     }
 
     /**
@@ -175,6 +175,6 @@ class InviteController extends Controller
         Mail::to($sentInvite->email)->send(new InviteUser($sentInvite));
 
         return to_route('users.invites.index', ['user' => $user])
-            ->withSuccess(trans('user.invite-resent-success'));
+            ->with('success', trans('user.invite-resent-success'));
     }
 }

--- a/app/Http/Controllers/User/NotificationController.php
+++ b/app/Http/Controllers/User/NotificationController.php
@@ -47,7 +47,7 @@ class NotificationController extends Controller
         $notification->markAsRead();
 
         return redirect()->to($notification->data['url'])
-            ->withSuccess(trans('notification.marked-read'));
+            ->with('success', trans('notification.marked-read'));
     }
 
     /**
@@ -60,7 +60,7 @@ class NotificationController extends Controller
         $notification->markAsRead();
 
         return to_route('users.notifications.index', ['user' => $user])
-            ->withSuccess(trans('notification.marked-read'));
+            ->with('success', trans('notification.marked-read'));
     }
 
     /**
@@ -75,7 +75,7 @@ class NotificationController extends Controller
         $user->unreadNotifications()->update(['read_at' => now()]);
 
         return to_route('users.notifications.index', ['user' => $user])
-            ->withSuccess(trans('notification.all-marked-read'));
+            ->with('success', trans('notification.all-marked-read'));
     }
 
     /**
@@ -88,7 +88,7 @@ class NotificationController extends Controller
         $notification->delete();
 
         return to_route('users.notifications.index', ['user' => $user])
-            ->withSuccess(trans('notification.deleted'));
+            ->with('success', trans('notification.deleted'));
     }
 
     /**
@@ -101,6 +101,6 @@ class NotificationController extends Controller
         $user->notifications()->delete();
 
         return to_route('users.notifications.index', ['user' => $user])
-            ->withSuccess(trans('notification.all-deleted'));
+            ->with('success', trans('notification.all-deleted'));
     }
 }

--- a/app/Http/Controllers/User/NotificationSettingController.php
+++ b/app/Http/Controllers/User/NotificationSettingController.php
@@ -40,7 +40,7 @@ class NotificationSettingController extends Controller
         cache()->forget('user-notification:by-user-id:'.$user->id);
 
         return to_route('users.notification_settings.edit', ['user' => $user])
-            ->withSuccess('Your notification settings have been successfully saved.');
+            ->with('success', 'Your notification settings have been successfully saved.');
     }
 
     /**

--- a/app/Http/Controllers/User/PasskeyController.php
+++ b/app/Http/Controllers/User/PasskeyController.php
@@ -72,6 +72,6 @@ class PasskeyController extends Controller
         Unit3dAnnounce::addUser($user);
 
         return to_route('users.passkeys.index', ['user' => $user])
-            ->withSuccess('Your passkey was changed successfully.');
+            ->with('success', 'Your passkey was changed successfully.');
     }
 }

--- a/app/Http/Controllers/User/PasswordController.php
+++ b/app/Http/Controllers/User/PasswordController.php
@@ -65,7 +65,7 @@ class PasswordController extends Controller
         });
 
         return to_route('users.password.edit', ['user' => $user])
-            ->withSuccess('Your new password has been saved successfully.');
+            ->with('success', 'Your new password has been saved successfully.');
     }
 
     /**

--- a/app/Http/Controllers/User/PeerController.php
+++ b/app/Http/Controllers/User/PeerController.php
@@ -73,6 +73,6 @@ class PeerController extends Controller
 
         $user->decrement('own_flushes');
 
-        return redirect()->back()->withSuccess('All peers last announced from the client over 70 minutes ago have been flushed successfully!');
+        return redirect()->back()->with('success', 'All peers last announced from the client over 70 minutes ago have been flushed successfully!');
     }
 }

--- a/app/Http/Controllers/User/PostTipController.php
+++ b/app/Http/Controllers/User/PostTipController.php
@@ -71,6 +71,6 @@ class PostTipController extends Controller
             $tip->recipient->notify((new NewPostTip($tip))->afterCommit());
         });
 
-        return redirect()->back()->withSuccess(trans('bon.success-tip'));
+        return redirect()->back()->with('success', trans('bon.success-tip'));
     }
 }

--- a/app/Http/Controllers/User/PrivacySettingController.php
+++ b/app/Http/Controllers/User/PrivacySettingController.php
@@ -40,7 +40,7 @@ class PrivacySettingController extends Controller
         cache()->forget('user-privacy:by-user-id:'.$user->id);
 
         return to_route('users.privacy_settings.edit', ['user' => $user])
-            ->withSuccess('Your privacy settings have been successfully saved.');
+            ->with('success', 'Your privacy settings have been successfully saved.');
     }
 
     /**

--- a/app/Http/Controllers/User/ResurrectionController.php
+++ b/app/Http/Controllers/User/ResurrectionController.php
@@ -75,7 +75,7 @@ class ResurrectionController extends Controller
         ]);
 
         return to_route('torrents.show', ['id' => $torrent->id])
-            ->withSuccess(trans('graveyard.resurrect-complete'));
+            ->with('success', trans('graveyard.resurrect-complete'));
     }
 
     /**
@@ -88,6 +88,6 @@ class ResurrectionController extends Controller
         $resurrection->delete();
 
         return to_route('users.resurrections.index', ['user' => $user])
-            ->withSuccess(trans('graveyard.resurrect-canceled'));
+            ->with('success', trans('graveyard.resurrect-canceled'));
     }
 }

--- a/app/Http/Controllers/User/RsskeyController.php
+++ b/app/Http/Controllers/User/RsskeyController.php
@@ -52,7 +52,7 @@ class RsskeyController extends Controller
         });
 
         return to_route('users.rsskeys.index', ['user' => $user])
-            ->withSuccess('Your RSS key was changed successfully.');
+            ->with('success', 'Your RSS key was changed successfully.');
     }
 
     /**

--- a/app/Http/Controllers/User/SeedboxController.php
+++ b/app/Http/Controllers/User/SeedboxController.php
@@ -80,7 +80,7 @@ class SeedboxController extends Controller
         ]);
 
         return to_route('users.seedboxes.index', ['user' => $user])
-            ->withSuccess(trans('user.seedbox-added-success'));
+            ->with('success', trans('user.seedbox-added-success'));
     }
 
     /**
@@ -95,6 +95,6 @@ class SeedboxController extends Controller
         $seedbox->delete();
 
         return to_route('users.seedboxes.index', ['user' => $user])
-            ->withSuccess(trans('user.seedbox-deleted-success'));
+            ->with('success', trans('user.seedbox-deleted-success'));
     }
 }

--- a/app/Http/Controllers/User/TorrentTipController.php
+++ b/app/Http/Controllers/User/TorrentTipController.php
@@ -75,6 +75,6 @@ class TorrentTipController extends Controller
             }
         });
 
-        return redirect()->back()->withSuccess(trans('bon.success-tip'));
+        return redirect()->back()->with('success', trans('bon.success-tip'));
     }
 }

--- a/app/Http/Controllers/User/TransactionController.php
+++ b/app/Http/Controllers/User/TransactionController.php
@@ -127,7 +127,7 @@ class TransactionController extends Controller
 
             $user->decrement('seedbonus', $bonExchange->cost);
 
-            return back()->withSuccess(trans('bon.success'));
+            return back()->with('success', trans('bon.success'));
         }, 5);
     }
 }

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -248,7 +248,7 @@ class UserController extends Controller
         }
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess('Your Account Was Updated Successfully!');
+            ->with('success', 'Your Account Was Updated Successfully!');
     }
 
     /**

--- a/app/Http/Controllers/User/WarningController.php
+++ b/app/Http/Controllers/User/WarningController.php
@@ -50,7 +50,7 @@ class WarningController extends Controller
         );
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess('Warning issued successfully!');
+            ->with('success', 'Warning issued successfully!');
     }
 
     /**
@@ -77,7 +77,7 @@ class WarningController extends Controller
         $warning->delete();
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess('Warning Was Successfully Deleted');
+            ->with('success', 'Warning Was Successfully Deleted');
     }
 
     /**
@@ -101,7 +101,7 @@ class WarningController extends Controller
         );
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess('All Warnings Were Successfully Deleted');
+            ->with('success', 'All Warnings Were Successfully Deleted');
     }
 
     /**
@@ -114,6 +114,6 @@ class WarningController extends Controller
         $warning->restore();
 
         return to_route('users.show', ['user' => $user])
-            ->withSuccess('Warning Was Successfully Restored');
+            ->with('success', 'Warning Was Successfully Restored');
     }
 }

--- a/app/Http/Controllers/User/WishController.php
+++ b/app/Http/Controllers/User/WishController.php
@@ -94,7 +94,7 @@ class WishController extends Controller
         }
 
         return to_route('users.wishes.index', ['user' => $user])
-            ->withSuccess('Wish Successfully Added!');
+            ->with('success', 'Wish Successfully Added!');
     }
 
     /**
@@ -107,6 +107,6 @@ class WishController extends Controller
         $wish->delete();
 
         return to_route('users.wishes.index', ['user' => $user])
-            ->withSuccess('Wish Successfully Removed!');
+            ->with('success', 'Wish Successfully Removed!');
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -68,13 +68,13 @@ class FortifyServiceProvider extends ServiceProvider
                     Unit3dAnnounce::addUser($user);
 
                     return to_route('home.index')
-                        ->withSuccess(trans('auth.welcome-restore'));
+                        ->with('success', trans('auth.welcome-restore'));
                 }
 
                 // Check if user has read the rules
                 if ($request->user()->read_rules == 0) {
                     return redirect()->to(config('other.rules_url'))
-                        ->withWarning(trans('auth.require-rules'));
+                        ->with('warning', trans('auth.require-rules'));
                 }
 
                 // Fix for issue described in https://github.com/laravel/framework/pull/46133
@@ -91,7 +91,7 @@ class FortifyServiceProvider extends ServiceProvider
                 }
 
                 return redirect()->intended()
-                    ->withSuccess(trans('auth.welcome'));
+                    ->with('success', trans('auth.welcome'));
             }
         });
 
@@ -129,7 +129,7 @@ class FortifyServiceProvider extends ServiceProvider
                     }
 
                     return to_route('login')
-                        ->withSuccess(trans('auth.activation-success'));
+                        ->with('success', trans('auth.activation-success'));
                 }
 
                 return to_route('login')

--- a/tests/Feature/Http/Controllers/PostControllerTest.php
+++ b/tests/Feature/Http/Controllers/PostControllerTest.php
@@ -100,7 +100,7 @@ test('store returns an ok response', function (): void {
         // TODO: send request data
     ]);
 
-    $response->assertRedirect(withSuccess(trans('forum.reply-topic-success')));
+    $response->assertRedirect(with('success', trans('forum.reply-topic-success')));
 
     // TODO: perform additional assertions
 });
@@ -115,7 +115,7 @@ test('update returns an ok response', function (): void {
         // TODO: send request data
     ]);
 
-    $response->assertRedirect(withSuccess(trans('forum.edit-post-success')));
+    $response->assertRedirect(with('success', trans('forum.edit-post-success')));
 
     // TODO: perform additional assertions
 });

--- a/tests/Feature/Http/Controllers/User/GiftControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/GiftControllerTest.php
@@ -100,7 +100,7 @@ test('store returns an ok response', function (): void {
         // TODO: send request data
     ]);
 
-    $response->assertRedirect(withSuccess(trans('bon.gift-sent')));
+    $response->assertRedirect(with('success', trans('bon.gift-sent')));
 
     // TODO: perform additional assertions
 });

--- a/tests/Feature/Http/Controllers/User/NotificationControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/NotificationControllerTest.php
@@ -137,7 +137,7 @@ test('show returns an ok response', function (): void {
 
     $response = $this->actingAs($authUser)->get(route('users.notifications.show', [$user, $notification]));
 
-    $response->assertRedirect(withSuccess(trans('notification.marked-read')));
+    $response->assertRedirect(with('success', trans('notification.marked-read')));
 
     // TODO: perform additional assertions
 });

--- a/tests/Feature/Http/Controllers/User/TipControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/TipControllerTest.php
@@ -75,7 +75,7 @@ test('store returns an ok response', function (): void {
         // TODO: send request data
     ]);
 
-    $response->assertRedirect(withSuccess(trans('bon.success-tip')));
+    $response->assertRedirect(with('success', trans('bon.success-tip')));
 
     // TODO: perform additional assertions
 });


### PR DESCRIPTION
Allows ctrl+clicking to access the underlying function unlike the previous magic implementation. Probably also negligibly faster.

Swapped all instances of `>withSuccess(` -> `>with('success', `, `>withWarning(` -> `>with('warning', `, and `>withInfo(` -> `>with('info', ` with ide's find and replace.