### PR TITLE
(Fix) Hide metadata input box when it doesn't exist

### DIFF
--- a/resources/views/requests/create.blade.php
+++ b/resources/views/requests/create.blade.php
@@ -129,7 +129,7 @@
                                     This movie exists on TMDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="tmdb_movie_exists">
                                 <input type="hidden" name="tmdb_movie_id" value="0" />
                                 <input
                                     id="tmdb_movie_id"
@@ -166,7 +166,7 @@
                                     This TV show exists on TMDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="tmdb_tv_exists">
                                 <input type="hidden" name="tmdb_tv_id" value="0" />
                                 <input
                                     id="tmdb_tv_id"
@@ -203,7 +203,7 @@
                                     This title exists on IMDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="imdb_title_exists">
                                 <input type="hidden" name="imdb" value="0" />
                                 <input
                                     id="autoimdb"
@@ -241,7 +241,7 @@
                                     This TV show exists on TVDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="tvdb_tv_exists">
                                 <input type="hidden" name="tvdb" value="0" />
                                 <input
                                     id="autotvdb"
@@ -278,7 +278,7 @@
                                     This anime exists on MAL
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="mal_anime_exists">
                                 <input type="hidden" name="mal" value="0" />
                                 <input
                                     id="automal"
@@ -316,7 +316,7 @@
                                     This game exists on IGDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="igdb_game_exists">
                                 <input
                                     id="igdb"
                                     class="form__text"

--- a/resources/views/requests/edit.blade.php
+++ b/resources/views/requests/edit.blade.php
@@ -143,7 +143,7 @@
                                     This movie exists on TMDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="tmdb_movie_exists">
                                 <input type="hidden" name="tmdb_movie_id" value="0" />
                                 <input
                                     id="tmdb_movie_id"
@@ -183,7 +183,7 @@
                                     This TV show exists on TMDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="tmdb_tv_exists">
                                 <input type="hidden" name="tmdb_tv_id" value="0" />
                                 <input
                                     id="tmdb_tv_id"
@@ -224,7 +224,7 @@
                                     This title exists on IMDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="imdb_title_exists">
                                 <input type="hidden" name="imdb" value="0" />
                                 <input
                                     id="autoimdb"
@@ -262,7 +262,7 @@
                                     This TV show exists on TVDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="tvdb_tv_exists">
                                 <input type="hidden" name="tvdb" value="0" />
                                 <input
                                     id="autotvdb"
@@ -299,7 +299,7 @@
                                     This anime exists on MAL
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="mal_anime_exists">
                                 <input type="hidden" name="mal" value="0" />
                                 <input
                                     id="automal"
@@ -336,7 +336,7 @@
                                     This game exists on IGDB
                                 </label>
                             </p>
-                            <p class="form__group">
+                            <p class="form__group" x-show="igdb_game_exists">
                                 <input
                                     id="igdb"
                                     class="form__text"

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -301,7 +301,7 @@
                             </label>
                             <output name="apimatch" id="apimatch" for="torrent"></output>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="tmdb_movie_exists">
                             <input type="hidden" name="tmdb_movie_id" value="0" />
                             <input
                                 type="text"
@@ -336,7 +336,7 @@
                             </label>
                             <output name="apimatch" id="apimatch" for="torrent"></output>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="tmdb_tv_exists">
                             <input type="hidden" name="tmdb_tv_id" value="0" />
                             <input
                                 type="text"
@@ -373,7 +373,7 @@
                                 This title exists on IMDB
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="imdb_title_exists">
                             <input type="hidden" name="imdb" value="0" />
                             <input
                                 type="text"
@@ -411,7 +411,7 @@
                                 This TV show exists on TVDB
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="tvdb_tv_exists">
                             <input type="hidden" name="tvdb" value="0" />
                             <input
                                 type="text"
@@ -448,7 +448,7 @@
                                 This anime exists on MAL
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="mal_anime_exists">
                             <input type="hidden" name="mal" value="0" />
                             <input
                                 type="text"
@@ -488,7 +488,7 @@
                                 This game exists on IGDB
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="igdb_game_exists">
                             <input
                                 type="text"
                                 name="igdb"

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -288,7 +288,7 @@
                                 This movie exists on TMDB
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="tmdb_movie_exists">
                             <input type="hidden" name="tmdb_movie_id" value="0" />
                             <input
                                 id="tmdb_movie_id"
@@ -327,7 +327,7 @@
                                 This TV show exists on TMDB
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="tmdb_tv_exists">
                             <input type="hidden" name="tmdb_tv_id" value="0" />
                             <input
                                 id="tmdb_tv_id"
@@ -365,7 +365,7 @@
                                 This title exists on IMDB
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="imdb_title_exists">
                             <input type="hidden" name="imdb" value="0" />
                             <input
                                 id="imdb"
@@ -404,7 +404,7 @@
                                 This TV show exists on TVDB
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="tvdb_tv_exists">
                             <input type="hidden" name="tvdb" value="0" />
                             <input
                                 id="tvdb"
@@ -442,7 +442,7 @@
                                 This anime exists on MAL
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="mal_anime_exists">
                             <input type="hidden" name="mal" value="0" />
                             <input
                                 id="mal"
@@ -481,7 +481,7 @@
                                 This game exists on IGDB
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-show="igdb_game_exists">
                             <input type="hidden" name="igdb" value="0" />
                             <input
                                 id="igdb"


### PR DESCRIPTION
Prevents users inputting data into the box while the checkbox is unticked.