### PR TITLE
(Fix) BBCode link double encoding

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -519,6 +519,6 @@ class Bbcode
             }
         }
 
-        return htmlspecialchars($url, ENT_QUOTES | ENT_HTML5);
+        return $url;
     }
 }


### PR DESCRIPTION
We already encode the entire content of the bbcode, so encoding links a second time aren't necessary.

Regression from #3222