### PR TITLE
(Update) Use an extra tag row for meta

### DIFF
--- a/resources/sass/components/_meta.scss
+++ b/resources/sass/components/_meta.scss
@@ -1,11 +1,11 @@
 .meta {
     display: grid;
-    grid-template-areas: 'poster title actions' 'poster ids ids' 'poster description description' 'poster chips chips';
+    grid-template-areas: 'poster title actions' 'poster tags tags' 'poster ids ids' 'poster description description' 'poster chips chips';
     grid-template-columns: auto 1fr auto;
-    grid-template-rows: auto auto auto minmax(0, 1fr);
-    gap: 16px 32px;
+    grid-template-rows: auto auto auto auto minmax(0, 1fr);
+    gap: 8px 32px;
     padding: 16px;
-    max-height: 510px;
+    max-height: 540px;
 }
 
 .meta__poster-link {
@@ -58,7 +58,7 @@
 
 @media only screen and (max-width: 1200px) {
     .meta {
-        grid-template-areas: 'poster title actions' 'poster ids ids' 'poster description description' 'chips chips chips';
+        grid-template-areas: 'poster title actions' 'poster tags tags' 'poster ids ids' 'poster description description' 'chips chips chips';
         grid-template-columns: 140px minmax(0, 1fr) auto;
     }
 
@@ -70,7 +70,7 @@
 @media screen and (max-width: 767px) {
     .meta {
         max-height: unset;
-        grid-template-areas: 'poster title actions' 'poster ids ids' 'poster description description' 'chips chips chips';
+        grid-template-areas: 'poster title actions' 'poster tags tags' 'poster ids ids' 'description description description' 'chips chips chips';
         grid-template-columns: 96px minmax(0, 1fr) auto;
     }
 
@@ -85,7 +85,7 @@
 
 @media screen and (max-width: 480px) {
     .meta {
-        grid-template-areas: 'poster title actions' 'ids ids ids' 'description description description' 'chips chips chips';
+        grid-template-areas: 'poster title actions' 'tags tags tags' 'ids ids ids' 'description description description' 'chips chips chips';
         grid-template-columns: 64px minmax(0, 1fr) auto;
         column-gap: 12px;
         align-items: center;
@@ -217,7 +217,7 @@
     display: flex;
     column-gap: 0;
     list-style-type: none;
-    margin: -10px;
+    margin: 0 0 0 -10px;
     padding: 0;
     align-items: center;
 
@@ -447,5 +447,52 @@
         -webkit-line-clamp: 4;
         overflow: hidden;
         -webkit-box-orient: vertical;
+    }
+}
+
+/* Tags
+---------------------------------------------------------------------------- */
+
+.work__tags {
+    grid-area: tags;
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0 0 0 -12px;
+    padding: 0;
+    list-style-type: none;
+    align-items: baseline;
+    font-size: 14px;
+}
+
+.work__tags li:not(:last-child)::after {
+    content: '\2022';
+    display: inline-block;
+    margin-left: -0.5ch;
+}
+
+.work__tags li {
+    white-space: nowrap;
+}
+
+.work__tags > li > a,
+.work__tags > li > span {
+    color: var(--torrent-tag-fg);
+    padding: 6px 12px;
+    display: inline-block;
+}
+
+.work__tags > li > a:hover {
+    background-color: var(--torrent-tag-hover-bg);
+    border-radius: 9999px;
+    color: var(--torrent-tag-hover-fg);
+}
+
+@media screen and (max-width: 767px) {
+    .work__tags {
+        gap: 6px;
+    }
+
+    .work__tags.work__tags > li::after {
+        display: none;
     }
 }

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -99,6 +99,44 @@
             @endif
         </ul>
     </div>
+    <ul class="work__tags">
+        <li class="work__media-type">
+            <a
+                class="work__media-type-link"
+                href="{{ route('torrents.index', ['categoryIds' => [$category->id]]) }}"
+            >
+                {{ __('mediahub.movie') }}
+            </a>
+        </li>
+        <li class="work__language">
+            <a
+                class="work__language-link"
+                href="{{ $meta?->original_language === null ? '#' : route('torrents.index', ['primaryLanguageNames' => [$meta->original_language]]) }}"
+            >
+                {{ $meta->original_language ?? __('common.unknown') }}
+            </a>
+        </li>
+        <li class="work__runtime">
+            <span class="work__runtime-text">
+                {{ \Carbon\CarbonInterval::minutes($meta->runtime ?? 0)->cascade()->forHumans(null, true) }}
+            </span>
+        </li>
+        <li class="work__rating">
+            <span
+                class="work__rating-text"
+                title="{{ $meta->vote_count ?? 0 }} {{ __('torrent.votes') }}"
+            >
+                {{ round(($meta->vote_average ?? 0) * 10) }}%
+            </span>
+        </li>
+        @if ($meta?->trailer)
+            <li class="work__trailer show-trailer">
+                <a class="work__trailer-link" href="#">
+                    {{ __('torrent.view-trailer') }}
+                </a>
+            </li>
+        @endif
+    </ul>
     <ul class="meta__ids">
         @foreach (array_unique(array_filter([$meta->id ?? 0, $torrent->tmdb_movie_id ?? 0])) as $tmdbId)
             <li class="meta__tmdb">
@@ -243,33 +281,6 @@
         </section>
         <section class="meta__chip-container">
             <h2 class="meta__heading">Extra Information</h2>
-            <article class="meta-chip-wrapper meta-chip">
-                <i class="{{ config('other.font-awesome') }} fa-star meta-chip__icon"></i>
-                <h2 class="meta-chip__name">{{ __('torrent.rating') }}</h2>
-                <h3 class="meta-chip__value">
-                    {{ ($meta->vote_average ?? 0) * 10 }}% / {{ $meta->vote_count ?? 0 }}
-                    {{ __('torrent.votes') }}
-                </h3>
-            </article>
-            @if ($meta?->trailer)
-                <article class="meta__trailer show-trailer">
-                    <a class="meta-chip" href="#">
-                        <i
-                            class="{{ config('other.font-awesome') }} fa-external-link meta-chip__icon"
-                        ></i>
-                        <h2 class="meta-chip__name">Trailer</h2>
-                        <h3 class="meta-chip__value">View</h3>
-                    </a>
-                </article>
-            @endif
-
-            <article class="meta__runtime">
-                <a class="meta-chip" href="#">
-                    <i class="{{ config('other.font-awesome') }} fa-clock meta-chip__icon"></i>
-                    <h2 class="meta-chip__name">Runtime</h2>
-                    <h3 class="meta-chip__value">{{ $meta->runtime ?? 0 }} Minutes</h3>
-                </a>
-            </article>
             @if ($meta?->genres?->isNotEmpty())
                 <article class="meta__genres">
                     <a
@@ -286,19 +297,6 @@
                     </a>
                 </article>
             @endif
-
-            <article class="meta__language">
-                <a
-                    class="meta-chip"
-                    href="{{ $meta?->original_language === null ? '#' : route('torrents.index', ['primaryLanguageNames' => [$meta->original_language]]) }}"
-                >
-                    <i class="{{ config('other.font-awesome') }} fa-language meta-chip__icon"></i>
-                    <h2 class="meta-chip__name">Primary Language</h2>
-                    <h3 class="meta-chip__value">
-                        {{ $meta->original_language ?? __('common.unknown') }}
-                    </h3>
-                </a>
-            </article>
 
             @if ($meta?->collections?->isNotEmpty())
                 <article class="meta__collection">

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -98,6 +98,44 @@
             @endif
         </ul>
     </div>
+    <ul class="work__tags">
+        <li class="work__media-type">
+            <a
+                class="work__media-type-link"
+                href="{{ route('torrents.index', ['categoryIds' => [$category->id]]) }}"
+            >
+                {{ __('mediahub.show') }}
+            </a>
+        </li>
+        <li class="work__language">
+            <a
+                class="work__language-link"
+                href="{{ $meta?->original_language === null ? '#' : route('torrents.index', ['primaryLanguageNames' => [$meta->original_language]]) }}"
+            >
+                {{ $meta->original_language ?? __('common.unknown') }}
+            </a>
+        </li>
+        <li class="work__runtime">
+            <span class="work__runtime-text">
+                {{ \Carbon\CarbonInterval::minutes($meta->episode_run_time ?? 0)->cascade()->forHumans(null, true) }}
+            </span>
+        </li>
+        <li class="work__rating">
+            <span
+                class="work__rating-text"
+                title="{{ $meta->vote_count ?? 0 }} {{ __('torrent.votes') }}"
+            >
+                {{ round(($meta->vote_average ?? 0) * 10) }}%
+            </span>
+        </li>
+        @if ($meta?->trailer)
+            <li class="work__trailer show-trailer">
+                <a class="work__trailer-link" href="#">
+                    {{ __('torrent.view-trailer') }}
+                </a>
+            </li>
+        @endif
+    </ul>
     <ul class="meta__ids">
         @foreach (array_unique(array_filter([$meta->id ?? 0, $torrent->tmdb_tv_id ?? 0])) as $tmdbId)
             <li class="meta__tmdb">
@@ -242,33 +280,6 @@
         </section>
         <section class="meta__chip-container">
             <h2 class="meta__heading">Extra Information</h2>
-            <article class="meta-chip-wrapper meta-chip">
-                <i class="{{ config('other.font-awesome') }} fa-star meta-chip__icon"></i>
-                <h2 class="meta-chip__name">{{ __('torrent.rating') }}</h2>
-                <h3 class="meta-chip__value">
-                    {{ ($meta->vote_average ?? 0) * 10 }}% / {{ $meta->vote_count ?? 0 }}
-                    {{ __('torrent.votes') }}
-                </h3>
-            </article>
-            @if ($meta?->trailer)
-                <article class="meta__trailer show-trailer">
-                    <a class="meta-chip" href="#">
-                        <i
-                            class="{{ config('other.font-awesome') }} fa-external-link meta-chip__icon"
-                        ></i>
-                        <h2 class="meta-chip__name">Trailer</h2>
-                        <h3 class="meta-chip__value">View</h3>
-                    </a>
-                </article>
-            @endif
-
-            <article class="meta__runtime">
-                <a class="meta-chip" href="#">
-                    <i class="{{ config('other.font-awesome') }} fa-clock meta-chip__icon"></i>
-                    <h2 class="meta-chip__name">Runtime</h2>
-                    <h3 class="meta-chip__value">{{ $meta->episode_run_time ?? 0 }} Minutes</h3>
-                </a>
-            </article>
             @if ($meta?->genres?->isNotEmpty())
                 <article class="meta__genres">
                     <a
@@ -286,18 +297,6 @@
                 </article>
             @endif
 
-            <article class="meta__language">
-                <a
-                    class="meta-chip"
-                    href="{{ $meta?->original_language === null ? '#' : route('torrents.index', ['primaryLanguageNames' => [$meta->original_language]]) }}"
-                >
-                    <i class="{{ config('other.font-awesome') }} fa-language meta-chip__icon"></i>
-                    <h2 class="meta-chip__name">Primary Language</h2>
-                    <h3 class="meta-chip__value">
-                        {{ $meta->original_language ?? __('common.unknown') }}
-                    </h3>
-                </a>
-            </article>
             @foreach ($meta?->networks ?? [] as $network)
                 <article class="meta__company">
                     <a


### PR DESCRIPTION
The extra information column is getting too long for content that should be visible at first glance without scrolling.