### PR TITLE
(Fix) Torrent group row layout no edit permission

### DIFF
--- a/resources/views/components/partials/_torrent-group-row.blade.php
+++ b/resources/views/components/partials/_torrent-group-row.blade.php
@@ -34,16 +34,16 @@
     </div>
 </td>
 
-@if (auth()->user()->group->is_editor || auth()->user()->group->is_modo || (auth()->id() === $torrent->user_id && ($torrent->status !== \App\Enums\ModerationStatus::APPROVED || now()->isBefore($torrent->created_at->addDay()))))
-    <td class="torrent-search--grouped__edit">
+<td class="torrent-search--grouped__edit">
+    @if (auth()->user()->group->is_editor || auth()->user()->group->is_modo || (auth()->id() === $torrent->user_id && ($torrent->status !== \App\Enums\ModerationStatus::APPROVED || now()->isBefore($torrent->created_at->addDay()))))
         <a
             href="{{ route('torrents.edit', ['id' => $torrent->id]) }}"
             title="{{ __('common.edit') }}"
         >
             <i class="{{ config('other.font-awesome') }} fa-pencil-alt"></i>
         </a>
-    </td>
-@endif
+    @endif
+</td>
 
 <td class="torrent-search--grouped__bookmark">
     <button

--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -831,7 +831,7 @@
                                 <th class="similar-torrents__name-header">
                                     {{ __('torrent.name') }}
                                 </th>
-                                <th class="similar-torrents__actions-header" colspan="2">
+                                <th class="similar-torrents__actions-header" colspan="3">
                                     {{ __('common.actions') }}
                                 </th>
                                 <th class="similar-torrents__size-header">


### PR DESCRIPTION
The table cell was missing when the user couldn't edit, which broke the table. Now we still include the table cell, but leave it empty if the user can't edit.