### PR TITLE
(Fix) Bon earnings query duplicate column error when no earnings exist

### DIFF
--- a/app/Http/Livewire/UserEarnings.php
+++ b/app/Http/Livewire/UserEarnings.php
@@ -69,8 +69,9 @@ class UserEarnings extends Component
     #[Computed]
     final public function bonEarnings(): \Illuminate\Support\Collection
     {
-        $outerQuery = DB::query();
+        $outerQuery = DB::query()->select(DB::raw(1));
         $innerQuery = Peer::query()
+            ->select(DB::raw(1))
             ->join('history', fn ($join) => $join->on('history.torrent_id', '=', 'peers.torrent_id')->on('history.user_id', '=', 'peers.user_id'))
             ->join('torrents', 'peers.torrent_id', '=', 'torrents.id')
             ->where('peers.seeder', '=', true)


### PR DESCRIPTION
A new column is selected for every earning, but if there are no earnings, then no columns are selected, and laravel selects `*` by default. Change it to select `1` by default instead, so that it doesn't fall back to `*` when no earnings exist. This selected column won't ever be used, but won't cause any errors either.