### PR TITLE
(Fix) Don't switch category to movie on tv upload validation fail

### DIFF
--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -42,7 +42,7 @@
     <section
         class="upload panelV2"
         x-data="{
-            cat: {{ (int) $category_id }},
+            cat: {{ old('category_id', (int) $category_id) }},
             cats: JSON.parse(atob('{{ base64_encode(json_encode($categories)) }}')),
             tmdb_movie_exists: true,
             tmdb_tv_exists: true,


### PR DESCRIPTION
It also unexpectedly causes all the other fields to be cleared if the validation fails.