### PR TITLE
(Fix) Missing quick search result hover fg style variable

### DIFF
--- a/resources/sass/components/_quick_search.scss
+++ b/resources/sass/components/_quick_search.scss
@@ -99,6 +99,7 @@
 .quick-search__result-link:hover,
 .quick-search__result-link:focus {
     background-color: var(--quick-search-result-hover-bg);
+    color: var(--quick-search-result-hover-fg);
 }
 
 .quick-search__image {


### PR DESCRIPTION
This variable is defined, but not used.