### PR TITLE
(Update) Collection on similar meta and collection posters

### DIFF
--- a/app/Http/Controllers/MediaHub/TmdbCollectionController.php
+++ b/app/Http/Controllers/MediaHub/TmdbCollectionController.php
@@ -35,7 +35,7 @@ class TmdbCollectionController extends Controller
     public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('mediahub.collection.show', [
-            'collection' => TmdbCollection::with(['movie' => fn ($query) => $query->has('torrents'), 'comments'])->findOrFail($id),
+            'collection' => TmdbCollection::with(['movies' => fn ($query) => $query->has('torrents'), 'comments'])->findOrFail($id),
         ]);
     }
 }

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -78,7 +78,7 @@ class RequestController extends Controller
                     'genres',
                     'credits' => ['person', 'occupation'],
                     'companies',
-                    'collection'
+                    'collections.movies'
                 ])
                     ->find($torrentRequest->tmdb_movie_id),
                 ($torrentRequest->category->game_meta && $torrentRequest->igdb) => IgdbGame::with([

--- a/app/Http/Controllers/SimilarTorrentController.php
+++ b/app/Http/Controllers/SimilarTorrentController.php
@@ -45,7 +45,8 @@ class SimilarTorrentController extends Controller
                 $meta = TmdbMovie::with([
                     'genres',
                     'credits' => ['person', 'occupation'],
-                    'companies'
+                    'companies',
+                    'collections.movies',
                 ])
                     ->findOrFail($tmdbId);
                 $tmdb = $tmdbId;

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -119,7 +119,10 @@ class TorrentController extends Controller
                 'genres',
                 'credits' => ['person', 'occupation'],
                 'companies',
-                'collection',
+                'collections.movies' => fn ($query) => $query
+                    ->select('tmdb_movies.id', 'tmdb_movies.title', 'tmdb_movies.poster', 'tmdb_movies.release_date')
+                    ->withMin('torrents', 'category_id')
+                    ->has('torrents'),
                 'recommendedMovies' => fn ($query) => $query
                     ->select('tmdb_movies.id', 'tmdb_movies.title', 'tmdb_movies.poster', 'tmdb_movies.release_date')
                     ->withMin('torrents', 'category_id')

--- a/app/Http/Livewire/TmdbCollectionSearch.php
+++ b/app/Http/Livewire/TmdbCollectionSearch.php
@@ -42,8 +42,8 @@ class TmdbCollectionSearch extends Component
     #[Computed]
     final public function collections(): \Illuminate\Pagination\LengthAwarePaginator
     {
-        return TmdbCollection::withCount('movie')
-            ->with('movie')
+        return TmdbCollection::withCount('movies')
+            ->with('movies')
             ->when($this->search !== '', fn ($query) => $query->where('name', 'LIKE', '%'.$this->search.'%'))
             ->oldest('name')
             ->paginate(25);

--- a/app/Jobs/ProcessMovieJob.php
+++ b/app/Jobs/ProcessMovieJob.php
@@ -86,7 +86,7 @@ class ProcessMovieJob implements ShouldQueue
             $collection = (new Client\Collection($movieScraper->data['belongs_to_collection']['id']))->getCollection();
 
             TmdbCollection::upsert($collection, 'id');
-            $movie->collection()->sync([$collection['id']]);
+            $movie->collections()->sync([$collection['id']]);
         }
 
         // People

--- a/app/Models/TmdbCollection.php
+++ b/app/Models/TmdbCollection.php
@@ -52,7 +52,7 @@ class TmdbCollection extends Model
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TmdbMovie, $this>
      */
-    public function movie(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
+    public function movies(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
         return $this->belongsToMany(TmdbMovie::class);
     }

--- a/app/Models/TmdbMovie.php
+++ b/app/Models/TmdbMovie.php
@@ -111,9 +111,9 @@ class TmdbMovie extends Model
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TmdbCollection, $this>
      */
-    public function collection(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
+    public function collections(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
-        return $this->belongsToMany(TmdbCollection::class)->take(1);
+        return $this->belongsToMany(TmdbCollection::class);
     }
 
     /**

--- a/resources/sass/components/_meta.scss
+++ b/resources/sass/components/_meta.scss
@@ -318,6 +318,15 @@
     will-change: backdrop-filter, background;
 }
 
+.meta-chip--value-only {
+    grid-template-areas: 'image value';
+
+    .meta-chip__value {
+        height: auto;
+        align-self: center;
+    }
+}
+
 .meta-chip:hover {
     backdrop-filter: var(--meta-chip-backdrop-filter-hover);
     -webkit-backdrop-filter: var(--meta-chip-backdrop-filter-hover);
@@ -389,6 +398,13 @@
 
 .meta-chip__value a:hover {
     color: var(--meta-chip-value-hover-fg);
+}
+
+.meta-chip__list {
+    display: flex;
+    margin-left: 8px;
+    flex-direction: column;
+    column-gap: 12px;
 }
 
 @media screen and (max-width: 767px) {

--- a/resources/sass/pages/_torrent.scss
+++ b/resources/sass/pages/_torrent.scss
@@ -96,6 +96,17 @@
     overflow-x: auto;
 }
 
+/* Collection
+---------------------------------------------------------------------------- */
+
+.collection-posters {
+    display: grid;
+    grid-auto-columns: 150px;
+    grid-auto-flow: column;
+    gap: 12px 24px;
+    overflow-x: auto;
+}
+
 /* NFO
 ---------------------------------------------------------------------------- */
 

--- a/resources/views/blocks/featured.blade.php
+++ b/resources/views/blocks/featured.blade.php
@@ -57,7 +57,7 @@
                                 ->with('genres', 'networks', 'seasons')
                                 ->find($feature->torrent->tmdb_tv_id ?? 0),
                             $feature->torrent->category->movie_meta => App\Models\TmdbMovie::query()
-                                ->with('genres', 'companies', 'collection')
+                                ->with('genres', 'companies')
                                 ->find($feature->torrent->tmdb_movie_id ?? 0),
                             $feature->torrent->category->game_meta => App\Models\Game::query()
                                 ->with('genres')

--- a/resources/views/livewire/tmdb-collection-search.blade.php
+++ b/resources/views/livewire/tmdb-collection-search.blade.php
@@ -44,7 +44,7 @@
                         </h3>
                         <p class="collection__description">
                             {{ __('mediahub.includes') }}
-                            {{ $collection->movie->pluck('title')->implode(',') }}
+                            {{ $collection->movies->pluck('title')->implode(',') }}
                         </p>
                     </article>
                 </li>

--- a/resources/views/mediahub/collection/show.blade.php
+++ b/resources/views/mediahub/collection/show.blade.php
@@ -68,7 +68,7 @@
             </div>
         </header>
         <div class="panel__body torrent-search--poster__results">
-            @foreach ($collection->movie->sortBy('release_date') as $movie)
+            @foreach ($collection->movies->sortBy('release_date') as $movie)
                 <x-movie.poster
                     :movie="$movie"
                     :category-id="$movie->torrents()->first()->category_id"

--- a/resources/views/torrent/partials/collection.blade.php
+++ b/resources/views/torrent/partials/collection.blade.php
@@ -1,31 +1,9 @@
-<div class="panel__body" style="padding: 5px">
-    @if (! empty($meta->collection['0']) && $torrent->category->movie_meta)
-        <article
-            class="collection"
-            style="
-                background-image: linear-gradient(rgba(0, 0, 0, 0.87), rgba(45, 71, 131, 0.46)),
-                    url({{ isset($meta->collection['0']->backdrop) ? tmdb_image('back_big', $meta->collection['0']->backdrop) : 'https://via.placeholder.com/1280x300' }});
-            "
-        >
-            <h3 class="collection__heading">
-                <a
-                    class="collection__link"
-                    href="{{ route('mediahub.collections.show', ['id' => $meta->collection['0']->id]) }}"
-                >
-                    {{ $meta->collection['0']->name }}
-                </a>
-            </h3>
-            <p class="collection__description">
-                {{ __('mediahub.includes') }}
-                {{ $meta->collection['0']->movie->pluck('title')->implode(',') }}
-            </p>
-        </article>
+<div class="panel__body collection-posters" style="padding: 5px">
+    @if ($meta?->collections->isNotEmpty() && $torrent->category->movie_meta)
+        @foreach ($meta?->collections?->first()?->movies as $movie)
+            <x-movie.poster :$movie :categoryId="$movie->torrents_min_category_id" />
+        @endforeach
     @else
-        <div class="text-center">
-            <h4 class="text-bold text-danger">
-                <i class="{{ config('other.font-awesome') }} fa-frown"></i>
-                No Collection Found!
-            </h4>
-        </div>
+        No Collection Found!
     @endif
 </div>

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -299,6 +299,77 @@
                     </h3>
                 </a>
             </article>
+
+            @if ($meta?->collections?->isNotEmpty())
+                <article class="meta__collection">
+                    <details>
+                        <summary class="meta-chip">
+                            <i
+                                class="{{ config('other.font-awesome') }} fa-rectangle-history meta-chip__icon"
+                            ></i>
+                            <h2 class="meta-chip__name">Collection</h2>
+                            <h3 class="meta-chip__value">
+                                {{ $meta?->collections?->first()?->name }}
+                            </h3>
+                        </summary>
+                        <div class="meta-chip__list">
+                            <article class="meta__collection-item">
+                                <a
+                                    class="meta-chip meta-chip--value-only"
+                                    href="{{ route('mediahub.collections.show', ['id' => $meta?->collections?->first()?->id]) }}"
+                                >
+                                    @if ($meta?->collections?->first()->poster)
+                                        <img
+                                            class="meta-chip__image"
+                                            src="{{ tmdb_image('poster_small', $meta?->collections?->first()->poster) }}"
+                                            alt=""
+                                        />
+                                    @else
+                                        <i
+                                            class="{{ config('other.font-awesome') }} fa-rectangle-history meta-chip__icon"
+                                        ></i>
+                                    @endif
+                                    <h3 class="meta-chip__value">View all</h3>
+                                </a>
+                            </article>
+                            @foreach ($meta?->collections?->first()->movies as $movie)
+                                <article class="meta__collection-item">
+                                    <a
+                                        class="meta-chip meta-chip--value-only"
+                                        href="{{ route('torrents.similar', ['tmdb' => $movie->id, 'category_id' => $category->id]) }}"
+                                    >
+                                        @if ($movie->poster)
+                                            <img
+                                                class="meta-chip__image"
+                                                src="{{ tmdb_image('poster_small', $movie->poster) }}"
+                                                alt=""
+                                            />
+                                        @else
+                                            <i
+                                                class="{{ config('other.font-awesome') }} fa-film meta-chip__icon"
+                                            ></i>
+                                        @endif
+                                        @if ($movie->is($meta))
+                                            <h3 class="meta-chip__value">
+                                                <strong>
+                                                    {{ $movie->title }}
+                                                    ({{ $movie->release_date->format('Y') }})
+                                                </strong>
+                                            </h3>
+                                        @else
+                                            <h3 class="meta-chip__value">
+                                                {{ $movie->title }}
+                                                ({{ $movie->release_date->format('Y') }})
+                                            </h3>
+                                        @endif
+                                    </a>
+                                </article>
+                            @endforeach
+                        </div>
+                    </details>
+                </article>
+            @endif
+
             @foreach ($meta?->companies ?? [] as $company)
                 <article class="meta__company">
                     <a


### PR DESCRIPTION
Show all movies in a collection that the current movie is in, in the similar meta. Also show movie posters instead of a collection card in the relations panel on the torrent page. Reorganize the relations so that plurals are correct and match the relation stored in the database. Even though there can be only one collection per movie as defined by tmdb, that's not the way the tables are stored and the queries are done, so use plural naming for now.