### PR TITLE
(Update) Hide 'flush ghost peers' button when external tracker is enabled

### DIFF
--- a/app/Http/Controllers/Staff/FlushController.php
+++ b/app/Http/Controllers/Staff/FlushController.php
@@ -45,6 +45,10 @@ class FlushController extends Controller
      */
     public function peers(): \Illuminate\Http\RedirectResponse
     {
+        if (config('announce.external_tracker.is_enabled')) {
+            return redirect()->back()->withErrors("The external tracker doesn't support flushing peers.");
+        }
+
         $carbon = new Carbon();
         $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2))->get();
 

--- a/app/Http/Controllers/User/PeerController.php
+++ b/app/Http/Controllers/User/PeerController.php
@@ -51,6 +51,10 @@ class PeerController extends Controller
     {
         abort_unless($request->user()->is($user), 403);
 
+        if (config('announce.external_tracker.is_enabled')) {
+            return redirect()->back()->withErrors("The external tracker doesn't support flushing peers.");
+        }
+
         // Check if User can flush
         if ($request->user()->own_flushes <= 0) {
             return redirect()->back()->withErrors('You can only flush twice a day!');

--- a/resources/views/Staff/dashboard/index.blade.php
+++ b/resources/views/Staff/dashboard/index.blade.php
@@ -407,23 +407,25 @@
                     </p>
                 @endif
 
-                <div class="form__group form__group--horizontal">
-                    <form
-                        method="POST"
-                        action="{{ route('staff.flush.peers') }}"
-                        x-data="confirmation"
-                    >
-                        @csrf
-                        <button
-                            x-on:click.prevent="confirmAction"
-                            data-b64-deletion-message="{{ base64_encode('Are you sure you want to delete all ghost peers?') }}"
-                            class="form__button form__button--text"
+                @if (! config('announce.external_tracker.is_enabled'))
+                    <div class="form__group form__group--horizontal">
+                        <form
+                            method="POST"
+                            action="{{ route('staff.flush.peers') }}"
+                            x-data="confirmation"
                         >
-                            <i class="{{ config('other.font-awesome') }} fa-ghost"></i>
-                            {{ __('staff.flush-ghost-peers') }}
-                        </button>
-                    </form>
-                </div>
+                            @csrf
+                            <button
+                                x-on:click.prevent="confirmAction"
+                                data-b64-deletion-message="{{ base64_encode('Are you sure you want to delete all ghost peers?') }}"
+                                class="form__button form__button--text"
+                            >
+                                <i class="{{ config('other.font-awesome') }} fa-ghost"></i>
+                                {{ __('staff.flush-ghost-peers') }}
+                            </button>
+                        </form>
+                    </div>
+                @endif
             </div>
         </section>
         <section class="panelV2 panel--grid-item">

--- a/resources/views/user/buttons/user.blade.php
+++ b/resources/views/user/buttons/user.blade.php
@@ -279,17 +279,20 @@
                         {{ __('user.bookmarks') }}
                     </a>
                 </li>
-                <form
-                    action="{{ route('users.peers.mass_destroy', ['user' => $user]) }}"
-                    method="POST"
-                    style="display: contents"
-                >
-                    @csrf()
-                    @method('DELETE')
-                    <button class="nav-tab__link" type="submit">
-                        {{ __('staff.flush-ghost-peers') }}
-                    </button>
-                </form>
+                @if (! config('announce.external_tracker.is_enabled'))
+                    <form
+                        action="{{ route('users.peers.mass_destroy', ['user' => $user]) }}"
+                        method="POST"
+                        style="display: contents"
+                    >
+                        @csrf()
+                        @method('DELETE')
+                        <button class="nav-tab__link" type="submit">
+                            {{ __('staff.flush-ghost-peers') }}
+                        </button>
+                    </form>
+                @endif
+
                 <li class="nav-tabV2" x-data="dialog">
                     <a class="nav-tab__link" x-bind="showDialog">Download Torrent Files</a>
 


### PR DESCRIPTION
The button doesn't do anything anyways for the external trackers. Users have to just wait it out.