### PR TITLE
(Update) Add index to reports table for mod navbar query

### DIFF
--- a/database/migrations/2025_02_19_063416_create_index_on_reports_solved_snoozed_until.php
+++ b/database/migrations/2025_02_19_063416_create_index_on_reports_solved_snoozed_until.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('reports', function (Blueprint $table): void {
+            $table->index(['solved', 'snoozed_until']);
+        });
+    }
+};


### PR DESCRIPTION
A query quering by these columns is executed every http request for moderator navbars, so speeding it up is useful.