### PR TITLE
(Fix) Enforce tmdb poster height

### DIFF
--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -145,7 +145,9 @@
 }
 
 .torrent-search--list__poster-img {
-    width: 53px;
+    /* TMDb posters should always be a ratio of 1.5 */
+    width: 54px;
+    height: 81px;
     border-radius: 5px;
 }
 


### PR DESCRIPTION
Makes it so the table doesn't jump around on page load.