### PR TITLE
(Fix) Tmdb fetching when cache is empty

### DIFF
--- a/app/Jobs/ProcessMovieJob.php
+++ b/app/Jobs/ProcessMovieJob.php
@@ -129,7 +129,9 @@ class ProcessMovieJob implements ShouldQueue
 
         TmdbPerson::upsert($people, 'id');
 
-        cache()->put($cache, 8 * 3600);
+        if ($cache !== []) {
+            cache()->put($cache, 8 * 3600);
+        }
 
         TmdbCredit::where('tmdb_movie_id', '=', $this->id)->delete();
         TmdbCredit::upsert($credits, ['tmdb_person_id', 'tmdb_movie_id', 'tmdb_tv_id', 'occupation_id', 'character']);

--- a/app/Jobs/ProcessTvJob.php
+++ b/app/Jobs/ProcessTvJob.php
@@ -147,7 +147,9 @@ class ProcessTvJob implements ShouldQueue
 
         TmdbPerson::upsert($people, 'id');
 
-        cache()->put($cache, 8 * 3600);
+        if ($cache !== []) {
+            cache()->put($cache, 8 * 3600);
+        }
 
         TmdbCredit::where('tmdb_tv_id', '=', $this->id)->delete();
         TmdbCredit::upsert($credits, ['tmdb_person_id', 'tmdb_movie_id', 'tmdb_tv_id', 'occupation_id', 'character']);


### PR DESCRIPTION
Redis fails if no values are sent.

Looks like these changes got lost from yesterday.