### PR TITLE
(Fix) Avatar styles on playlist page

### DIFF
--- a/resources/sass/components/_playlist.scss
+++ b/resources/sass/components/_playlist.scss
@@ -21,10 +21,19 @@
     background: #0008;
     backdrop-filter: blur(5px);
     display: grid;
-    grid-template: 'author' 'description' / 1fr;
+    grid-template: 'avatar author' 'description description' / auto 1fr;
     align-items: center;
     gap: 1.5rem;
     color: #fff;
+}
+
+.playlist__author-link {
+    grid-area: avatar;
+}
+
+.playlist__author-avatar {
+    width: 50px;
+    border-radius: 50%;
 }
 
 .playlist__author {


### PR DESCRIPTION
The `playlist__` styles shouldn't have been changed in #4650. The `playlists__` styles are correct however.