### PR TITLE
(Refactor) Move base view layout database queries inside view composers

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,7 +21,10 @@ use App\Helpers\HiddenCaptcha;
 use App\Interfaces\ByteUnitsInterface;
 use App\Models\User;
 use App\Observers\UserObserver;
+use App\View\Composers\FooterComposer;
+use App\View\Composers\TopNavComposer;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
@@ -84,5 +87,8 @@ class AppServiceProvider extends ServiceProvider
         Vite::useStyleTagAttributes([
             'crossorigin' => 'anonymous',
         ]);
+
+        View::composer('partials.footer', FooterComposer::class);
+        View::composer('partials.top_nav', TopNavComposer::class);
     }
 }

--- a/app/View/Composers/FooterComposer.php
+++ b/app/View/Composers/FooterComposer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Composers;
+
+use App\Models\Page;
+use Illuminate\View\View;
+
+class FooterComposer
+{
+    /**
+     * Bind data to the view.
+     */
+    public function compose(View $view): void
+    {
+        $view->with([
+            'pages' => cache()->remember('cached-pages', 3600, fn () => Page::select(['id', 'name', 'created_at'])->take(6)->get())
+        ]);
+    }
+}

--- a/app/View/Composers/TopNavComposer.php
+++ b/app/View/Composers/TopNavComposer.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Composers;
+
+use App\Models\Donation;
+use App\Models\Event;
+use App\Models\Page;
+use App\Models\Report;
+use App\Models\Scopes\ApprovedScope;
+use App\Models\Ticket;
+use App\Models\Torrent;
+use Illuminate\View\View;
+
+class TopNavComposer
+{
+    /**
+     * Bind data to the view.
+     */
+    public function compose(View $view): void
+    {
+        $user = auth()->user()->load('group');
+
+        $view->with([
+            'pages' => cache()->remember(
+                'cached-pages',
+                3600,
+                fn () => Page::select(['id', 'name', 'created_at'])->take(6)->get()
+            ),
+            'hasUnreadTicket' => Ticket::query()
+                ->when(
+                    $user->group->is_modo,
+                    fn ($query) => $query
+                        ->whereNull('closed_at')
+                        ->whereNull('staff_id')
+                        ->orWhere(
+                            fn ($query) => $query
+                                ->where('staff_id', '=', $user->id)
+                                ->where('staff_read', '=', false)
+                        ),
+                    fn ($query) => $query
+                        ->where('user_id', '=', $user->id)
+                        ->where('user_read', '=', false),
+                )
+                ->exists(),
+            'events' => Event::query()
+                ->where('active', '=', true)
+                ->withExists([
+                    'claimedPrizes' => fn ($query) => $query
+                        ->where('created_at', '>', now()->startOfDay())
+                        ->where('user_id', '=', $user->id),
+                ])
+                ->get(),
+            'donationPercentage' => value(function (): int|string {
+                $sum = Donation::query()
+                    ->join('donation_packages', 'donations.package_id', '=', 'donation_packages.id')
+                    ->where('donations.created_at', '>=', now()->startOfMonth())
+                    ->where('donations.status', Donation::APPROVED)
+                    ->sum('donation_packages.cost');
+
+                return $sum ? min(100, number_format(($sum / config('donation.monthly_goal')) * 100)) : 0;
+            }),
+            // Generally sites have more seeders than leechers, so it ends up being faster (by approximately 50%) to compute these stats instead of computing them individually
+            'peerCount' => cache()->remember(
+                "users:{$user->id}:peer-count",
+                60,
+                fn () => $user->peers()->where('active', '=', 1)->count(),
+            ),
+            'leechCount' => cache()->remember(
+                "users:{$user->id}:leech-count",
+                60,
+                fn () => $user->peers()->where('active', '=', 1)->where('seeder', '=', false)->count(),
+            ),
+            'hasActiveWarning'    => $user->warnings()->exists(),
+            'hasUnresolvedReport' => $user->group->is_modo
+                ? Report::query()->whereNull('snoozed_until')->where('solved', '=', false)
+                : false,
+            'hasUnmoderatedTorrent' => $user->group->is_torrent_modo
+                ? Torrent::query()
+                    ->withoutGlobalScope(ApprovedScope::class)
+                    ->where('status', '=', Torrent::PENDING)
+                    ->exists()
+                : false,
+            'hasUnreadPm'           => $user->participations()->where('read', '=', false)->exists(),
+            'hasUnreadNotification' => $user->unreadNotifications()->exists(),
+            'avatarUrl'             => url($user->image ? 'files/img/'.$user->image : 'img/profile.png'),
+            'uploadCount'           => cache()->remember(
+                "users:{$user->id}:upload-count",
+                60,
+                fn () => $user->torrents()->count(),
+            ),
+            'downloadCount' => cache()->remember(
+                "users:{$user->id}:download-count",
+                60,
+                fn () => $user->history()->where('actual_downloaded', '>', 0)->count(),
+            ),
+            'user' => $user,
+        ]);
+    }
+}

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -45,11 +45,11 @@
                 <li><a href="{{ route('wikis.index') }}">Wikis</a></li>
             </ul>
         </section>
-        @if ($footer_pages = cache()->remember('cached-pages',3600,fn () => \App\Models\Page::select(['id', 'name', 'created_at'])->take(6)->get()))
+        @if ($pages->isNotEmpty())
             <section class="footer__section">
                 <h2 class="footer__section-title">{{ __('common.pages') }}</h2>
                 <ul class="footer__section-list">
-                    @foreach ($footer_pages as $page)
+                    @foreach ($pages as $page)
                         <li>
                             <a href="{{ route('pages.show', ['page' => $page]) }}">
                                 {{ $page->name }}


### PR DESCRIPTION
Keeps code more organized by not having database queries inside the view. Just learned that these were a thing, and realized in the process why there was the issue with #4198 - it was because it was matching on `*`, i.e. all views, so it would render once for every single view, including each include.