### PR TITLE
(Fix) Rely on if tmdb/igdb exists to determine meta

### DIFF
--- a/app/Helpers/TorrentHelper.php
+++ b/app/Helpers/TorrentHelper.php
@@ -77,7 +77,7 @@ class TorrentHelper
         $uploader = $torrent->user;
 
         switch (true) {
-            case $torrent->category->movie_meta:
+            case $torrent->tmdb_movie_id !== null:
                 User::query()
                     ->whereRelation('wishes', 'tmdb_movie_id', '=', $torrent->tmdb_movie_id)
                     ->get()
@@ -85,7 +85,7 @@ class TorrentHelper
                     ->notify(new NewWishListNotice($torrent));
 
                 break;
-            case $torrent->category->tv_meta:
+            case $torrent->tmdb_tv_id !== null:
                 User::query()
                     ->whereRelation('wishes', 'tmdb_tv_id', '=', $torrent->tmdb_tv_id)
                     ->get()

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -155,13 +155,11 @@ class RequestController extends Controller
             );
         }
 
-        $category = $torrentRequest->category;
-
         match (true) {
-            $category->tv_meta && $torrentRequest->tmdb_tv_id > 0       => new TMDBScraper()->tv($torrentRequest->tmdb_tv_id),
-            $category->movie_meta && $torrentRequest->tmdb_movie_id > 0 => new TMDBScraper()->movie($torrentRequest->tmdb_movie_id),
-            $category->game_meta && $torrentRequest->igdb > 0           => new IgdbScraper()->game($torrentRequest->igdb),
-            default                                                     => null,
+            $torrentRequest->tmdb_tv_id !== null    => new TMDBScraper()->tv($torrentRequest->tmdb_tv_id),
+            $torrentRequest->tmdb_movie_id !== null => new TMDBScraper()->movie($torrentRequest->tmdb_movie_id),
+            $torrentRequest->igdb !== null          => new IgdbScraper()->game($torrentRequest->igdb),
+            default                                 => null,
         };
 
         return to_route('requests.index')
@@ -225,10 +223,10 @@ class RequestController extends Controller
         $category = $torrentRequest->category;
 
         match (true) {
-            $category->tv_meta && $torrentRequest->tmdb_tv_id > 0       => new TMDBScraper()->tv($torrentRequest->tmdb_tv_id),
-            $category->movie_meta && $torrentRequest->tmdb_movie_id > 0 => new TMDBScraper()->movie($torrentRequest->tmdb_movie_id),
-            $category->game_meta && $torrentRequest->igdb > 0           => new IgdbScraper()->game($torrentRequest->igdb),
-            default                                                     => null,
+            $torrentRequest->tmdb_tv_id !== null    => new TMDBScraper()->tv($torrentRequest->tmdb_tv_id),
+            $torrentRequest->tmdb_movie_id !== null => new TMDBScraper()->movie($torrentRequest->tmdb_movie_id),
+            $torrentRequest->igdb !== null          => new IgdbScraper()->game($torrentRequest->igdb),
+            default                                 => null,
         };
 
         return to_route('requests.show', ['torrentRequest' => $torrentRequest])

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -260,10 +260,10 @@ class TorrentController extends Controller
         // Meta
 
         match (true) {
-            $category->tv_meta && $torrent->tmdb_tv_id > 0       => new TMDBScraper()->tv($torrent->tmdb_tv_id),
-            $category->movie_meta && $torrent->tmdb_movie_id > 0 => new TMDBScraper()->movie($torrent->tmdb_movie_id),
-            $category->game_meta && $torrent->igdb > 0           => new IgdbScraper()->game($torrent->igdb),
-            default                                              => null,
+            $torrent->tmdb_tv_id !== null    => new TMDBScraper()->tv($torrent->tmdb_tv_id),
+            $torrent->tmdb_movie_id !== null => new TMDBScraper()->movie($torrent->tmdb_movie_id),
+            $torrent->igdb !== null          => new IgdbScraper()->game($torrent->igdb),
+            default                          => null,
         };
 
         return to_route('torrents.show', ['id' => $id])
@@ -449,10 +449,10 @@ class TorrentController extends Controller
 
         // Meta
         match (true) {
-            $category->tv_meta && $torrent->tmdb_tv_id > 0       => new TMDBScraper()->tv($torrent->tmdb_tv_id),
-            $category->movie_meta && $torrent->tmdb_movie_id > 0 => new TMDBScraper()->movie($torrent->tmdb_movie_id),
-            $category->game_meta && $torrent->igdb > 0           => new IgdbScraper()->game($torrent->igdb),
-            default                                              => null,
+            $torrent->tmdb_tv_id !== null    => new TMDBScraper()->tv($torrent->tmdb_tv_id),
+            $torrent->tmdb_movie_id !== null => new TMDBScraper()->movie($torrent->tmdb_movie_id),
+            $torrent->igdb !== null          => new IgdbScraper()->game($torrent->igdb),
+            default                          => null,
         };
 
         // Torrent Keywords System


### PR DESCRIPTION
Instead of blindly using the respective tmdb associated with the torrent's category. Also fixes wishlist notifications if a user has a wishlist entry with a null tmdb and a user uploads a torrent without a tmdb.