### PR TITLE
(Update) Use strict cookies by default

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -195,5 +195,5 @@ return [
     |
     */
 
-    'same_site' => 'lax',
+    'same_site' => 'strict',
 ];


### PR DESCRIPTION
Tested and no breakage. This probably should have been done ages ago.