### PR TITLE
(Fix) Include deleted torrents in top nav torrent downloads

### DIFF
--- a/app/View/Composers/TopNavComposer.php
+++ b/app/View/Composers/TopNavComposer.php
@@ -93,7 +93,7 @@ class TopNavComposer
             'downloadCount' => cache()->remember(
                 "users:{$user->id}:download-count",
                 60,
-                fn () => $user->history()->where('actual_downloaded', '>', 0)->count(),
+                fn () => $user->history()->withoutGlobalScopes()->where('actual_downloaded', '>', 0)->count(),
             ),
             'user' => $user,
         ]);


### PR DESCRIPTION
This value wasn't matching the value on the profile. The downloads number should be all time, and not only count existing torrents.