### PR TITLE
(Update) Change passkey in external tracker in single request

### DIFF
--- a/app/Http/Controllers/User/PasskeyController.php
+++ b/app/Http/Controllers/User/PasskeyController.php
@@ -51,13 +51,15 @@ class PasskeyController extends Controller
 
         cache()->forget('user:'.$user->passkey);
 
-        Unit3dAnnounce::removeUser($user);
+        $newPasskey = md5(random_bytes(60).$user->password);
 
-        DB::transaction(static function () use ($user, $changedByStaff): void {
+        Unit3dAnnounce::addUser($user, $newPasskey);
+
+        DB::transaction(static function () use ($user, $changedByStaff, $newPasskey): void {
             $user->passkeys()->latest()->first()?->update(['deleted_at' => now()]);
 
             $user->update([
-                'passkey' => md5(random_bytes(60).$user->password)
+                'passkey' => $newPasskey,
             ]);
 
             $user->passkeys()->create(['content' => $user->passkey]);
@@ -65,9 +67,7 @@ class PasskeyController extends Controller
             if ($changedByStaff) {
                 $user->notify(new PasskeyReset());
             }
-        });
-
-        Unit3dAnnounce::addUser($user);
+        }, 5);
 
         return to_route('users.passkeys.index', ['user' => $user])
             ->with('success', 'Your passkey was changed successfully.');

--- a/app/Services/Unit3dAnnounce.php
+++ b/app/Services/Unit3dAnnounce.php
@@ -170,7 +170,7 @@ class Unit3dAnnounce
         return $torrent;
     }
 
-    public static function addUser(User $user): bool
+    public static function addUser(User $user, ?string $newPasskey = null): bool
     {
         if ($user->deleted_at !== null) {
             return true;
@@ -185,6 +185,7 @@ class Unit3dAnnounce
             'id'           => (int) $user->id,
             'group_id'     => (int) $user->group_id,
             'passkey'      => $user->passkey,
+            'new_passkey'  => $newPasskey,
             'can_download' => (bool) $user->can_download,
             'is_donor'     => (bool) $user->is_donor,
             'is_lifetime'  => (bool) $user->is_lifetime,


### PR DESCRIPTION
Instead of first removing, and then re-adding.