### PR TITLE
(Fix) Only cache tmdb fetching after successful fetch

### DIFF
--- a/app/Jobs/ProcessMovieJob.php
+++ b/app/Jobs/ProcessMovieJob.php
@@ -72,10 +72,6 @@ class ProcessMovieJob implements ShouldQueue
 
     public function handle(): void
     {
-        // TMDB caches their api responses for 8 hours, so don't abuse them
-
-        cache()->put("tmdb-movie-scraper:{$this->id}", now(), 8 * 3600);
-
         // Movie
 
         $movieScraper = new Client\Movie($this->id);
@@ -142,5 +138,9 @@ class ProcessMovieJob implements ShouldQueue
             ->where('tmdb_movie_id', '=', $this->id)
             ->whereRelation('category', 'movie_meta', '=', true)
             ->searchable();
+
+        // TMDB caches their api responses for 8 hours, so don't abuse them
+
+        cache()->put("tmdb-movie-scraper:{$this->id}", now(), 8 * 3600);
     }
 }

--- a/app/Jobs/ProcessTvJob.php
+++ b/app/Jobs/ProcessTvJob.php
@@ -72,10 +72,6 @@ class ProcessTvJob implements ShouldQueue
 
     public function handle(): void
     {
-        // TMDB caches their api responses for 8 hours, so don't abuse them
-
-        cache()->put("tmdb-tv-scraper:{$this->id}", now(), 8 * 3600);
-
         // Tv
 
         $tvScraper = new Client\TV($this->id);
@@ -144,5 +140,9 @@ class ProcessTvJob implements ShouldQueue
             ->where('tmdb_tv_id', '=', $this->id)
             ->whereRelation('category', 'tv_meta', '=', true)
             ->searchable();
+
+        // TMDB caches their api responses for 8 hours, so don't abuse them
+
+        cache()->put("tmdb-tv-scraper:{$this->id}", now(), 8 * 3600);
     }
 }


### PR DESCRIPTION
Instead of caching before, the job failing, and being unable to retry.