### PR TITLE
(Fix) Swap subtitle language code for name on create page

### DIFF
--- a/resources/views/subtitle/create.blade.php
+++ b/resources/views/subtitle/create.blade.php
@@ -54,7 +54,7 @@
                                 value="{{ $media_language->id }}"
                                 @selected(old('media_language') == $media_language->id)
                             >
-                                {{ $media_language->code }}
+                                {{ $media_language->name }}
                             </option>
                         @endforeach
                     </select>


### PR DESCRIPTION
So that it matches the edit page and what's displayed on the torrent page.