### PR TITLE
(Fix) Occasional tmdb ssl errors break `fetch:meta` command

### DIFF
--- a/app/Console/Commands/FetchMeta.php
+++ b/app/Console/Commands/FetchMeta.php
@@ -68,8 +68,13 @@ class FetchMeta extends Command
 
         foreach ($tmdbMovieIds as $id) {
             usleep(250_000);
-            ProcessMovieJob::dispatchSync($id);
-            $this->info("Movie metadata fetched for tmdb {$id}");
+
+            try {
+                ProcessMovieJob::dispatchSync($id);
+                $this->info("Movie metadata fetched for tmdb {$id}");
+            } catch (Exception $e) {
+                $this->warn("Movie metadata fetch failed for tmdb {$id}: ".$e->getMessage());
+            }
         }
 
         $this->info('Querying all tmdb tv ids');
@@ -85,8 +90,13 @@ class FetchMeta extends Command
 
         foreach ($tmdbTvIds as $id) {
             usleep(250_000);
-            ProcessTvJob::dispatchSync($id);
-            $this->info("TV metadata fetched for tmdb {$id}");
+
+            try {
+                ProcessTvJob::dispatchSync($id);
+                $this->info("TV metadata fetched for tmdb {$id}");
+            } catch (Exception $e) {
+                $this->warn("TV metadata fetch failed for tmdb {$id}: ".$e->getMessage());
+            }
         }
 
         $this->info('Querying all igdb game ids');
@@ -102,8 +112,13 @@ class FetchMeta extends Command
 
         foreach ($igdbGameIds as $id) {
             usleep(250_000);
-            ProcessIgdbGameJob::dispatchSync($id);
-            $this->info("Game metadata fetched for igdb {$id}");
+
+            try {
+                ProcessIgdbGameJob::dispatchSync($id);
+                $this->info("Game metadata fetched for igdb {$id}");
+            } catch (Exception $e) {
+                $this->warn("Game metadata fetch failed for igdb {$id}: ".$e->getMessage());
+            }
         }
 
         $this->alert('Meta fetch queueing complete in '.now()->floatDiffInSeconds($start).'s.');

--- a/app/Services/Tmdb/Client/Collection.php
+++ b/app/Services/Tmdb/Client/Collection.php
@@ -57,6 +57,7 @@ class Collection
     public function __construct(int $id)
     {
         $this->data = Http::acceptJson()
+            ->retry([1000, 5000, 15000])
             ->withUrlParameters(['id' => $id])
             ->get('https://api.TheMovieDB.org/3/collection/{id}', [
                 'api_key'            => config('api-keys.tmdb'),

--- a/app/Services/Tmdb/Client/Company.php
+++ b/app/Services/Tmdb/Client/Company.php
@@ -42,6 +42,7 @@ class Company
         $this->tmdb = new TMDB();
 
         $this->data = Http::acceptJson()
+            ->retry([1000, 5000, 15000])
             ->withUrlParameters(['id' => $id])
             ->get('https://api.TheMovieDB.org/3/company/{id}', [
                 'api_key'            => config('api-keys.tmdb'),

--- a/app/Services/Tmdb/Client/Movie.php
+++ b/app/Services/Tmdb/Client/Movie.php
@@ -242,6 +242,7 @@ class Movie
     public function __construct(int $id)
     {
         $this->data = Http::acceptJson()
+            ->retry([1000, 5000, 15000])
             ->withUrlParameters(['id' => $id])
             ->get('https://api.TheMovieDB.org/3/movie/{id}', [
                 'api_key'            => config('api-keys.tmdb'),

--- a/app/Services/Tmdb/Client/Network.php
+++ b/app/Services/Tmdb/Client/Network.php
@@ -53,6 +53,7 @@ class Network
     public function __construct(int $id)
     {
         $this->data = Http::acceptJson()
+            ->retry([1000, 5000, 15000])
             ->withUrlParameters(['id' => $id])
             ->get('https://api.TheMovieDB.org/3/network/{id}', [
                 'api_key'            => config('api-keys.tmdb'),

--- a/app/Services/Tmdb/Client/Person.php
+++ b/app/Services/Tmdb/Client/Person.php
@@ -46,6 +46,7 @@ class Person
     public function __construct(int $id)
     {
         $this->data = Http::acceptJson()
+            ->retry([1000, 5000, 15000])
             ->withUrlParameters(['id' => $id])
             ->get('https://api.TheMovieDB.org/3/person/{id}', [
                 'api_key'            => config('api-keys.tmdb'),

--- a/app/Services/Tmdb/Client/TV.php
+++ b/app/Services/Tmdb/Client/TV.php
@@ -302,6 +302,7 @@ class TV
     public function __construct(int $id)
     {
         $this->data = Http::acceptJson()
+            ->retry([1000, 5000, 15000])
             ->withUrlParameters(['id' => $id])
             ->get('https://api.TheMovieDB.org/3/tv/{id}', [
                 'api_key'            => config('api-keys.tmdb'),


### PR DESCRIPTION
Sometimes, there is an ssl error from tmdb (Once every few hundred thousand http requests). When this happens, because the jobs are processed synchronously to avoid dos'ing tmdb, it throws an exception and kills the command. Instead, allow the http requests to be retried, and skip the fetch if it still fails after 3 retries.