### PR TITLE
(Fix) Allow `data:` image links via csp

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -530,7 +530,7 @@ return [
             'self' => true,
 
             'schemes' => [
-                // 'data:',
+                'data:',
                 'https:',
             ],
 


### PR DESCRIPTION
We use inline svg data links in a few places like quick search people fallback image when there's no still available from tmdb, as well as the icon for select dropdown. Some user scripts also use it. `data:` links for specifically images are relatively harmless security-wise, so let's allow them, but still keep them blocked at the bbcode level.