### PR TITLE
(Fix) Allow User model instantiation with `new User(['id' => $id])`

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -107,7 +107,7 @@ class User extends Authenticatable implements MustVerifyEmail
      *
      * @var string[]
      */
-    protected $guarded = ['id', 'created_at', 'updated_at'];
+    protected $guarded = [];
 
     /**
      * Get the attributes that should be cast.


### PR DESCRIPTION
We use this syntax for sending notifications without requerying the database. Also, we don't use $request->all() for anything user-related anymore so we should be safe to allow all attributes to be mass filled.