### PR TITLE
(Update) Set aria-valuemax to 100 instead of donation goal

### DIFF
--- a/resources/views/partials/top-nav.blade.php
+++ b/resources/views/partials/top-nav.blade.php
@@ -225,7 +225,7 @@
                                 "
                                 aria-valuenow="{{ $donationPercentage }}"
                                 aria-valuemin="0"
-                                aria-valuemax="{{ config('donation.monthly_goal') }}"
+                                aria-valuemax="100"
                             ></div>
                         </div>
                     </div>


### PR DESCRIPTION
The aria values do seem to just be accessibility practices but the current logic is to set the valuenow to the donation **percentage** while setting the valuemax to the donation **goal**  which seems like a mistake that unexpectedly discloses donation goals.