### PR TITLE
(Fix) Send staff forum notificaton to all permitted to the forum

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -105,7 +105,10 @@ class PostController extends Controller
         if (config('other.staff-forum-notify') && ($forum->id == config('other.staff-forum-id') || $forum->forum_category_id == config('other.staff-forum-id'))) {
             $staffers = User::query()
                 ->where('id', '!=', $user->id)
-                ->whereRelation('group', 'is_modo', '=', true)
+                ->whereRelation('forumPermissions', [
+                    ['read_topic', '=', 1],
+                    ['forum_id', '=', $forum->id],
+                ])
                 ->get();
 
             foreach ($staffers as $staffer) {


### PR DESCRIPTION
Instead of hard coding it to the is_modo perm. This became an issue when the is_torrent_modo flag was added.