### PR TITLE
(Fix) Don't hide existing sidebar if main is empty

### DIFF
--- a/resources/views/Staff/announce/index.blade.php
+++ b/resources/views/Staff/announce/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Announces - {{ config('other.title') }}</title>
@@ -15,6 +15,6 @@
 
 @section('page', 'page__history--index')
 
-@section('content')
+@section('main')
     @livewire('announce-search')
 @endsection

--- a/resources/views/Staff/apikey/index.blade.php
+++ b/resources/views/Staff/apikey/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/application/index.blade.php
+++ b/resources/views/Staff/application/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Applications - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/application/show.blade.php
+++ b/resources/views/Staff/application/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>Application - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/article/create.blade.php
+++ b/resources/views/Staff/article/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Articles - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/article/edit.blade.php
+++ b/resources/views/Staff/article/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Articles - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/article/index.blade.php
+++ b/resources/views/Staff/article/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Articles - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/audit/index.blade.php
+++ b/resources/views/Staff/audit/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Audits Log - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/authentication/index.blade.php
+++ b/resources/views/Staff/authentication/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/automatic-torrent-freeleech/create.blade.php
+++ b/resources/views/Staff/automatic-torrent-freeleech/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/automatic-torrent-freeleech/edit.blade.php
+++ b/resources/views/Staff/automatic-torrent-freeleech/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/automatic-torrent-freeleech/index.blade.php
+++ b/resources/views/Staff/automatic-torrent-freeleech/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/backup/index.blade.php
+++ b/resources/views/Staff/backup/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/ban/index.blade.php
+++ b/resources/views/Staff/ban/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Bans - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/blacklist/clients/create.blade.php
+++ b/resources/views/Staff/blacklist/clients/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/blacklist/clients/edit.blade.php
+++ b/resources/views/Staff/blacklist/clients/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/blacklist/clients/index.blade.php
+++ b/resources/views/Staff/blacklist/clients/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/blocked_ip/index.blade.php
+++ b/resources/views/Staff/blocked_ip/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/bon_earning/create.blade.php
+++ b/resources/views/Staff/bon_earning/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/bon_earning/edit.blade.php
+++ b/resources/views/Staff/bon_earning/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/bon_earning/index.blade.php
+++ b/resources/views/Staff/bon_earning/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">
@@ -9,7 +9,7 @@
     <li class="breadcrumb--active">{{ __('bon.bon') }} {{ __('bon.earning') }}</li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">{{ __('bon.bon') }} {{ __('bon.exchange') }}</h2>

--- a/resources/views/Staff/bon_exchange/create.blade.php
+++ b/resources/views/Staff/bon_exchange/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/bon_exchange/edit.blade.php
+++ b/resources/views/Staff/bon_exchange/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/bon_exchange/index.blade.php
+++ b/resources/views/Staff/bon_exchange/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">
@@ -9,7 +9,7 @@
     <li class="breadcrumb--active">{{ __('bon.bon') }} {{ __('bon.exchange') }}</li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">{{ __('bon.bon') }} {{ __('bon.exchange') }}</h2>

--- a/resources/views/Staff/category/create.blade.php
+++ b/resources/views/Staff/category/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/category/edit.blade.php
+++ b/resources/views/Staff/category/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/category/index.blade.php
+++ b/resources/views/Staff/category/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/chat/bot/edit.blade.php
+++ b/resources/views/Staff/chat/bot/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('bot.edit-bot') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/chat/bot/index.blade.php
+++ b/resources/views/Staff/chat/bot/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/chat/room/create.blade.php
+++ b/resources/views/Staff/chat/room/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/chat/room/edit.blade.php
+++ b/resources/views/Staff/chat/room/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/chat/room/index.blade.php
+++ b/resources/views/Staff/chat/room/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/chat/status/create.blade.php
+++ b/resources/views/Staff/chat/status/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/chat/status/edit.blade.php
+++ b/resources/views/Staff/chat/status/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/chat/status/index.blade.php
+++ b/resources/views/Staff/chat/status/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/cheated_torrent/index.blade.php
+++ b/resources/views/Staff/cheated_torrent/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/cheater/index.blade.php
+++ b/resources/views/Staff/cheater/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/command/index.blade.php
+++ b/resources/views/Staff/command/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Commands - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/dashboard/index.blade.php
+++ b/resources/views/Staff/dashboard/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/distributor/create.blade.php
+++ b/resources/views/Staff/distributor/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/distributor/delete.blade.php
+++ b/resources/views/Staff/distributor/delete.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/distributor/edit.blade.php
+++ b/resources/views/Staff/distributor/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/distributor/index.blade.php
+++ b/resources/views/Staff/distributor/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/donation/index.blade.php
+++ b/resources/views/Staff/donation/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">
@@ -9,7 +9,7 @@
     <li class="breadcrumb--active">Donations</li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">Donation Statistics</h2>

--- a/resources/views/Staff/donation_gateway/create.blade.php
+++ b/resources/views/Staff/donation_gateway/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">
@@ -12,7 +12,7 @@
     <li class="breadcrumb--active">Create Gateway</li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">Add New Gateway</h2>

--- a/resources/views/Staff/donation_gateway/edit.blade.php
+++ b/resources/views/Staff/donation_gateway/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">
@@ -12,7 +12,7 @@
     <li class="breadcrumb--active">Edit Gateway</li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">Edit: {{ $gateway->name }}</h2>

--- a/resources/views/Staff/donation_gateway/index.blade.php
+++ b/resources/views/Staff/donation_gateway/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">
@@ -9,7 +9,7 @@
     <li class="breadcrumb--active">Gateways</li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">Gateways</h2>

--- a/resources/views/Staff/donation_package/create.blade.php
+++ b/resources/views/Staff/donation_package/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">
@@ -12,7 +12,7 @@
     <li class="breadcrumb--active">Create Package</li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">Add New Package</h2>

--- a/resources/views/Staff/donation_package/edit.blade.php
+++ b/resources/views/Staff/donation_package/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">
@@ -12,7 +12,7 @@
     <li class="breadcrumb--active">Edit Package</li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">Edit: {{ $package->name }}</h2>

--- a/resources/views/Staff/donation_package/index.blade.php
+++ b/resources/views/Staff/donation_package/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">
@@ -9,7 +9,7 @@
     <li class="breadcrumb--active">Packages</li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">Packages</h2>

--- a/resources/views/Staff/email-update/index.blade.php
+++ b/resources/views/Staff/email-update/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/event/create.blade.php
+++ b/resources/views/Staff/event/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/event/edit.blade.php
+++ b/resources/views/Staff/event/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/event/index.blade.php
+++ b/resources/views/Staff/event/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/forum-category/create.blade.php
+++ b/resources/views/Staff/forum-category/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Add Forums - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/forum-category/edit.blade.php
+++ b/resources/views/Staff/forum-category/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/forum-category/index.blade.php
+++ b/resources/views/Staff/forum-category/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>Forums - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/forum/create.blade.php
+++ b/resources/views/Staff/forum/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Add Forums - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/forum/edit.blade.php
+++ b/resources/views/Staff/forum/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/gift/index.blade.php
+++ b/resources/views/Staff/gift/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/group/create.blade.php
+++ b/resources/views/Staff/group/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/group/edit.blade.php
+++ b/resources/views/Staff/group/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/group/index.blade.php
+++ b/resources/views/Staff/group/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/history/index.blade.php
+++ b/resources/views/Staff/history/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>History - {{ config('other.title') }}</title>
@@ -15,6 +15,6 @@
 
 @section('page', 'page__history--index')
 
-@section('content')
+@section('main')
     @livewire('history-search')
 @endsection

--- a/resources/views/Staff/internals/create.blade.php
+++ b/resources/views/Staff/internals/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/internals/edit.blade.php
+++ b/resources/views/Staff/internals/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/internals/index.blade.php
+++ b/resources/views/Staff/internals/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/invite/index.blade.php
+++ b/resources/views/Staff/invite/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Invites Log - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/leaker/index.blade.php
+++ b/resources/views/Staff/leaker/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Leakers - {{ config('other.title') }}</title>
@@ -15,6 +15,6 @@
 
 @section('page', 'page__leakers--index')
 
-@section('content')
+@section('main')
     @livewire('leaker-search')
 @endsection

--- a/resources/views/Staff/mass_email/create.blade.php
+++ b/resources/views/Staff/mass_email/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/masspm/index.blade.php
+++ b/resources/views/Staff/masspm/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/media_language/create.blade.php
+++ b/resources/views/Staff/media_language/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/media_language/edit.blade.php
+++ b/resources/views/Staff/media_language/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/media_language/index.blade.php
+++ b/resources/views/Staff/media_language/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/moderation/index.blade.php
+++ b/resources/views/Staff/moderation/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Moderation - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/note/index.blade.php
+++ b/resources/views/Staff/note/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/page/create.blade.php
+++ b/resources/views/Staff/page/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/page/edit.blade.php
+++ b/resources/views/Staff/page/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/page/index.blade.php
+++ b/resources/views/Staff/page/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/passkey/index.blade.php
+++ b/resources/views/Staff/passkey/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/password-reset-history/index.blade.php
+++ b/resources/views/Staff/password-reset-history/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/peer/index.blade.php
+++ b/resources/views/Staff/peer/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Peers - {{ config('other.title') }}</title>
@@ -19,6 +19,6 @@
 
 @section('page', 'page__peers--index')
 
-@section('content')
+@section('main')
     @livewire('peer-search')
 @endsection

--- a/resources/views/Staff/poll/create.blade.php
+++ b/resources/views/Staff/poll/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Polls - {{ config('other.title') }}</title>

--- a/resources/views/Staff/poll/edit.blade.php
+++ b/resources/views/Staff/poll/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Polls - {{ config('other.title') }}</title>

--- a/resources/views/Staff/poll/index.blade.php
+++ b/resources/views/Staff/poll/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Polls - {{ config('other.title') }}</title>

--- a/resources/views/Staff/poll/show.blade.php
+++ b/resources/views/Staff/poll/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Poll Results - {{ config('other.title') }}</title>

--- a/resources/views/Staff/region/create.blade.php
+++ b/resources/views/Staff/region/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/region/edit.blade.php
+++ b/resources/views/Staff/region/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/region/index.blade.php
+++ b/resources/views/Staff/region/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/report/index.blade.php
+++ b/resources/views/Staff/report/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Reports - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/report/show.blade.php
+++ b/resources/views/Staff/report/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>Reports - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/resolution/create.blade.php
+++ b/resources/views/Staff/resolution/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/resolution/edit.blade.php
+++ b/resources/views/Staff/resolution/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/resolution/index.blade.php
+++ b/resources/views/Staff/resolution/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/rss/create.blade.php
+++ b/resources/views/Staff/rss/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('rss.create-public-feed') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/rss/edit.blade.php
+++ b/resources/views/Staff/rss/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('rss.edit-public-feed') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/rss/index.blade.php
+++ b/resources/views/Staff/rss/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/rsskey/index.blade.php
+++ b/resources/views/Staff/rsskey/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/seedbox/index.blade.php
+++ b/resources/views/Staff/seedbox/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/type/create.blade.php
+++ b/resources/views/Staff/type/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/type/edit.blade.php
+++ b/resources/views/Staff/type/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/type/index.blade.php
+++ b/resources/views/Staff/type/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/unregistered-info-hash/index.blade.php
+++ b/resources/views/Staff/unregistered-info-hash/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/uploader/index.blade.php
+++ b/resources/views/Staff/uploader/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/user/edit.blade.php
+++ b/resources/views/Staff/user/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/Staff/user/index.blade.php
+++ b/resources/views/Staff/user/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/warning/index.blade.php
+++ b/resources/views/Staff/warning/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Warnings Log - {{ __('staff.staff-dashboard') }} - {{ config('other.title') }}</title>

--- a/resources/views/Staff/watchlist/index.blade.php
+++ b/resources/views/Staff/watchlist/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/Staff/whitelisted-image-url/index.blade.php
+++ b/resources/views/Staff/whitelisted-image-url/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/wiki/create.blade.php
+++ b/resources/views/Staff/wiki/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/wiki/edit.blade.php
+++ b/resources/views/Staff/wiki/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/wiki_category/create.blade.php
+++ b/resources/views/Staff/wiki_category/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/wiki_category/edit.blade.php
+++ b/resources/views/Staff/wiki_category/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/Staff/wiki_category/index.blade.php
+++ b/resources/views/Staff/wiki_category/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/article/index.blade.php
+++ b/resources/views/article/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('articles.articles') }} - {{ config('other.title') }}</title>

--- a/resources/views/article/show.blade.php
+++ b/resources/views/article/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('auth.password-confirm.title') }} - {{ config('other.title') }}</title>
@@ -17,7 +17,7 @@
     </li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <h2 class="panel__heading">{{ __('auth.password-confirmation') }}</h2>
         <div class="panel__body">

--- a/resources/views/contact/index.blade.php
+++ b/resources/views/contact/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ __('common.contact') }} - {{ config('other.title') }}</title>

--- a/resources/views/donation/index.blade.php
+++ b/resources/views/donation/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Donate - {{ config('other.title') }}</title>
@@ -12,7 +12,7 @@
     <li class="breadcrumb--active">Donate</li>
 @endsection
 
-@section('content')
+@section('main')
     <section x-data class="panelV2">
         <h2 class="panel__heading">Support {{ config('other.title') }}</h2>
         <div class="panel__body">

--- a/resources/views/event/index.blade.php
+++ b/resources/views/event/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumb--active">

--- a/resources/views/event/show.blade.php
+++ b/resources/views/event/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/forum/category_topic/index.blade.php
+++ b/resources/views/forum/category_topic/index.blade.php
@@ -25,6 +25,6 @@
 
 @section('page', 'page__forum--category')
 
-@section('main')
+@section('content')
     @livewire('forum-category-topic-search', ['category' => $category])
 @endsection

--- a/resources/views/forum/forum_topic/create.blade.php
+++ b/resources/views/forum/forum_topic/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('forum.create-new-topic') }} - {{ config('other.title') }}</title>
@@ -36,7 +36,7 @@
     @include('forum.partials.buttons')
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <h2 class="panel__heading">{{ __('forum.create-new-topic') }}</h2>
         <div class="panel__body">

--- a/resources/views/forum/forum_topic/index.blade.php
+++ b/resources/views/forum/forum_topic/index.blade.php
@@ -33,6 +33,6 @@
 
 @section('page', 'page__forum--display')
 
-@section('main')
+@section('content')
     @livewire('forum-topic-search', ['forum' => $forum])
 @endsection

--- a/resources/views/forum/index.blade.php
+++ b/resources/views/forum/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ __('forum.forums') }} - {{ config('other.title') }}</title>

--- a/resources/views/forum/post/edit.blade.php
+++ b/resources/views/forum/post/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>
@@ -44,7 +44,7 @@
     @include('forum.partials.buttons')
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <h2 class="panel__heading">
             {{ __('common.edit') }} {{ __('forum.post') }} {{ strtolower(__('forum.in')) }}:

--- a/resources/views/forum/post/index.blade.php
+++ b/resources/views/forum/post/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/forum/subscriptions.blade.php
+++ b/resources/views/forum/subscriptions.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/forum/topic/edit.blade.php
+++ b/resources/views/forum/topic/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('forum.create-new-topic') }} - {{ config('other.title') }}</title>

--- a/resources/views/forum/topic/index.blade.php
+++ b/resources/views/forum/topic/index.blade.php
@@ -25,6 +25,6 @@
     @include('forum.partials.buttons')
 @endsection
 
-@section('main')
+@section('content')
     @livewire('topic-search')
 @endsection

--- a/resources/views/forum/topic/show.blade.php
+++ b/resources/views/forum/topic/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ $topic->name }} - Forums - {{ config('other.title') }}</title>

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('page', 'page__home')
 

--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -44,26 +44,7 @@
             @endif
         </header>
         <main class="@yield('page')">
-            @hasSection('main')
-                @hasSection('sidebar')
-                <article class="sidebar2">
-                    <div>
-                        @yield('main')
-                    </div>
-                    <aside>
-                        @yield('sidebar')
-                    </aside>
-                </article>
-                @else
-                <article>
-                    @yield('main')
-                </article>
-                @endif
-            @else
-                <article>
-                    @yield('content')
-                </article>
-            @endif
+            @yield('content')
         </main>
         @include('partials.footer')
 

--- a/resources/views/layout/with-main-and-sidebar.blade.php
+++ b/resources/views/layout/with-main-and-sidebar.blade.php
@@ -1,0 +1,12 @@
+@extends('layout.default')
+
+@section('content')
+    <article class="sidebar2">
+        <div>
+            @yield('main')
+        </div>
+        <aside>
+            @yield('sidebar')
+        </aside>
+    </article>
+@endsection

--- a/resources/views/layout/with-main.blade.php
+++ b/resources/views/layout/with-main.blade.php
@@ -1,0 +1,7 @@
+@extends('layout.default')
+
+@section('content')
+    <article>
+        @yield('main')
+    </article>
+@endsection

--- a/resources/views/livewire/forum-category-topic-search.blade.php
+++ b/resources/views/livewire/forum-category-topic-search.blade.php
@@ -1,4 +1,4 @@
-<div class="sidebar2">
+<article class="sidebar2">
     <div>
         <section class="panelV2">
             <h2 class="panel__heading">{{ $category->description }}</h2>
@@ -178,4 +178,4 @@
             </div>
         </section>
     </aside>
-</div>
+</article>

--- a/resources/views/livewire/forum-topic-search.blade.php
+++ b/resources/views/livewire/forum-topic-search.blade.php
@@ -1,4 +1,4 @@
-<div class="sidebar2">
+<article class="sidebar2">
     <div>
         <section class="panelV2">
             <h2 class="panel__heading">{{ $forum->description }}</h2>
@@ -220,4 +220,4 @@
             </div>
         </section>
     </aside>
-</div>
+</article>

--- a/resources/views/livewire/notification-search.blade.php
+++ b/resources/views/livewire/notification-search.blade.php
@@ -1,4 +1,4 @@
-<div class="sidebar2">
+<article class="sidebar2">
     <div>
         <section class="panelV2">
             <h2 class="panel__heading">{{ __('notification.notifications') }}</h2>
@@ -398,4 +398,4 @@
             </div>
         </section>
     </aside>
-</div>
+</article>

--- a/resources/views/livewire/person-search.blade.php
+++ b/resources/views/livewire/person-search.blade.php
@@ -1,4 +1,4 @@
-<div class="sidebar2">
+<article class="sidebar2">
     <div>
         <section class="panelV2">
             <h2 class="panel__heading">{{ __('mediahub.persons') }}</h2>
@@ -98,4 +98,4 @@
             </div>
         </section>
     </aside>
-</div>
+</article>

--- a/resources/views/livewire/subtitle-search.blade.php
+++ b/resources/views/livewire/subtitle-search.blade.php
@@ -1,4 +1,4 @@
-<div class="sidebar2 sidebar--inverse">
+<article class="sidebar2 sidebar--inverse">
     <div>
         <section class="panelV2">
             <h2 class="panel__heading">{{ __('common.subtitles') }}</h2>
@@ -193,4 +193,4 @@
             </div>
         </section>
     </aside>
-</div>
+</article>

--- a/resources/views/livewire/topic-search.blade.php
+++ b/resources/views/livewire/topic-search.blade.php
@@ -1,4 +1,4 @@
-<div class="sidebar2">
+<article class="sidebar2">
     <div>
         <section class="panelV2">
             <h2 class="panel__heading">{{ __('common.latest-topics') }}</h2>
@@ -201,4 +201,4 @@
             </div>
         </section>
     </aside>
-</div>
+</article>

--- a/resources/views/livewire/torrent-request-search.blade.php
+++ b/resources/views/livewire/torrent-request-search.blade.php
@@ -1,4 +1,4 @@
-<div class="sidebar2 sidebar--inverse">
+<article class="sidebar2 sidebar--inverse">
     <div>
         <section class="panelV2">
             <header class="panel__header">
@@ -456,4 +456,4 @@
             </dl>
         </section>
     </aside>
-</div>
+</article>

--- a/resources/views/livewire/user-earnings.blade.php
+++ b/resources/views/livewire/user-earnings.blade.php
@@ -1,4 +1,4 @@
-<div class="sidebar2">
+<article class="sidebar2">
     <div>
         <section class="panelV2" x-data="toggle">
             <h2 class="panel__heading">{{ __('bon.earnings') }}</h2>
@@ -322,4 +322,4 @@
             </dl>
         </section>
     </aside>
-</div>
+</article>

--- a/resources/views/mediahub/collection/index.blade.php
+++ b/resources/views/mediahub/collection/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('mediahub.collections') }} - {{ config('other.title') }}</title>
@@ -19,6 +19,6 @@
     </li>
 @endsection
 
-@section('content')
+@section('main')
     @livewire('collection-search')
 @endsection

--- a/resources/views/mediahub/collection/show.blade.php
+++ b/resources/views/mediahub/collection/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $collection->name }} - {{ config('other.title') }}</title>

--- a/resources/views/mediahub/company/index.blade.php
+++ b/resources/views/mediahub/company/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('mediahub.companies') }} - {{ config('other.title') }}</title>
@@ -19,6 +19,6 @@
     </li>
 @endsection
 
-@section('content')
+@section('main')
     @livewire('company-search')
 @endsection

--- a/resources/views/mediahub/genre/index.blade.php
+++ b/resources/views/mediahub/genre/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('common.genres') }} - {{ config('other.title') }}</title>
@@ -19,7 +19,7 @@
     </li>
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <h2 class="panel__heading">{{ __('common.genres') }}</h2>
         <div class="panel__body">

--- a/resources/views/mediahub/index.blade.php
+++ b/resources/views/mediahub/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ __('mediahub.title') }} - {{ config('other.title') }}</title>

--- a/resources/views/mediahub/network/index.blade.php
+++ b/resources/views/mediahub/network/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('mediahub.networks') }} - {{ config('other.title') }}</title>
@@ -19,6 +19,6 @@
     </li>
 @endsection
 
-@section('content')
+@section('main')
     @livewire('network-search')
 @endsection

--- a/resources/views/mediahub/person/show.blade.php
+++ b/resources/views/mediahub/person/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/missing/index.blade.php
+++ b/resources/views/missing/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Missing Media</title>

--- a/resources/views/page/aboutus.blade.php
+++ b/resources/views/page/aboutus.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ __('common.about') }} - {{ config('other.title') }}</title>

--- a/resources/views/page/blacklist/client.blade.php
+++ b/resources/views/page/blacklist/client.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumb--active">

--- a/resources/views/page/index.blade.php
+++ b/resources/views/page/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumb--active">Pages</li>
@@ -6,7 +6,7 @@
 
 @section('page', 'page__page--index')
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <h2 class="panel__heading">Pages</h2>
         <div class="data-table-wrapper">

--- a/resources/views/page/internal.blade.php
+++ b/resources/views/page/internal.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumb--active">

--- a/resources/views/page/page.blade.php
+++ b/resources/views/page/page.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/page/staff.blade.php
+++ b/resources/views/page/staff.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumb--active">{{ config('other.title') }} {{ __('common.staff') }}</li>

--- a/resources/views/playlist/create.blade.php
+++ b/resources/views/playlist/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('playlist.title') }} - {{ config('other.title') }}</title>

--- a/resources/views/playlist/edit.blade.php
+++ b/resources/views/playlist/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('playlist.edit-playlist') }} - {{ config('other.title') }}</title>

--- a/resources/views/playlist/index.blade.php
+++ b/resources/views/playlist/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumb--active">
@@ -6,6 +6,6 @@
     </li>
 @endsection
 
-@section('content')
+@section('main')
     @livewire('playlist-search')
 @endsection

--- a/resources/views/playlist/show.blade.php
+++ b/resources/views/playlist/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/poll/latest.blade.php
+++ b/resources/views/poll/latest.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('poll.polls') }} - {{ config('other.title') }}</title>

--- a/resources/views/poll/result.blade.php
+++ b/resources/views/poll/result.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('poll.results') }} - {{ config('other.title') }}</title>

--- a/resources/views/poll/show.blade.php
+++ b/resources/views/poll/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ __('poll.poll') }} - {{ config('other.title') }}</title>

--- a/resources/views/requests/create.blade.php
+++ b/resources/views/requests/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ __('request.add-request') }} - {{ config('other.title') }}</title>

--- a/resources/views/requests/edit.blade.php
+++ b/resources/views/requests/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('request.edit-request') }} - {{ config('other.title') }}</title>

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Request - {{ config('other.title') }} - {{ $torrentRequest->name }}</title>

--- a/resources/views/rss/create.blade.php
+++ b/resources/views/rss/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('rss.create-private-feed') }} - {{ config('other.title') }}</title>

--- a/resources/views/rss/edit.blade.php
+++ b/resources/views/rss/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('rss.edit-private-feed') }} - {{ config('other.title') }}</title>

--- a/resources/views/rss/index.blade.php
+++ b/resources/views/rss/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/stats/clients/clients.blade.php
+++ b/resources/views/stats/clients/clients.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/groups/group.blade.php
+++ b/resources/views/stats/groups/group.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/groups/groups-requirements.blade.php
+++ b/resources/views/stats/groups/groups-requirements.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/groups/groups.blade.php
+++ b/resources/views/stats/groups/groups.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/index.blade.php
+++ b/resources/views/stats/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/languages/languages.blade.php
+++ b/resources/views/stats/languages/languages.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/requests/bountied.blade.php
+++ b/resources/views/stats/requests/bountied.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/themes/index.blade.php
+++ b/resources/views/stats/themes/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/torrents/completed.blade.php
+++ b/resources/views/stats/torrents/completed.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/torrents/dead.blade.php
+++ b/resources/views/stats/torrents/dead.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/torrents/dying.blade.php
+++ b/resources/views/stats/torrents/dying.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/torrents/leeched.blade.php
+++ b/resources/views/stats/torrents/leeched.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/torrents/seeded.blade.php
+++ b/resources/views/stats/torrents/seeded.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/users/bankers.blade.php
+++ b/resources/views/stats/users/bankers.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/users/downloaded.blade.php
+++ b/resources/views/stats/users/downloaded.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/users/leechers.blade.php
+++ b/resources/views/stats/users/leechers.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/users/seeders.blade.php
+++ b/resources/views/stats/users/seeders.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/users/seedsize.blade.php
+++ b/resources/views/stats/users/seedsize.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/users/seedtime.blade.php
+++ b/resources/views/stats/users/seedtime.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/users/upload-snatches.blade.php
+++ b/resources/views/stats/users/upload-snatches.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/users/uploaded.blade.php
+++ b/resources/views/stats/users/uploaded.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/users/uploaders.blade.php
+++ b/resources/views/stats/users/uploaders.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/yearly_overviews/index.blade.php
+++ b/resources/views/stats/yearly_overviews/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/stats/yearly_overviews/show.blade.php
+++ b/resources/views/stats/yearly_overviews/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('stat.stats') }} - {{ config('other.title') }}</title>

--- a/resources/views/subtitle/create.blade.php
+++ b/resources/views/subtitle/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/ticket/create.blade.php
+++ b/resources/views/ticket/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('ticket.helpdesk') }} - {{ config('other.title') }}</title>
@@ -17,7 +17,7 @@
 
 @section('page', 'page__ticket--create')
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <h2 class="panel__heading">
             <i class="fas fa-plus"></i>

--- a/resources/views/ticket/index.blade.php
+++ b/resources/views/ticket/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('ticket.helpdesk') }} - {{ config('other.title') }}</title>

--- a/resources/views/ticket/show.blade.php
+++ b/resources/views/ticket/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ __('ticket.helpdesk') }} - {{ config('other.title') }}</title>

--- a/resources/views/top10/index.blade.php
+++ b/resources/views/top10/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Top 10</title>

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>Upload - {{ config('other.title') }}</title>

--- a/resources/views/torrent/download_check.blade.php
+++ b/resources/views/torrent/download_check.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ __('torrent.download-check') }} - {{ config('other.title') }}</title>

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/torrent/external-tracker.blade.php
+++ b/resources/views/torrent/external-tracker.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/torrent/history.blade.php
+++ b/resources/views/torrent/history.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>
@@ -49,7 +49,7 @@
     @endif
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <header class="panel__header">
             <h2 class="panel__heading">

--- a/resources/views/torrent/index.blade.php
+++ b/resources/views/torrent/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('torrent.torrents') }} - {{ config('other.title') }}</title>
@@ -37,6 +37,6 @@
     </li>
 @endsection
 
-@section('content')
+@section('main')
     @livewire('torrent-search')
 @endsection

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('torrent.peers') }} - {{ $torrent->name }} - {{ config('other.title') }}</title>

--- a/resources/views/torrent/pending.blade.php
+++ b/resources/views/torrent/pending.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ __('common.pending-torrents') }} - {{ config('other.title') }}</title>

--- a/resources/views/torrent/show.blade.php
+++ b/resources/views/torrent/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/torrent/similar.blade.php
+++ b/resources/views/torrent/similar.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/user/achievement/index.blade.php
+++ b/resources/views/user/achievement/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/apikey/index.blade.php
+++ b/resources/views/user/apikey/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/conversations/create.blade.php
+++ b/resources/views/user/conversations/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/user/conversations/index.blade.php
+++ b/resources/views/user/conversations/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/user/conversations/show.blade.php
+++ b/resources/views/user/conversations/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/user/earning/index.blade.php
+++ b/resources/views/user/earning/index.blade.php
@@ -22,6 +22,6 @@
 
 @section('page', 'page__bonus--index')
 
-@section('main')
+@section('content')
     @livewire('user-earnings', ['userId' => $user->id])
 @endsection

--- a/resources/views/user/email/edit.blade.php
+++ b/resources/views/user/email/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/follower/index.blade.php
+++ b/resources/views/user/follower/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.followers') }} - {{ config('other.title') }}</title>
@@ -19,7 +19,7 @@
     @include('user.buttons.user')
 @endsection
 
-@section('content')
+@section('main')
     @if (auth()->user()->isAllowed($user, 'follower', 'show_follower'))
         <section class="panelV2">
             <h2 class="panel__heading">{{ __('user.followers') }}</h2>

--- a/resources/views/user/following/index.blade.php
+++ b/resources/views/user/following/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.following') }} - {{ config('other.title') }}</title>
@@ -19,7 +19,7 @@
     @include('user.buttons.user')
 @endsection
 
-@section('content')
+@section('main')
     @if (auth()->id() === $user->id || auth()->user()->group->is_modo)
         <section class="panelV2">
             <h2 class="panel__heading">{{ __('user.following') }}</h2>

--- a/resources/views/user/general_setting/edit.blade.php
+++ b/resources/views/user/general_setting/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>
@@ -22,7 +22,7 @@
     @include('user.buttons.user')
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <h2 class="panel__heading">General {{ __('user.settings') }}</h2>
         <div class="panel__body">

--- a/resources/views/user/gift/create.blade.php
+++ b/resources/views/user/gift/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/user/gift/index.blade.php
+++ b/resources/views/user/gift/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.gifts') }} - {{ config('other.title') }}</title>

--- a/resources/views/user/history/index.blade.php
+++ b/resources/views/user/history/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.torrents') }} - {{ config('other.title') }}</title>

--- a/resources/views/user/invite-tree/index.blade.php
+++ b/resources/views/user/invite-tree/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/invite/create.blade.php
+++ b/resources/views/user/invite/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/invite/index.blade.php
+++ b/resources/views/user/invite/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} - {{ __('user.invites') }} - {{ config('other.title') }}</title>

--- a/resources/views/user/notification/index.blade.php
+++ b/resources/views/user/notification/index.blade.php
@@ -10,6 +10,6 @@
     </li>
 @endsection
 
-@section('main')
+@section('content')
     @livewire('notification-search')
 @endsection

--- a/resources/views/user/notification_setting/edit.blade.php
+++ b/resources/views/user/notification_setting/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/user/passkey/index.blade.php
+++ b/resources/views/user/passkey/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/password/edit.blade.php
+++ b/resources/views/user/password/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/peer/index.blade.php
+++ b/resources/views/user/peer/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.active') }} - {{ config('other.title') }}</title>

--- a/resources/views/user/post-tip/index.blade.php
+++ b/resources/views/user/post-tip/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.tips') }} - {{ config('other.title') }}</title>

--- a/resources/views/user/post/index.blade.php
+++ b/resources/views/user/post/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.posts') }} - {{ config('other.title') }}</title>

--- a/resources/views/user/privacy_setting/edit.blade.php
+++ b/resources/views/user/privacy_setting/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>
@@ -30,7 +30,7 @@
     @include('user.buttons.user')
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <h2 class="panel__heading">{{ __('user.privacy') }}</h2>
         <div class="panel__body">

--- a/resources/views/user/profile/edit.blade.php
+++ b/resources/views/user/profile/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.profile') }} - {{ config('other.title') }}</title>
@@ -19,7 +19,7 @@
     @include('user.buttons.user')
 @endsection
 
-@section('content')
+@section('main')
     <section class="panelV2">
         <h2 class="panel__heading">{{ __('user.edit-profile') }}</h2>
         <div class="panel__body">

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/resurrection/index.blade.php
+++ b/resources/views/user/resurrection/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>
@@ -23,6 +23,6 @@
 
 @section('page', 'page__user-resurrections--index')
 
-@section('content')
+@section('main')
     @livewire('user-resurrections', ['userId' => $user->id])
 @endsection

--- a/resources/views/user/rsskey/index.blade.php
+++ b/resources/views/user/rsskey/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/seedbox/index.blade.php
+++ b/resources/views/user/seedbox/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>

--- a/resources/views/user/topic/index.blade.php
+++ b/resources/views/user/topic/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.topics') }} - {{ config('other.title') }}</title>

--- a/resources/views/user/torrent-tip/index.blade.php
+++ b/resources/views/user/torrent-tip/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.tips') }} - {{ config('other.title') }}</title>

--- a/resources/views/user/torrent/index.blade.php
+++ b/resources/views/user/torrent/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.uploads') }} - {{ config('other.title') }}</title>

--- a/resources/views/user/transaction/create.blade.php
+++ b/resources/views/user/transaction/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">

--- a/resources/views/user/two_factor_auth/edit.blade.php
+++ b/resources/views/user/two_factor_auth/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>

--- a/resources/views/user/wish/index.blade.php
+++ b/resources/views/user/wish/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>{{ $user->username }} {{ __('user.wishlist') }} - {{ config('other.title') }}</title>

--- a/resources/views/wiki/index.blade.php
+++ b/resources/views/wiki/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main')
 
 @section('title')
     <title>Wikis - {{ config('other.title') }}</title>

--- a/resources/views/wiki/show.blade.php
+++ b/resources/views/wiki/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+@extends('layout.with-main-and-sidebar')
 
 @section('breadcrumbs')
     <li class="breadcrumbV2">


### PR DESCRIPTION
A nice cleanup overall.

- `@section('content')` -> `@section('main')`
- `@extends('layout.default')` -> `@extends('layout.with-main')`
- `@extends\('layout.with-main'\)((.|[\n])*)@section\('sidebar'\)` -> `@extends('layout.with-main-and-sidebar')$1@section('sidebar')`

Plus, removed the unintentional double div nesting in livewire components that include a sidebar.

Fixes #3987 