### PR TITLE
(Fix) Use sync for the connection queue in tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,7 @@
     <ini name="display_errors" value="true"/>
     <env name="DB_CONNECTION" value="mysql"/>
     <env name="APP_ENV" value="testing"/>
+    <env name="QUEUE_CONNECTION" value="sync" />
     <!--
     <env name="REDIS_HOST" value="127.0.0.1" />
     <env name="REDIS_PORT" value="6379" />

--- a/tests/Feature/Http/Controllers/Staff/MassActionControllerTest.php
+++ b/tests/Feature/Http/Controllers/Staff/MassActionControllerTest.php
@@ -20,6 +20,7 @@ use App\Models\Group;
 use App\Models\PrivateMessage;
 use App\Models\User;
 use Database\Seeders\GroupsTableSeeder;
+use Database\Seeders\UsersTableSeeder;
 
 test('create returns an ok response', function (): void {
     $response = $this->get(route('staff.mass-pm.create'));
@@ -37,6 +38,7 @@ test('store validates with a form request', function (): void {
 });
 
 test('store returns an ok response', function (): void {
+    $this->seed(UsersTableSeeder::class);
     $message = PrivateMessage::factory()->create();
 
     $response = $this->post(route('staff.mass-pm.store'), [


### PR DESCRIPTION
Tests more accurately as we can ensure jobs finish successfully.