### PR TITLE
(Fix) Normalize torrent featured flag

### DIFF
--- a/app/Console/Commands/DemoSeed.php
+++ b/app/Console/Commands/DemoSeed.php
@@ -89,7 +89,6 @@ class DemoSeed extends Command
                         'region_id'      => random_int(1, 242),
                         'distributor_id' => random_int(1, 965),
                         'free'           => $freeleech[$selected],
-                        'featured'       => false,
                         'sticky'         => 0,
                         'mediainfo'      => '
 Complete name                            : Double.Impact.1991.1080p.BluRay.DD+5.1.x264-LoRD.mkv
@@ -285,7 +284,6 @@ Menu
                         'region_id'      => random_int(1, 242),
                         'distributor_id' => random_int(1, 965),
                         'free'           => $freeleech[$selected],
-                        'featured'       => false,
                         'sticky'         => 0,
                         'mediainfo'      => '
 Complete name                            : Double.Impact.1991.1080p.BluRay.DD+5.1.x264-LoRD.mkv

--- a/app/Http/Controllers/TorrentBuffController.php
+++ b/app/Http/Controllers/TorrentBuffController.php
@@ -141,10 +141,7 @@ class TorrentBuffController extends Controller
         abort_unless($user->group->is_modo || $user->group->is_internal, 403);
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
-        if ($torrent->featured === false) {
-            $torrent->featured = true;
-            $torrent->save();
-
+        if ($torrent->featured()->doesntExist()) {
             Unit3dAnnounce::addFeaturedTorrent($torrent->id);
 
             $featured = new FeaturedTorrent();
@@ -180,8 +177,6 @@ class TorrentBuffController extends Controller
         $featured_torrent = FeaturedTorrent::where('torrent_id', '=', $id)->sole();
 
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
-        $torrent->featured = false;
-        $torrent->save();
 
         Unit3dAnnounce::removeFeaturedTorrent($torrent->id);
 

--- a/app/Http/Livewire/PersonCredit.php
+++ b/app/Http/Livewire/PersonCredit.php
@@ -157,6 +157,7 @@ class PersonCredit extends Component
         $torrents = Torrent::query()
             ->with('type:id,name,position', 'resolution:id,name,position')
             ->withExists([
+                'featured as featured',
                 'freeleechTokens' => fn ($query) => $query->where('user_id', '=', auth()->id()),
             ])
             ->select([
@@ -176,7 +177,6 @@ class PersonCredit extends Component
                 'free',
                 'doubleup',
                 'highspeed',
-                'featured',
                 'sticky',
                 'sd',
                 'internal',

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -589,6 +589,7 @@ class TorrentSearch extends Component
                 'leeches' => fn ($query) => $query->where('active', '=', true)->where('visible', '=', true),
             ])
             ->withExists([
+                'featured as featured',
                 'freeleechTokens'    => fn ($query) => $query->where('user_id', '=', $user->id),
                 'bookmarks'          => fn ($query) => $query->where('user_id', '=', $user->id),
                 'history as seeding' => fn ($query) => $query->where('user_id', '=', $user->id)
@@ -626,7 +627,6 @@ class TorrentSearch extends Component
                 'free',
                 'doubleup',
                 'highspeed',
-                'featured',
                 'sticky',
                 'sd',
                 'internal',

--- a/app/Http/Resources/TorrentResource.php
+++ b/app/Http/Resources/TorrentResource.php
@@ -59,7 +59,7 @@ class TorrentResource extends JsonResource
                 'double_upload'    => $this->doubleup,
                 'refundable'       => $this->refundable,
                 'internal'         => $this->internal,
-                'featured'         => $this->featured,
+                'featured'         => $this->whenHas('featured'),
                 'personal_release' => $this->personal_release,
                 'uploader'         => $this->anon ? 'Anonymous' : $this->user->username,
                 'seeders'          => $this->seeders,

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -61,7 +61,6 @@ use Laravel\Scout\Searchable;
  * @property bool                            $doubleup
  * @property bool                            $refundable
  * @property int                             $highspeed
- * @property bool                            $featured
  * @property int                             $status
  * @property \Illuminate\Support\Carbon|null $moderated_at
  * @property int|null                        $moderated_by
@@ -98,7 +97,7 @@ class Torrent extends Model
     /**
      * Get the attributes that should be cast.
      *
-     * @return array{tmdb: 'int', igdb: 'int', bumped_at: 'datetime', fl_until: 'datetime', du_until: 'datetime', doubleup: 'bool', refundable: 'bool', featured: 'bool', moderated_at: 'datetime', sticky: 'bool'}
+     * @return array{tmdb: 'int', igdb: 'int', bumped_at: 'datetime', fl_until: 'datetime', du_until: 'datetime', doubleup: 'bool', refundable: 'bool', moderated_at: 'datetime', sticky: 'bool'}
      */
     protected function casts(): array
     {
@@ -110,7 +109,6 @@ class Torrent extends Model
             'du_until'     => 'datetime',
             'doubleup'     => 'bool',
             'refundable'   => 'bool',
-            'featured'     => 'bool',
             'moderated_at' => 'datetime',
             'sticky'       => 'bool',
         ];
@@ -165,7 +163,6 @@ class Torrent extends Model
             torrents.doubleup,
             torrents.refundable,
             torrents.highspeed,
-            torrents.featured,
             torrents.status,
             torrents.anon,
             torrents.sticky,
@@ -305,6 +302,11 @@ class Torrent extends Model
                 FROM torrent_trumps
                 WHERE torrents.id = torrent_trumps.torrent_id
             ) AS trumpable,
+            EXISTS(
+                SELECT *
+                FROM featured_torrents
+                WHERE torrents.id = featured_torrents.torrent_id
+            ) AS featured,
             (
                 SELECT JSON_OBJECT(
                     'id', movies.id,

--- a/database/factories/TorrentFactory.php
+++ b/database/factories/TorrentFactory.php
@@ -64,7 +64,6 @@ class TorrentFactory extends Factory
             'free'            => $freeleech[$selected],
             'doubleup'        => $this->faker->boolean(),
             'highspeed'       => $this->faker->boolean(),
-            'featured'        => false,
             'status'          => Torrent::APPROVED,
             'moderated_at'    => now(),
             'moderated_by'    => 1,

--- a/database/migrations/2025_02_10_164236_drop_featured_column_from_torrents_table.php
+++ b/database/migrations/2025_02_10_164236_drop_featured_column_from_torrents_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->dropColumn('featured');
+        });
+    }
+};

--- a/resources/views/torrent/partials/tools.blade.php
+++ b/resources/views/torrent/partials/tools.blade.php
@@ -317,7 +317,7 @@
                         </form>
                     </li>
                     <li>
-                        @if ($torrent->featured === false)
+                        @if ($featured === null)
                             <form
                                 method="POST"
                                 action="{{ route('torrent_feature', ['id' => $torrent->id]) }}"


### PR DESCRIPTION
When the featured flag goes out of sync with the featured_torrents table (for reasons still unknown), the torrent is permanently labeled as freeleech, while 100% of traffic is always credited.