### PR TITLE
(Fix) Increase job timeout for tmdb tv fetching

### DIFF
--- a/app/Jobs/ProcessTvJob.php
+++ b/app/Jobs/ProcessTvJob.php
@@ -49,6 +49,22 @@ class ProcessTvJob implements ShouldQueue
     }
 
     /**
+     * The number of seconds the job can run before timing out.
+     *
+     * Some shows have 2000+ credits requiring more than the default of 60 seconds.
+     *
+     * @var int
+     */
+    public $timeout = 300;
+
+    /**
+     * Indicate if the job should be marked as failed on timeout.
+     *
+     * @var bool
+     */
+    public $failOnTimeout = true;
+
+    /**
      * Get the middleware the job should pass through.
      *
      * @return array<int, object>


### PR DESCRIPTION
Some shows have 2000+ credits requiring more than the default timeout of 60 seconds. Mark any timed out jobs as failed to make easier to debug future instances.