### PR TITLE
(Fix) Search by tmdb 0 to find missing tmdbs

### DIFF
--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -536,10 +536,12 @@ readonly class TorrentSearchFiltersDTO
         if ($this->tmdbId !== null) {
             if ($this->tmdbId === 0) {
                 $filters[] = [
-                    'tmdb_movie_id IS NULL AND tmdb_tv_id IS NOT NULL',
-                    'tmdb_tv_id IS NULL AND tmdb_movie_id IS NOT NULL',
-                    'tmdb_movie_id = 0 AND tmdb_tv_id != 0',
-                    'tmdb_tv_id = 0 AND tmdb_movie_id != 0',
+                    'tmdb_movie_id IS NULL',
+                    'tmdb_movie_id = 0',
+                ];
+                $filters[] = [
+                    'tmdb_tv_id IS NULL',
+                    'tmdb_tv_id = 0',
                 ];
             } else {
                 $filters[] = [


### PR DESCRIPTION
Not sure what was going through my mind when deciding the query for this the first time around, it didn't exactly do anything useful. Now it's back to doing what it used to do before the switch to nulls instead of 0s for metadata ids: finding torrents without any associated tmdb.