### PR TITLE
(Fix) Active warnings query in navbar

### DIFF
--- a/app/View/Composers/TopNavComposer.php
+++ b/app/View/Composers/TopNavComposer.php
@@ -73,7 +73,7 @@ class TopNavComposer
                 60,
                 fn () => $user->peers()->where('active', '=', 1)->where('seeder', '=', false)->count(),
             ),
-            'hasActiveWarning'    => $user->warnings()->exists(),
+            'hasActiveWarning'    => $user->warnings()->where('active', '=', true)->exists(),
             'hasUnresolvedReport' => $user->group->is_modo && Report::query()->whereNull('snoozed_until')->where(
                 'solved',
                 '=',


### PR DESCRIPTION
We only want active warnings.