### PR TITLE
(Fix) Credit character too long to fit in database column

### DIFF
--- a/app/Services/Tmdb/Client/Movie.php
+++ b/app/Services/Tmdb/Client/Movie.php
@@ -363,7 +363,7 @@ class Movie
                 'movie_id'      => $this->data['id'] ?? null,
                 'person_id'     => $person['id'] ?? null,
                 'occupation_id' => Occupation::ACTOR->value,
-                'character'     => $person['character'] ?? '',
+                'character'     => Str::limit($person['character'] ?? '', 200),
                 'order'         => $person['order'] ?? null
             ];
         }

--- a/app/Services/Tmdb/Client/TV.php
+++ b/app/Services/Tmdb/Client/TV.php
@@ -412,7 +412,7 @@ class TV
                     'tv_id'         => $this->data['id'],
                     'person_id'     => $person['id'],
                     'occupation_id' => Occupation::ACTOR->value,
-                    'character'     => $role['character'] ?? '',
+                    'character'     => Str::limit($role['character'] ?? '', 200),
                     'order'         => $person['order'] ?? null
                 ];
             }


### PR DESCRIPTION
Limit it to 200 instead of erroring.