### PR TITLE
(Fix) Specifying ticket file attachment disk

### DIFF
--- a/app/Http/Livewire/AttachmentUpload.php
+++ b/app/Http/Livewire/AttachmentUpload.php
@@ -53,7 +53,7 @@ class AttachmentUpload extends Component
 
         $fileName = uniqid('', true).'.'.$this->attachment->getClientOriginalExtension();
 
-        $this->attachment->storeAs('attachments', $fileName, 'attachments');
+        $this->attachment->storeAs('', $fileName, 'attachment-files');
 
         $attachment = new TicketAttachment();
         $attachment->user_id = $this->user->id;


### PR DESCRIPTION
`attachments` is not the name of a disk, but `attachment-files` is. Also remove the path prefix since this disk only stores attachment files.

Regression from #4497.