### PR TITLE
(Fix) Filled request filter broken when fill approver soft deleted

### DIFF
--- a/app/Http/Controllers/ApprovedRequestFillController.php
+++ b/app/Http/Controllers/ApprovedRequestFillController.php
@@ -43,7 +43,7 @@ class ApprovedRequestFillController extends Controller
      */
     public function store(Request $request, TorrentRequest $torrentRequest): \Illuminate\Http\RedirectResponse
     {
-        abort_unless(($request->user()->id === $torrentRequest->user_id || $request->user()->group->is_modo) && $torrentRequest->approved_by === null, 403);
+        abort_unless(($request->user()->id === $torrentRequest->user_id || $request->user()->group->is_modo) && $torrentRequest->approved_when === null, 403);
 
         $approver = $request->user();
         $filler = $torrentRequest->filler()->sole();

--- a/app/Http/Controllers/BountyController.php
+++ b/app/Http/Controllers/BountyController.php
@@ -40,7 +40,7 @@ class BountyController extends Controller
      */
     public function store(StoreTorrentRequestBountyRequest $request, TorrentRequest $torrentRequest): \Illuminate\Http\RedirectResponse
     {
-        abort_unless($torrentRequest->approved_by === null, 403);
+        abort_unless($torrentRequest->approved_when === null, 403);
 
         $user = $request->user();
 

--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -396,7 +396,7 @@ class SimilarTorrent extends Component
             ->where('category_id', '=', $this->category->id)
             ->when(
                 $this->hideFilledRequests,
-                fn ($query) => $query->where(fn ($query) => $query->whereDoesntHave('torrent')->orWhereDoesntHave('approver'))
+                fn ($query) => $query->where(fn ($query) => $query->whereNull('torrent_id')->orWhereNull('approved_when'))
             )
             ->latest()
             ->get();

--- a/app/Http/Livewire/TorrentRequestSearch.php
+++ b/app/Http/Livewire/TorrentRequestSearch.php
@@ -287,17 +287,17 @@ class TorrentRequestSearch extends Component
                     })
                         ->orWhere(function ($query): void {
                             if ($this->claimed) {
-                                $query->whereNotNull('claimed')->whereNull('torrent_id')->whereNull('approved_by');
+                                $query->whereNotNull('claimed')->whereNull('torrent_id')->whereNull('approved_when');
                             }
                         })
                         ->orWhere(function ($query): void {
                             if ($this->pending) {
-                                $query->whereNotNull('torrent_id')->whereNull('approved_by');
+                                $query->whereNotNull('torrent_id')->whereNull('approved_when');
                             }
                         })
                         ->orWhere(function ($query): void {
                             if ($this->filled) {
-                                $query->whereNotNull('torrent_id')->whereNotNull('approved_by');
+                                $query->whereNotNull('torrent_id')->whereNotNull('approved_when');
                             }
                         });
                 });

--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -996,7 +996,7 @@
                                             {{ __('request.claimed') }}
 
                                             @break
-                                        @case($torrentRequest->torrent_id !== null && $torrentRequest->approved_by === null)
+                                        @case($torrentRequest->torrent_id !== null && $torrentRequest->approved_when === null)
                                             <i class="fas fa-circle text-purple"></i>
                                             {{ __('request.pending') }}
 

--- a/resources/views/livewire/torrent-request-search.blade.php
+++ b/resources/views/livewire/torrent-request-search.blade.php
@@ -95,7 +95,7 @@
                                             {{ __('request.claimed') }}
 
                                             @break
-                                        @case($torrentRequest->torrent_id !== null && $torrentRequest->approved_by === null)
+                                        @case($torrentRequest->torrent_id !== null && $torrentRequest->approved_when === null)
                                             <i class="fas fa-circle text-purple"></i>
                                             {{ __('request.pending') }}
 

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -51,7 +51,7 @@
 
                     @break
                     {{-- Pending --}}
-                @case($torrentRequest->torrent_id !== null && $torrentRequest->approved_by === null)
+                @case($torrentRequest->torrent_id !== null && $torrentRequest->approved_when === null)
                     @include('requests.partials.report')
                     @includeWhen($user->group->is_modo, 'requests.partials.edit')
                     @includeWhen($user->group->is_modo, 'requests.partials.delete')
@@ -111,7 +111,7 @@
                             {{ __('request.claimed') }}
 
                             @break
-                        @case($torrentRequest->torrent !== null && $torrentRequest->approved_by === null)
+                        @case($torrentRequest->torrent !== null && $torrentRequest->approved_when === null)
                             <i class="fas fa-circle text-purple"></i>
                             {{ __('request.pending') }}
 
@@ -207,7 +207,7 @@
                         </dd>
                     </div>
                 </dl>
-                @if ($torrentRequest->approved_by === null && ($torrentRequest->user_id == $user->id || auth()->user()->group->is_modo))
+                @if ($torrentRequest->approved_when === null && ($torrentRequest->user_id == $user->id || auth()->user()->group->is_modo))
                     <div class="panel__body">
                         <div class="form__group">
                             <form

--- a/resources/views/stats/requests/bountied.blade.php
+++ b/resources/views/stats/requests/bountied.blade.php
@@ -52,7 +52,7 @@
                                         class="{{ config('other.font-awesome') }} fa-times-circle text-danger"
                                         title="{{ __('stat.request-not-fulfilled') }}"
                                     ></i>
-                                @elseif ($request->torrent_id !== null && $request->approved_by === null)
+                                @elseif ($request->torrent_id !== null && $request->approved_when === null)
                                     <i
                                         class="{{ config('other.font-awesome') }} fa-question-circle text-info"
                                         title="{{ __('stat.request-pending-aproval') }}"


### PR DESCRIPTION
Use the timestamp instead of the user id as it doesn't disappear when the user is (soft) deleted. The `whereDoesntHave` is the real issue here since it handles soft deletion, but since users are also deletable, handle all cases where it checks the field directly as well to instead use the timestamp.