### PR TITLE
(Update) Use separate rate limit for search results

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -76,6 +76,7 @@ class RouteServiceProvider extends ServiceProvider
         RateLimiter::for('chat', fn (Request $request) => Limit::perMinute(60)->by('chat'.($request->user()?->id ?? $request->ip())));
         RateLimiter::for('rss', fn (Request $request) => Limit::perMinute(30)->by('rss'.$request->ip()));
         RateLimiter::for('authenticated-images', fn (Request $request): Limit => Limit::perMinute(200)->by('authenticated-images:'.$request->user()->id));
+        RateLimiter::for('search', fn (Request $request): Limit => Limit::perMinute(100)->by('search:'.$request->user()->id));
     }
 
     protected function removeIndexPhpFromUrl(): void

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,5 +57,5 @@ Route::middleware(['web', 'auth', 'banned', 'verified'])->group(function (): voi
         Route::post('/{postId}/dislike', [App\Http\Controllers\API\DislikeController::class, 'store'])->name('api.posts.dislike.store');
     });
 
-    Route::get('/quicksearch', [App\Http\Controllers\API\QuickSearchController::class, 'index'])->name('api.quicksearch');
+    Route::get('/quicksearch', [App\Http\Controllers\API\QuickSearchController::class, 'index'])->name('api.quicksearch')->middleware('throttle:search')->withoutMiddleware('throttle:web');
 });


### PR DESCRIPTION
We want search results to update as more characters are typed relatively quickly. Unfortunately this is opposite of our goal of a low rate limit. Separating this route into a separate rate limit solves this issue.