### PR TITLE
(Update) Allow refreshing tmdb metadata when missing from database

### DIFF
--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -77,16 +77,19 @@
                         </button>
                     </form>
                 </li>
+            @endif
+
+            @if ($meta?->id || $torrent?->tmdb_movie_id ?? null)
                 <li>
                     <form
-                        action="{{ route('torrents.similar.update', ['category' => $category, 'metaId' => $meta->id]) }}"
+                        action="{{ route('torrents.similar.update', ['category' => $category, 'metaId' => $meta?->id ?? $torrent->tmdb_movie_id]) }}"
                         method="post"
                     >
                         @csrf
                         @method('PATCH')
 
                         <button
-                            @if (cache()->has('tmdb-movie-scraper:' . $meta->id) && ! auth()->user()->group->is_modo)
+                            @if (cache()->has('tmdb-movie-scraper:' . ($meta?->id ?? $torrent->tmdb_movie_id)) && ! auth()->user()->group->is_modo)
                                 disabled
                                 title="This item was recently updated. Try again tomorrow."
                             @endif

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -77,15 +77,18 @@
                         </button>
                     </form>
                 </li>
+            @endif
+
+            @if ($meta?->id || $torrent?->tmdb_tv_id ?? null)
                 <li>
                     <form
-                        action="{{ route('torrents.similar.update', ['category' => $category, 'metaId' => $meta->id]) }}"
+                        action="{{ route('torrents.similar.update', ['category' => $category, 'metaId' => $meta?->id ?? $torrent->tmdb_tv_id]) }}"
                         method="post"
                     >
                         @csrf
                         @method('PATCH')
                         <button
-                            @if (cache()->has('tmdb-tv-scraper:' . $meta->id) && ! auth()->user()->group->is_modo)
+                            @if (cache()->has('tmdb-tv-scraper:' . ($meta?->id ?? $torrent->tmdb_tv_id)) && ! auth()->user()->group->is_modo)
                                 disabled
                                 title="This item was recently updated. Try again tomorrow."
                             @endif


### PR DESCRIPTION
Previously, one would need to edit a torrent and submit to trigger a metadata scrape. The button to refresh would previously only show up if a movie/tv record already existed.