### PR TITLE
(Update) Include user group freeleech when searching for freeleech

### DIFF
--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -313,8 +313,7 @@ readonly class TorrentSearchFiltersDTO
                 $this->free !== [],
                 fn ($query) => $query
                     ->when(
-                        config('other.freeleech'),
-                        fn ($query) => $query->whereBetween('free', [0, 100]),
+                        !(config('other.freeleech') || $this->user->group->is_freeleech),
                         fn ($query) => $query->where(
                             fn ($query) => $query
                                 ->whereIntegerInRaw('free', (array) $this->free)
@@ -611,7 +610,7 @@ readonly class TorrentSearchFiltersDTO
         }
 
         if ($this->free !== []) {
-            if (!config('other.freeleech')) {
+            if (!(config('other.freeleech') || $this->user->group->is_freeleech)) {
                 if (\in_array(100, $this->free, false)) {
                     $filters[] = [
                         'free IN '.json_encode(array_map('intval', $this->free)),


### PR DESCRIPTION
If we're including global freeleech in this filter, then user group freeleech should probably also be included.