### PR TITLE
(Update) Don't report tmdb meta fetch 404s exceptions in logs

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -36,6 +36,7 @@ class Handler extends ExceptionHandler
      */
     protected $dontReport = [
         \Illuminate\Queue\MaxAttemptsExceededException::class,
+        MetaFetchNotFoundException::class,
     ];
 
     /**

--- a/app/Exceptions/MetaFetchNotFoundException.php
+++ b/app/Exceptions/MetaFetchNotFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Exceptions;
+
+use Exception;
+
+class MetaFetchNotFoundException extends Exception
+{
+}

--- a/app/Services/Tmdb/Client/TV.php
+++ b/app/Services/Tmdb/Client/TV.php
@@ -17,7 +17,11 @@ declare(strict_types=1);
 namespace App\Services\Tmdb\Client;
 
 use App\Enums\Occupation;
+use App\Exceptions\MetaFetchNotFoundException;
 use App\Services\Tmdb\TMDB;
+use Exception;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 
@@ -301,15 +305,32 @@ class TV
      */
     public function __construct(int $id)
     {
-        $this->data = Http::acceptJson()
-            ->retry([1000, 5000, 15000])
+        // Adds extra logic for when a tmdb isn't found because it's a common
+        // error that admins don't want to deal with. Hides 404s from logs via
+        // App\Exceptions\Handler.php::dontReport, but still throws an exception
+        // when the job is dispatched in sync for the FetchMeta.php command.
+        $response = Http::acceptJson()
+            ->retry(
+                [1000, 5000, 15000],
+                when: fn (Exception $exception) => !($exception instanceof RequestException && $exception->response->notFound()),
+                throw: false
+            )
             ->withUrlParameters(['id' => $id])
             ->get('https://api.TheMovieDB.org/3/tv/{id}', [
                 'api_key'            => config('api-keys.tmdb'),
                 'language'           => config('app.meta_locale'),
                 'append_to_response' => 'videos,images,aggregate_credits,external_ids,keywords,recommendations,alternative_titles',
             ])
-            ->json();
+            ->throwIf(fn (Response $response) => !$response->notFound());
+
+        if ($response->notFound()) {
+            throw new MetaFetchNotFoundException(
+                $response->toException()->getMessage(),
+                $response->toException()->getCode()
+            );
+        }
+
+        $this->data = $response->json();
 
         $this->tmdb = new TMDB();
     }


### PR DESCRIPTION
But still report them in fetch:meta command.

fixes #4770