### PR TITLE
(Update) Use simple paginate for announce log

### DIFF
--- a/app/Http/Livewire/AnnounceSearch.php
+++ b/app/Http/Livewire/AnnounceSearch.php
@@ -59,16 +59,16 @@ class AnnounceSearch extends Component
     }
 
     /**
-     * @return \Illuminate\Pagination\LengthAwarePaginator<int, Announce>
+     * @return \Illuminate\Pagination\Paginator<int, Announce>
      */
     #[Computed]
-    final public function announces(): \Illuminate\Pagination\LengthAwarePaginator
+    final public function announces(): \Illuminate\Pagination\Paginator
     {
         return Announce::query()
             ->when($this->torrentId !== '', fn ($query) => $query->where('torrent_id', '=', $this->torrentId))
             ->when($this->userId !== '', fn ($query) => $query->where('user_id', '=', $this->userId))
             ->when($this->sortField !== '', fn ($query) => $query->orderBy($this->sortField, $this->sortDirection))
-            ->paginate($this->perPage);
+            ->simplePaginate($this->perPage);
     }
 
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application

--- a/resources/views/partials/pagination.blade.php
+++ b/resources/views/partials/pagination.blade.php
@@ -65,54 +65,58 @@
                         @endif
                     @endif
 
-                    @for ($page = max(2, $paginator->currentPage() - 3); $page <= min($paginator->currentPage() + 3, $paginator->lastPage() - 1); $page++)
-                        @if ($page === $paginator->currentPage())
-                            <li class="pagination__current">{{ $page }}</li>
-                        @else
+                    @if (method_exists('lastPage', $paginator))
+                        @for ($page = max(2, $paginator->currentPage() - 3); $page <= min($paginator->currentPage() + 3, $paginator->lastPage() - 1); $page++)
+                            @if ($page === $paginator->currentPage())
+                                <li class="pagination__current">{{ $page }}</li>
+                            @else
+                                <li>
+                                    <a
+                                        class="pagination__link"
+                                        href="{{ $paginator->url($page) }}"
+                                        wire:click.prevent="gotoPage({{ $page }}, '{{ $paginator->getPageName() }}')"
+                                        x-on:click="{{ $scrollIntoViewJsSnippet }}"
+                                    >
+                                        {{ $page }}
+                                    </a>
+                                </li>
+                            @endif
+                        @endfor
+
+                        @if ($paginator->currentPage() + 3 < $paginator->lastPage() - 1)
+                            @if ($paginator->currentPage() + 4 === $paginator->lastPage() - 1)
+                                <li>
+                                    <a
+                                        class="pagination__link"
+                                        href="{{ $paginator->url($paginator->currentPage() + 4) }}"
+                                        wire:click.prevent="gotoPage({{ $paginator->currentPage() + 4 }}, '{{ $paginator->getPageName() }}')"
+                                        x-on:click="{{ $scrollIntoViewJsSnippet }}"
+                                    >
+                                        {{ $paginator->currentPage() + 4 }}
+                                    </a>
+                                </li>
+                            @else
+                                <li class="pagination__ellipsis">&middot;&middot;&middot;</li>
+                            @endif
+                        @endif
+
+                        @if ($paginator->hasMorePages())
                             <li>
                                 <a
                                     class="pagination__link"
-                                    href="{{ $paginator->url($page) }}"
-                                    wire:click.prevent="gotoPage({{ $page }}, '{{ $paginator->getPageName() }}')"
+                                    href="{{ $paginator->url($paginator->lastPage()) }}"
+                                    wire:click.prevent="gotoPage({{ $paginator->lastPage() }}, '{{ $paginator->getPageName() }}')"
                                     x-on:click="{{ $scrollIntoViewJsSnippet }}"
+                                    rel="next"
                                 >
-                                    {{ $page }}
-                                </a>
-                            </li>
-                        @endif
-                    @endfor
-
-                    @if ($paginator->currentPage() + 3 < $paginator->lastPage() - 1)
-                        @if ($paginator->currentPage() + 4 === $paginator->lastPage() - 1)
-                            <li>
-                                <a
-                                    class="pagination__link"
-                                    href="{{ $paginator->url($paginator->currentPage() + 4) }}"
-                                    wire:click.prevent="gotoPage({{ $paginator->currentPage() + 4 }}, '{{ $paginator->getPageName() }}')"
-                                    x-on:click="{{ $scrollIntoViewJsSnippet }}"
-                                >
-                                    {{ $paginator->currentPage() + 4 }}
+                                    {{ $paginator->lastPage() }}
                                 </a>
                             </li>
                         @else
-                            <li class="pagination__ellipsis">&middot;&middot;&middot;</li>
+                            <li class="pagination__current">{{ $paginator->lastPage() }}</li>
                         @endif
-                    @endif
-
-                    @if ($paginator->hasMorePages())
-                        <li>
-                            <a
-                                class="pagination__link"
-                                href="{{ $paginator->url($paginator->lastPage()) }}"
-                                wire:click.prevent="gotoPage({{ $paginator->lastPage() }}, '{{ $paginator->getPageName() }}')"
-                                x-on:click="{{ $scrollIntoViewJsSnippet }}"
-                                rel="next"
-                            >
-                                {{ $paginator->lastPage() }}
-                            </a>
-                        </li>
                     @else
-                        <li class="pagination__current">{{ $paginator->lastPage() }}</li>
+                        <li class="pagination__current">{{ $paginator->currentPage() }}</li>
                     @endif
                 </ul>
             </li>


### PR DESCRIPTION
Prevents time outs when there's billions of records in the announces table.

We can also try cursor pagination if simple pagination doesn't work.

Diff best viewed without whitespace changes.