### PR TITLE
(Refactor) Replace `users.active` with `users.email_verified_at`

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -59,7 +59,6 @@ class ResetUserPassword implements ResetsUserPasswords
             $user->markEmailAsVerified();
         }
 
-        $user->active = true;
         $user->save();
 
         $user->passwordResetHistories()->create();

--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -136,7 +136,7 @@ class RssController extends Controller
         $bannedGroup = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
         $disabledGroup = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
 
-        abort_if($user->group_id === $bannedGroup[0] || $user->group_id === $disabledGroup[0] || !$user->active, 404);
+        abort_if($user->group_id === $bannedGroup[0] || $user->group_id === $disabledGroup[0] || $user->email_verified_at === null, 404);
 
         $rss = Rss::query()
             ->where(

--- a/app/Http/Controllers/Staff/MassActionController.php
+++ b/app/Http/Controllers/Staff/MassActionController.php
@@ -40,7 +40,6 @@ class MassActionController extends Controller
         foreach (User::where('group_id', '=', $validatingGroup[0])->get() as $user) {
             $user->update([
                 'group_id'          => $memberGroup[0],
-                'active'            => 1,
                 'can_download'      => 1,
                 'email_verified_at' => now(),
             ]);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -39,7 +39,6 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
  * @property string|null                     $two_factor_confirmed_at
  * @property string                          $passkey
  * @property int                             $group_id
- * @property bool                            $active
  * @property int                             $uploaded
  * @property int                             $downloaded
  * @property string|null                     $image
@@ -112,7 +111,20 @@ class User extends Authenticatable implements MustVerifyEmail
     /**
      * Get the attributes that should be cast.
      *
-     * @return array{last_login: 'datetime', last_action: 'datetime', disabled_at: 'datetime', can_comment: 'bool', can_download: 'bool', can_request: 'bool', can_invite: 'bool', can_upload: 'bool', can_chat: 'bool', seedbonus: 'decimal:2', active: 'bool', is_donor: 'bool', is_lifetime: 'bool'}
+     * @return array{
+     *     last_login: 'datetime',
+     *     last_action: 'datetime',
+     *     disabled_at: 'datetime',
+     *     can_comment: 'bool',
+     *     can_download: 'bool',
+     *     can_request: 'bool',
+     *     can_invite: 'bool',
+     *     can_upload: 'bool',
+     *     can_chat: 'bool',
+     *     seedbonus: 'decimal:2',
+     *     is_donor: 'bool',
+     *     is_lifetime: 'bool'
+     * }
      */
     protected function casts(): array
     {
@@ -127,7 +139,6 @@ class User extends Authenticatable implements MustVerifyEmail
             'can_invite'   => 'bool',
             'can_upload'   => 'bool',
             'can_chat'     => 'bool',
-            'active'       => 'bool',
             'is_donor'     => 'bool',
             'is_lifetime'  => 'bool',
         ];

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -120,7 +120,6 @@ class FortifyServiceProvider extends ServiceProvider
                     if ($user->group_id === $validatingGroup[0]) {
                         $user->can_download = 1;
                         $user->group_id = $memberGroup[0];
-                        $user->active = true;
                         $user->save();
 
                         cache()->forget('user:'.$user->passkey);
@@ -211,7 +210,7 @@ class FortifyServiceProvider extends ServiceProvider
                 // Check if user is activated
                 $validatingGroup = cache()->rememberForever('validating_group', fn () => Group::query()->where('slug', '=', 'validating')->pluck('id'));
 
-                if ($user->active === false || $user->group_id === $validatingGroup[0]) {
+                if ($user->email_verified_at === null || $user->group_id === $validatingGroup[0]) {
                     $request->session()->invalidate();
 
                     throw ValidationException::withMessages([

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -44,7 +44,6 @@ class UserFactory extends Factory
             'password'          => Hash::make('password'),
             'passkey'           => md5(random_bytes(60)),
             'group_id'          => Group::factory(),
-            'active'            => true,
             'uploaded'          => $this->faker->randomNumber(),
             'downloaded'        => $this->faker->randomNumber(),
             'image'             => null,

--- a/database/migrations/2025_06_11_053944_alter_users_drop_active.php
+++ b/database/migrations/2025_06_11_053944_alter_users_drop_active.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('active');
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -2446,7 +2446,6 @@ CREATE TABLE `users` (
   `two_factor_confirmed_at` timestamp NULL DEFAULT NULL,
   `passkey` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `group_id` int NOT NULL,
-  `active` tinyint(1) NOT NULL DEFAULT '0',
   `uploaded` bigint unsigned NOT NULL DEFAULT '0',
   `downloaded` bigint unsigned NOT NULL DEFAULT '0',
   `image` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -2965,3 +2964,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (346,'2025_04_07_15
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (347,'2025_04_15_075631_add_description_to_playlist_categories',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (348,'2025_04_15_090705_create_playlist_suggestions',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (349,'2025_05_28_084740_update_torrent_balance',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (350,'2025_06_11_053944_alter_users_drop_active',1);

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -37,7 +37,6 @@ class UsersTableSeeder extends Seeder
                 'passkey'           => md5(random_bytes(60)),
                 'rsskey'            => md5(random_bytes(60)),
                 'api_token'         => Str::random(100),
-                'active'            => true,
             ],
             [
                 'id'                => 2,
@@ -49,7 +48,6 @@ class UsersTableSeeder extends Seeder
                 'passkey'           => md5(random_bytes(60)),
                 'rsskey'            => md5(random_bytes(60)),
                 'api_token'         => Str::random(100),
-                'active'            => true,
             ],
             [
                 'id'                => 3,
@@ -61,7 +59,6 @@ class UsersTableSeeder extends Seeder
                 'passkey'           => md5(random_bytes(60)),
                 'rsskey'            => md5(random_bytes(60)),
                 'api_token'         => Str::random(100),
-                'active'            => true,
             ],
         ], ['username'], ['updated_at' => DB::raw('updated_at')]);
     }

--- a/tests/Feature/Factories/UserFactoryTest.php
+++ b/tests/Feature/Factories/UserFactoryTest.php
@@ -37,7 +37,6 @@ test('user factory returns correct values when created', function (): void {
             'password',
             'passkey',
             'group_id',
-            'active',
             'uploaded',
             'downloaded',
             'image',

--- a/tests/Feature/Http/Controllers/Staff/PollControllerTest.php
+++ b/tests/Feature/Http/Controllers/Staff/PollControllerTest.php
@@ -39,7 +39,6 @@ test('create a poll returns an ok response', function (): void {
     ]);
     $staff = User::factory()->create([
         'group_id' => $group->id,
-        'active'   => 1,
     ]);
 
     $pollTitle = 'Test Poll Title';
@@ -84,7 +83,6 @@ test('create a poll with expiration date returns an ok response', function (): v
     ]);
     $staff = User::factory()->create([
         'group_id' => $group->id,
-        'active'   => 1,
     ]);
 
     $pollTitle = 'Test Poll Title';
@@ -157,7 +155,6 @@ test('index returns an ok response', function (): void {
     ]);
     $staff = User::factory()->create([
         'group_id' => $group->id,
-        'active'   => 1,
     ]);
 
     $response = $this->actingAs($staff)->get(route('staff.polls.index'));


### PR DESCRIPTION
This is the correct column intended to be used by the Laravel framework. `active` seems to be a custom column that was implemented in UNIT3D before Laravel added email verification in version 5.7.