### PR TITLE
(Update) Speed up torrent grouping

### DIFF
--- a/.cspell/php_functions.txt
+++ b/.cspell/php_functions.txt
@@ -17,6 +17,7 @@ inet_pton
 intdiv
 intval
 isset
+krsort
 ksort
 ltrim
 microtime
@@ -39,6 +40,8 @@ strtolower
 strtotime
 strtoupper
 sys_getloadavg
+uasort
+usort
 uniqid
 unserialize
 urldecode

--- a/resources/views/components/movie/card.blade.php
+++ b/resources/views/components/movie/card.blade.php
@@ -59,7 +59,7 @@
     </header>
     <section>
         <table class="torrent-search--grouped__torrents">
-            @foreach ($media->torrents as $type => $torrents)
+            @foreach ($media->torrents['Movie'] as $type => $torrents)
                 <tbody>
                     @foreach ($torrents as $torrent)
                         <tr>

--- a/resources/views/components/tv/card.blade.php
+++ b/resources/views/components/tv/card.blade.php
@@ -58,7 +58,7 @@
         <p class="torrent-search--grouped__plot">{{ $media->overview ?? '' }}</p>
     </header>
     <section>
-        @if ($media->torrents->has('Complete Pack'))
+        @if (array_key_exists('Complete Pack', $media->torrents))
             <details class="torrent-search--grouped__dropdown" open>
                 <summary x-bind="complete">Complete Pack</summary>
                 <table class="torrent-search--grouped__torrents">
@@ -85,10 +85,10 @@
             </details>
         @endif
 
-        @if ($media->torrents->has('Specials'))
+        @if (array_key_exists('Specials', $media->torrents))
             <details
                 class="torrent-search--grouped__dropdown"
-                @if (! $media->torrents->has('Complete Pack') && ! $media->torrents->has('Seasons'))
+                @if (! array_key_exists('Complete Pack', $media->torrents) && ! array_key_exists('Seasons', $media->torrents))
                     open
                 @endif
             >
@@ -135,7 +135,7 @@
                 @endif
             >
                 <summary x-bind="season">{{ $seasonName }}</summary>
-                @if ($season->has('Season Pack') && ! $season->has('Episodes'))
+                @if (array_key_exists('Season Pack', $season) && ! array_key_exists('Episodes', $season))
                     <table class="torrent-search--grouped__torrents">
                         @foreach ($season['Season Pack'] as $type => $torrents)
                             <tbody>
@@ -157,7 +157,7 @@
                             </tbody>
                         @endforeach
                     </table>
-                @elseif ($season->has('Season Pack'))
+                @elseif (array_key_exists('Season Pack', $season))
                     <details open class="torrent-search--grouped__dropdown">
                         <summary x-bind="pack">Season Pack</summary>
                         <table class="torrent-search--grouped__torrents">
@@ -187,7 +187,7 @@
                 @foreach ($season['Episodes'] ?? [] as $episodeName => $episode)
                     <details
                         class="torrent-search--grouped__dropdown"
-                        @if ($loop->first && ! $season->has('Season Pack'))
+                        @if ($loop->first && ! array_key_exists('Season Pack', $season))
                             open
                         @endif
                     >


### PR DESCRIPTION
Shaves 110ms (from 150 ms to 40ms) from the logic to group torrents per tmdb and media type. It's not much compared to the rest of the request (~2s), but it's something. I could've got it down to 11 ms if laravel didn't have high overhead when accessing attributes, but it was 70ms before I started using ->getAttributeValue so that says something there.