### PR TITLE
(Fix) chat_hidden to chat_visible migration

### DIFF
--- a/database/migrations/2025_06_18_000000_add_homepage_block_settings_to_user_settings_table.php
+++ b/database/migrations/2025_06_18_000000_add_homepage_block_settings_to_user_settings_table.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class () extends Migration {
@@ -40,5 +41,9 @@ return new class () extends Migration {
             $table->boolean('latest_comments_visible')->default(true)->after('latest_posts_visible');
             $table->boolean('online_visible')->default(true)->after('latest_comments_visible');
         });
+
+        DB::table('user_settings')->update([
+            'chat_visible' => DB::raw('NOT chat_visible'),
+        ]);
     }
 };


### PR DESCRIPTION
The column value needs to be inverted where it already exists. Any sites running the develpoment branch in production and have already ran this migration will need to run this additional query manually.