### PR TITLE
(Fix) Require/exclude anon/personal_release on torrent edit

### DIFF
--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -41,7 +41,7 @@ class StoreTorrentRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, array<Closure(string, mixed, Closure(string): never): void|\Illuminate\Validation\Rules\ProhibitedIf|\Illuminate\Validation\ConditionalRules|\Illuminate\Validation\Rules\Unique|string>>
+     * @return array<string, array<Closure(string, mixed, Closure(string): never): void|\Illuminate\Validation\Rules\ProhibitedIf|\Illuminate\Validation\Rules\RequiredIf|\Illuminate\Validation\Rules\ExcludeIf|\Illuminate\Validation\ConditionalRules|\Illuminate\Validation\Rules\Unique|string>>
      */
     public function rules(Request $request): array
     {
@@ -225,7 +225,9 @@ class StoreTorrentRequest extends FormRequest
                 'sometimes',
                 'boolean',
                 /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
-                Rule::when(!$user->group->is_modo && !$user->internals_exists, 'prohibited'),
+                Rule::requiredIf($user->group->is_modo || $user->internals_exists),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::excludeIf(!($user->group->is_modo || $user->internals_exists)),
             ],
             'free' => [
                 'sometimes',
@@ -233,13 +235,17 @@ class StoreTorrentRequest extends FormRequest
                 'numeric',
                 'between:0,100',
                 /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
-                Rule::when(!$user->group->is_modo && !$user->internals_exists, 'prohibited'),
+                Rule::requiredIf($user->group->is_modo || $user->internals_exists),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::excludeIf(!($user->group->is_modo || $user->internals_exists)),
             ],
             'refundable' => [
                 'sometimes',
                 'boolean',
                 /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
-                Rule::when(!$user->group->is_modo && !$user->internals_exists, 'prohibited'),
+                Rule::requiredIf($user->group->is_modo || $user->internals_exists),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::excludeIf(!($user->group->is_modo || $user->internals_exists)),
             ],
         ];
     }

--- a/app/Http/Requests/UpdateTorrentRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequest.php
@@ -36,7 +36,7 @@ class UpdateTorrentRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, array<\Illuminate\Validation\ConditionalRules|\Illuminate\Validation\Rules\Unique|string>|string>
+     * @return array<string, list<\Illuminate\Validation\ConditionalRules|\Illuminate\Validation\Rules\ExcludeIf|\Illuminate\Validation\Rules\RequiredIf|\Illuminate\Validation\Rules\Unique|string>>
      */
     public function rules(Request $request): array
     {
@@ -44,6 +44,9 @@ class UpdateTorrentRequest extends FormRequest
 
         /** @var string $torrentId */
         $torrentId = $request->route('id');
+
+        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->find($torrentId);
+        $user = $request->user()->load('group')->loadExists('internals');
 
         return [
             'name' => [
@@ -124,9 +127,10 @@ class UpdateTorrentRequest extends FormRequest
                 'min:0',
             ],
             'anon' => [
-                'required',
+                'sometimes',
                 'boolean',
-                Rule::when(Torrent::withoutGlobalScope(ApprovedScope::class)->find($request->route('id'))->user_id !== $request->user()->id && !$request->user()->group->is_modo, 'exclude'),
+                Rule::requiredIf($torrent->user_id === $user->id || $user->group->is_modo),
+                Rule::excludeIf(!($torrent->user_id === $user->id || $user->group->is_modo)),
             ],
             'stream' => [
                 'required',
@@ -137,23 +141,36 @@ class UpdateTorrentRequest extends FormRequest
                 'boolean',
             ],
             'personal_release' => [
-                'required',
+                'sometimes',
                 'boolean',
+                Rule::requiredIf($torrent->user_id === $user->id || $user->group->is_modo),
+                Rule::excludeIf(!($torrent->user_id === $user->id || $user->group->is_modo)),
             ],
             'internal' => [
                 'sometimes',
                 'boolean',
-                Rule::when(!$request->user()->group->is_modo && !$request->user()->internals()->exists(), 'prohibited'),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::requiredIf($user->group->is_modo || $user->internals_exists),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::excludeIf(!($user->group->is_modo || $user->internals_exists)),
             ],
             'free' => [
                 'sometimes',
+                'integer',
+                'numeric',
                 'between:0,100',
-                Rule::when(!$request->user()->group->is_modo && !$request->user()->internals()->exists(), 'prohibited'),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::requiredIf($user->group->is_modo || $user->internals_exists),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::excludeIf(!($user->group->is_modo || $user->internals_exists)),
             ],
             'refundable' => [
                 'sometimes',
                 'boolean',
-                Rule::when(!$request->user()->group->is_modo && !$request->user()->internals()->exists(), 'prohibited'),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::requiredIf($user->group->is_modo || $user->internals_exists),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::excludeIf(!($user->group->is_modo || $user->internals_exists)),
             ],
         ];
     }

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -416,9 +416,8 @@
                         />
                         <label class="form__label" for="anon">{{ __('common.anonymous') }}?</label>
                     </p>
-                @else
-                    <input type="hidden" name="anon" value="{{ $torrent->anon }}" />
                 @endif
+
                 <p
                     class="form__group"
                     x-show="cats[cat].type === 'movie' || cats[cat].type === 'tv'"
@@ -481,13 +480,8 @@
                         />
                         <label class="form__label" for="personal_release">Personal Release?</label>
                     </p>
-                @else
-                    <input
-                        type="hidden"
-                        name="personal_release"
-                        value="{{ $torrent->personal_release }}"
-                    />
                 @endif
+
                 <p class="form__group">
                     <button class="form__button form__button--filled">
                         {{ __('common.submit') }}


### PR DESCRIPTION
Also refactor the other authorized booleans to exclude instead of prohibit and exclude original value from edit form.