### PR TITLE
(Fix) Don't hardcode websockets port in csp config

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -487,8 +487,8 @@ return [
             'self' => true,
 
             'allow' => [
-                'https://'.parse_url(env('APP_URL'), PHP_URL_HOST).':8443/socket.io/',
-                'wss://'.parse_url(env('APP_URL'), PHP_URL_HOST).':8443/socket.io/',
+                'https://'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT)).'/socket.io/',
+                'wss://'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT)).'/socket.io/',
                 'https://api.themoviedb.org/',
             ],
         ],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -867,7 +867,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$url of function parse_url expects string, bool\|string\|null given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 6
 			path: config/secure-headers.php
 
 		-


### PR DESCRIPTION
Allows using websocket on other ports specified in the VITE_ECHO_ADDRESS env variable.