### PR TITLE
(Update) Narrower sort icon

### DIFF
--- a/resources/views/livewire/includes/_sort-icon.blade.php
+++ b/resources/views/livewire/includes/_sort-icon.blade.php
@@ -1,7 +1,7 @@
 @if ($sortField === $field)
     <i
-        class="{{ config('other.font-awesome') }} fa-sort-amount-{{ $sortDirection === 'asc' ? 'up' : 'down' }}"
+        class="{{ config('other.font-awesome') }} fa-sort-{{ $sortDirection === 'asc' ? 'up' : 'down' }}"
     ></i>
 @else
-    <i class="{{ config('other.font-awesome') }} fa-sort-alt" style="opacity: 0.35"></i>
+    <i class="{{ config('other.font-awesome') }} fa-sort" style="opacity: 0.35"></i>
 @endif


### PR DESCRIPTION
This is the same style of sort icon that mediawiki uses, but the main advantage it has compared to the one currently used is that it takes up less horizontal width, meaning that when you have 10 narrow columns next to each other, such as on the user history/peers pages, you have about 50px more room for the torrent name before it wraps.
