### PR TITLE
(Refactor) Don't use unnecessary orderByRaw

### DIFF
--- a/app/Http/Livewire/TopUsers.php
+++ b/app/Http/Livewire/TopUsers.php
@@ -139,7 +139,7 @@ class TopUsers extends Component
             ->where('user_id', '!=', User::SYSTEM_USER_ID)
             ->where('anon', '=', false)
             ->groupBy('user_id')
-            ->orderByRaw('COALESCE(value, 0) DESC')
+            ->orderByDesc('value')
             ->take(8)
             ->get();
     }
@@ -154,7 +154,7 @@ class TopUsers extends Component
             ->select(DB::raw('user_id, COUNT(user_id) as value'))
             ->where('user_id', '!=', User::SYSTEM_USER_ID)
             ->groupBy('user_id')
-            ->orderByRaw('COALESCE(value, 0) DESC')
+            ->orderByDesc('value')
             ->take(8)
             ->get();
     }
@@ -169,7 +169,7 @@ class TopUsers extends Component
             ->select(DB::raw('user_id, COUNT(user_id) as value'))
             ->where('user_id', '!=', User::SYSTEM_USER_ID)
             ->groupBy('user_id')
-            ->orderByRaw('COALESCE(value, 0) DESC')
+            ->orderByDesc('value')
             ->take(8)
             ->get();
     }


### PR DESCRIPTION
Null values are always ordered last anyways. Additionally, count(*) returns 0, not null. Also fixes issue on mariadb with value being a reserved keyword.