### PR TITLE
(Update) Always notify uploader/requester on replies

### DIFF
--- a/app/Http/Livewire/Comment.php
+++ b/app/Http/Livewire/Comment.php
@@ -175,7 +175,11 @@ class Comment extends Component
             case $this->model instanceof Playlist:
             case $this->model instanceof TorrentRequest:
             case $this->model instanceof Torrent:
-                if ($this->user->id !== $this->comment->user_id) {
+                if ($this->user->id !== $this->model->user_id) {
+                    User::find($this->model->user_id)?->notify(new NewComment($this->model, $reply));
+                }
+
+                if ($this->user->id !== $this->comment->user_id && $this->comment->user_id !== $this->model->user_id) {
                     User::find($this->comment->user_id)?->notify(new NewComment($this->model, $reply));
                 }
 

--- a/app/Notifications/NewComment.php
+++ b/app/Notifications/NewComment.php
@@ -110,27 +110,27 @@ class NewComment extends Notification
         return match (true) {
             $this->model instanceof Torrent => [
                 'title' => 'New Torrent Comment Received',
-                'body'  => $username.' has left you a comment on Torrent '.$this->model->name,
+                'body'  => $username.' has left a comment on torrent '.$this->model->name,
                 'url'   => '/torrents/'.$this->model->id.'#comment-'.$this->comment->id,
             ],
             $this->model instanceof TorrentRequest => [
                 'title' => 'New Request Comment Received',
-                'body'  => $username.' has left you a comment on Torrent Request '.$this->model->name,
+                'body'  => $username.' has left a comment on torrent request '.$this->model->name,
                 'url'   => '/requests/'.$this->model->id.'#comment-'.$this->comment->id,
             ],
             $this->model instanceof Ticket => [
                 'title' => 'New Ticket Comment Received',
-                'body'  => $username.' has left you a comment on Ticket '.$this->model->subject,
+                'body'  => $username.' has left a comment on ticket '.$this->model->subject,
                 'url'   => '/tickets/'.$this->model->id.'#comment-'.$this->comment->id,
             ],
             $this->model instanceof Playlist => [
                 'title' => 'New Playlist Comment Received',
-                'body'  => $username.' has left you a comment on Playlist '.$this->model->name,
+                'body'  => $username.' has left a comment on playlist '.$this->model->name,
                 'url'   => '/playlists/'.$this->model->id.'#comment-'.$this->comment->id,
             ],
             $this->model instanceof Article => [
                 'title' => 'New Article Comment Received',
-                'body'  => $username.' has left you a comment on Article '.$this->model->title,
+                'body'  => $username.' has left a comment on article '.$this->model->title,
                 'url'   => '/articles/'.$this->model->id.'#comment-'.$this->comment->id,
             ],
         };


### PR DESCRIPTION
But don't send two notifications, one to the top level commenter, and one to the uploader, if they happen to be the same user. Keep the logic that notifies the top level commenter of any replies within.