### PR TITLE
(Fix) Scroll to top of panel on pagination click

### DIFF
--- a/resources/views/partials/pagination.blade.php
+++ b/resources/views/partials/pagination.blade.php
@@ -1,12 +1,12 @@
 @php
     if (! isset($scrollTo)) {
-        $scrollTo = 'body';
+        $scrollTo = '.panelV2';
     }
 
     $scrollIntoViewJsSnippet =
         $scrollTo !== false
             ? <<<JS
-       (\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
+       window.scroll({ top: ((\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).offsetTop - 80)})
     JS
             : '';
 @endphp


### PR DESCRIPTION
Instead of the body. Added a slight offset to counteract the sticky navbar.