### PR TITLE
(Update) Exclude cheated torrents under 5% the torrent size

### DIFF
--- a/app/Http/Controllers/Staff/CheatedTorrentController.php
+++ b/app/Http/Controllers/Staff/CheatedTorrentController.php
@@ -70,7 +70,9 @@ class CheatedTorrentController extends Controller
                         ->orWhereColumn(DB::raw('DATE_SUB(NOW(), INTERVAL 1 HOUR)'), '<', 'created_at')
                         ->orWhereColumn(DB::raw('DATE_SUB(NOW(), INTERVAL 1 HOUR)'), '<', 'completed_at')
                 )
-                ->having('current_balance', '<>', 0)
+                // Tolerance of 5%
+                // @phpstan-ignore argument.type (This function works with DB::raw() even though larastan doesn't think so)
+                ->havingBetween('current_balance', [DB::raw('-0.05 * size'), DB::raw('0.05 * size')], 'and', true)
                 ->orderByDesc('times_cheated')
                 ->paginate(25),
         ]);


### PR DESCRIPTION
Less false positives caused by different clients providing different traffic stats depending on if a downloaded piece is corrupted and retries or similar.