### PR TITLE
(Fix) Refresh meta button

### DIFF
--- a/app/Http/Controllers/SimilarTorrentController.php
+++ b/app/Http/Controllers/SimilarTorrentController.php
@@ -25,7 +25,6 @@ use App\Models\TmdbTv;
 use App\Services\Igdb\IgdbScraper;
 use App\Services\Tmdb\TMDBScraper;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 
 class SimilarTorrentController extends Controller
 {
@@ -125,25 +124,6 @@ class SimilarTorrentController extends Controller
             return to_route('torrents.similar', ['category_id' => $category->id, 'tmdb' => $metaId])
                 ->withErrors('There exists no torrent with this tmdb.');
         }
-
-        /** @phpstan-ignore match.unhandled (The first line of this method ensures that at least one of these are true) */
-        $cacheKey = match (true) {
-            $category->movie_meta => "tmdb-movie-scraper:{$metaId}",
-            $category->tv_meta    => "tmdb-tv-scraper:{$metaId}",
-            $category->game_meta  => "igdb-game-scraper:{$metaId}",
-        };
-
-        /** @var ?Carbon $lastUpdated */
-        $lastUpdated = cache()->get($cacheKey);
-
-        abort_if(
-            $lastUpdated !== null
-            && $lastUpdated->addDay()->isFuture()
-            && !($request->user()->group->is_modo || $request->user()->group->is_torrent_modo || $request->user()->group->is_editor),
-            403
-        );
-
-        cache()->put($cacheKey, now(), now()->addDay());
 
         /** @phpstan-ignore match.unhandled (The first line of this method ensures that at least one of these are true) */
         match (true) {

--- a/resources/views/torrent/partials/game-meta.blade.php
+++ b/resources/views/torrent/partials/game-meta.blade.php
@@ -76,7 +76,7 @@
                         @method('PATCH')
 
                         <button
-                            @if (cache()->has('igdb-game-scraper:' . ($meta?->id ?? $torrent->igdb)) && ! auth()->user()->group->is_modo)
+                            @if (cache()->has('igdb-game-scraper:' . ($meta?->id ?? $torrent->igdb)))
                                 disabled
                                 title="This item was recently updated. Try again tomorrow."
                             @endif

--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -89,7 +89,7 @@
                         @method('PATCH')
 
                         <button
-                            @if (cache()->has('tmdb-movie-scraper:' . ($meta?->id ?? $torrent->tmdb_movie_id)) && ! auth()->user()->group->is_modo)
+                            @if (cache()->has('tmdb-movie-scraper:' . ($meta?->id ?? $torrent->tmdb_movie_id)))
                                 disabled
                                 title="This item was recently updated. Try again tomorrow."
                             @endif

--- a/resources/views/torrent/partials/tv-meta.blade.php
+++ b/resources/views/torrent/partials/tv-meta.blade.php
@@ -88,7 +88,7 @@
                         @csrf
                         @method('PATCH')
                         <button
-                            @if (cache()->has('tmdb-tv-scraper:' . ($meta?->id ?? $torrent->tmdb_tv_id)) && ! auth()->user()->group->is_modo)
+                            @if (cache()->has('tmdb-tv-scraper:' . ($meta?->id ?? $torrent->tmdb_tv_id)))
                                 disabled
                                 title="This item was recently updated. Try again tomorrow."
                             @endif


### PR DESCRIPTION
Previously, the button would check if the cache key doesn't exist, then if so, add the cache key. But the middleware of ProcessMovieJob and ProcessTvJob will skip the update if the cache key is present.

Change the logic so that only the Job adds the cache key.

fixes #4745

Depends on #4747 