### PR TITLE
(Fix) Allow searching for movies/tv whose names are numbers

### DIFF
--- a/app/Http/Controllers/API/QuickSearchController.php
+++ b/app/Http/Controllers/API/QuickSearchController.php
@@ -52,7 +52,9 @@ class QuickSearchController extends Controller
         if (preg_match('/^(\d+)$/', $query, $matches)) {
             $filters[] = [
                 'tmdb_movie_id = '.$matches[1],
+                'tmdb_movie.name = '.$matches[1],
                 'tmdb_tv_id = '.$matches[1],
+                'tmdb_tv.name = '.$matches[1],
             ];
             $searchById = true;
         }


### PR DESCRIPTION
Searching for a number is a shortcut to searching by tmdb. Unfortunately, that means searching for movies/tv whose names are number never show up in the quick search results. Change the logic to also search by an exact name match when searching by number to additionally include shows whose names are numbers alongside the tmdb result.