### PR TITLE
(Fix) See more of the error message in github ci

### DIFF
--- a/.github/workflows/phpunit-test.yml
+++ b/.github/workflows/phpunit-test.yml
@@ -63,7 +63,7 @@ jobs:
             -   name: Clear Application Cache
                 run: php artisan clear:all_cache
             -   name: Run PHPUnit Tests
-                run: ./vendor/bin/pest --compact --coverage --parallel --processes=4 --bail
+                run: COLUMNS=200 ./vendor/bin/pest --compact --coverage --parallel --processes=4 --bail
                 env:
                     DB_CONNECTION: mysql
                     DB_PORT: ${{ job.services.mysql.ports['3306'] }}


### PR DESCRIPTION
Github actions by default uses 80 character width, which mean most error messages are truncated making it very difficult to determine what the error is. Wrapping doesn't look to be an option: https://rich.readthedocs.io/en/stable/console.html#environment-variables.