### PR TITLE
(Fix) Apostrophes in wikis and pages

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -58,6 +58,6 @@ class Page extends Model
      */
     public function getContentHtml(): string
     {
-        return Markdown::convert(htmlspecialchars_decode((new Bbcode())->parse($this->content, false)))->getContent();
+        return Markdown::convert(htmlspecialchars_decode((new Bbcode())->parse($this->content, false), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5))->getContent();
     }
 }

--- a/app/Models/Wiki.php
+++ b/app/Models/Wiki.php
@@ -52,6 +52,6 @@ class Wiki extends Model
      */
     public function getContentHtml(): string
     {
-        return Markdown::convert(htmlspecialchars_decode((new Bbcode())->parse($this->content, false)))->getContent();
+        return Markdown::convert(htmlspecialchars_decode((new Bbcode())->parse($this->content, false), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5))->getContent();
     }
 }


### PR DESCRIPTION
The same flags that are used to encode before parsing the bbcode must also be used here when decoding to reverse the process. Otherwise, apostrophes processed by the markdown engine are encoded a second time because the `ENT_HTML5` flag encodes them while the default (`ENT_HTML401`) does not.