### PR TITLE
(Refactor) Swap null coalescing for default model in user settings

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -248,11 +248,11 @@ class TorrentSearch extends Component
     final public function mount(Request $request): void
     {
         if ($request->missing('sortField')) {
-            $this->sortField = auth()->user()->settings?->torrent_sort_field ?? 'bumped_at';
+            $this->sortField = auth()->user()->settings->torrent_sort_field;
         }
 
         if ($request->missing('view')) {
-            $this->view = match (auth()->user()->settings?->torrent_layout) {
+            $this->view = match (auth()->user()->settings->torrent_layout) {
                 1       => 'card',
                 2       => 'group',
                 3       => 'poster',

--- a/app/Http/Middleware/SetLanguage.php
+++ b/app/Http/Middleware/SetLanguage.php
@@ -67,7 +67,7 @@ class SetLanguage
     {
         $user = auth()->user();
 
-        if ($user->settings?->locale) {
+        if ($user->settings->locale) {
             $this->setLocale($user->settings->locale);
         } else {
             $this->setDefaultLocale();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -294,7 +294,30 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function settings(): \Illuminate\Database\Eloquent\Relations\HasOne
     {
-        return $this->hasOne(UserSetting::class);
+        return $this->hasOne(UserSetting::class)->withDefault([
+            'censor'                            => false,
+            'news_visible'                      => true,
+            'chat_visible'                      => true,
+            'featured_visible'                  => true,
+            'random_media_visible'              => true,
+            'poll_visible'                      => true,
+            'top_torrents_visible'              => true,
+            'top_users_visible'                 => true,
+            'latest_topics_visible'             => true,
+            'latest_posts_visible'              => true,
+            'latest_comments_visible'           => true,
+            'online_visible'                    => true,
+            'locale'                            => config('app.locale'),
+            'style'                             => config('other.default_style', 0),
+            'torrent_layout'                    => 0,
+            'torrent_filters'                   => false,
+            'custom_css'                        => null,
+            'standalone_css'                    => null,
+            'show_poster'                       => false,
+            'unbookmark_torrents_on_completion' => false,
+            'torrent_sort_field'                => 'bumped_at',
+            'torrent_search_autofocus'          => false,
+        ]);
     }
 
     /**

--- a/app/Repositories/ChatRepository.php
+++ b/app/Repositories/ChatRepository.php
@@ -98,7 +98,7 @@ class ChatRepository
 
     public function message(int $userId, int $roomId, string $message, ?int $receiver = null, ?int $bot = null): Message
     {
-        if ($this->user->find($userId)->settings?->censor) {
+        if ($this->user->find($userId)->settings->censor) {
             $message = $this->censorMessage($message);
         }
 
@@ -123,7 +123,7 @@ class ChatRepository
     {
         $user = $this->user->find($receiver);
 
-        if ($user->settings?->censor) {
+        if ($user->settings->censor) {
             $message = $this->censorMessage($message);
         }
 
@@ -151,7 +151,7 @@ class ChatRepository
 
     public function privateMessage(int $userId, int $roomId, string $message, ?int $receiver = null, ?int $bot = null, ?bool $ignore = null): Message
     {
-        if ($this->user->find($userId)->settings?->censor) {
+        if ($this->user->find($userId)->settings->censor) {
             $message = $this->censorMessage($message);
         }
 

--- a/resources/views/components/movie/card.blade.php
+++ b/resources/views/components/movie/card.blade.php
@@ -5,7 +5,7 @@
 
 <article class="torrent-search--grouped__result">
     <header class="torrent-search--grouped__header">
-        @if (auth()->user()->settings?->show_poster)
+        @if (auth()->user()->settings->show_poster)
             <a
                 href="{{ route('torrents.similar', ['category_id' => $media->category_id, 'tmdb' => $media->id]) }}"
                 class="torrent-search--grouped__poster"

--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -6,8 +6,8 @@
 
 <tr
     @class([
-        'torrent-search--list__row' => auth()->user()->settings?->show_poster,
-        'torrent-search--list__no-poster-row' => ! auth()->user()->settings?->show_poster,
+        'torrent-search--list__row' => auth()->user()->settings->show_poster,
+        'torrent-search--list__no-poster-row' => ! auth()->user()->settings->show_poster,
         'torrent-search--list__sticky-row' => $torrent->sticky,
     ])
     data-torrent-id="{{ $torrent->id }}"
@@ -21,7 +21,7 @@
     data-resolution-id="{{ $torrent->resolution_id }}"
     wire:key="torrent-search-row-{{ $torrent->id }}"
 >
-    @if (auth()->user()->settings?->show_poster)
+    @if (auth()->user()->settings->show_poster)
         <td class="torrent-search--list__poster">
             <a
                 href="{{

--- a/resources/views/components/tv/card.blade.php
+++ b/resources/views/components/tv/card.blade.php
@@ -5,7 +5,7 @@
 
 <article class="torrent-search--grouped__result" x-data="torrentGroup">
     <header class="torrent-search--grouped__header">
-        @if (auth()->user()->settings?->show_poster)
+        @if (auth()->user()->settings->show_poster)
             <a
                 href="{{ route('torrents.similar', ['category_id' => $media->category_id, 'tmdb' => $media->id]) }}"
                 class="torrent-search--grouped__poster"

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -3,50 +3,50 @@
 @section('page', 'page__home')
 
 @section('main')
-    @if ($user->settings?->news_visible)
+    @if ($user->settings->news_visible)
         @include('blocks.news')
     @endif
 
-    @if ($user->settings?->chat_visible)
+    @if ($user->settings->chat_visible)
         <div id="vue">
             @include('blocks.chat')
         </div>
         @vite('resources/js/unit3d/chat.js')
     @endif
 
-    @if ($user->settings?->featured_visible)
+    @if ($user->settings->featured_visible)
         @include('blocks.featured')
     @endif
 
-    @if ($user->settings?->random_media_visible)
+    @if ($user->settings->random_media_visible)
         @livewire('random-media')
     @endif
 
-    @if ($user->settings?->poll_visible)
+    @if ($user->settings->poll_visible)
         @include('blocks.poll')
     @endif
 
-    @if ($user->settings?->top_torrents_visible)
+    @if ($user->settings->top_torrents_visible)
         @livewire('top-torrents')
     @endif
 
-    @if ($user->settings?->top_users_visible)
+    @if ($user->settings->top_users_visible)
         @livewire('top-users')
     @endif
 
-    @if ($user->settings?->latest_topics_visible)
+    @if ($user->settings->latest_topics_visible)
         @include('blocks.latest-topics')
     @endif
 
-    @if ($user->settings?->latest_posts_visible)
+    @if ($user->settings->latest_posts_visible)
         @include('blocks.latest-posts')
     @endif
 
-    @if ($user->settings?->latest_comments_visible)
+    @if ($user->settings->latest_comments_visible)
         @include('blocks.latest-comments')
     @endif
 
-    @if ($user->settings?->online_visible)
+    @if ($user->settings->online_visible)
         @include('blocks.online')
     @endif
 @endsection

--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ auth()->user()->settings?->locale ?? config('app.locale') }}">
+<html lang="{{ auth()->user()->settings->locale }}">
     <head>
         @include('partials.head')
     </head>

--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -10,7 +10,7 @@
                         type="search"
                         autocomplete="off"
                         placeholder=" "
-                        @if (auth()->user()->settings?->torrent_search_autofocus)
+                        @if (auth()->user()->settings->torrent_search_autofocus)
                             autofocus
                         @endif
                     />

--- a/resources/views/livewire/torrent-search.blade.php
+++ b/resources/views/livewire/torrent-search.blade.php
@@ -9,7 +9,7 @@
                     wire:model.live="name"
                     class="form__text"
                     placeholder=" "
-                    @if (auth()->user()->settings?->torrent_search_autofocus)
+                    @if (auth()->user()->settings->torrent_search_autofocus)
                         autofocus
                     @endif
                 />
@@ -769,11 +769,11 @@
                         <thead>
                             <tr
                                 @class([
-                                    'torrent-search--list__headers' => auth()->user()->settings?->show_poster,
-                                    'torrent-search--list__no-poster-headers' => ! auth()->user()->settings?->show_poster,
+                                    'torrent-search--list__headers' => auth()->user()->settings->show_poster,
+                                    'torrent-search--list__no-poster-headers' => ! auth()->user()->settings->show_poster,
                                 ])
                             >
-                                @if (auth()->user()->settings?->show_poster)
+                                @if (auth()->user()->settings->show_poster)
                                     <th class="torrent-search--list__poster-header">Poster</th>
                                 @endif
 

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -14,10 +14,10 @@
 <link rel="shortcut icon" href="{{ url('/favicon.ico') }}" type="image/x-icon" />
 <link rel="icon" href="{{ url('/favicon.ico') }}" type="image/x-icon" />
 
-@if (auth()->user()->settings?->standalone_css === null)
+@if (auth()->user()->settings->standalone_css === null)
     @vite('resources/sass/main.scss')
 
-    @switch(auth()->user()->settings?->style ?? config('other.default_style', 0))
+    @switch(auth()->user()->settings->style)
         @case(0)
             @vite('resources/sass/themes/_light.scss')
 
@@ -92,11 +92,11 @@
             @break
     @endswitch
 
-    @if (isset(auth()->user()->settings?->custom_css))
-        <link rel="stylesheet" href="{{ auth()->user()->settings?->custom_css }}" />
+    @if (isset(auth()->user()->settings->custom_css))
+        <link rel="stylesheet" href="{{ auth()->user()->settings->custom_css }}" />
     @endif
 @else
-    <link rel="stylesheet" href="{{ auth()->user()->settings?->standalone_css }}" />
+    <link rel="stylesheet" href="{{ auth()->user()->settings->standalone_css }}" />
 @endif
 
 @livewireStyles

--- a/resources/views/user/general-setting/edit.blade.php
+++ b/resources/views/user/general-setting/edit.blade.php
@@ -42,7 +42,7 @@
                             <option
                                 class="form__option"
                                 value="{{ $code }}"
-                                @selected(($user->settings?->locale ?? config('app.locale')) === $code)
+                                @selected($user->settings->locale === $code)
                             >
                                 {{ $name }}
                             </option>
@@ -57,105 +57,105 @@
                             <option
                                 class="form__option"
                                 value="0"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 0)
+                                @selected($user->settings->style === 0)
                             >
                                 Light
                             </option>
                             <option
                                 class="form__option"
                                 value="1"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 1)
+                                @selected($user->settings->style === 1)
                             >
                                 Galactic
                             </option>
                             <option
                                 class="form__option"
                                 value="2"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 2)
+                                @selected($user->settings->style === 2)
                             >
                                 Dark Blue
                             </option>
                             <option
                                 class="form__option"
                                 value="3"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 3)
+                                @selected($user->settings->style === 3)
                             >
                                 Dark Green
                             </option>
                             <option
                                 class="form__option"
                                 value="4"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 4)
+                                @selected($user->settings->style === 4)
                             >
                                 Dark Pink
                             </option>
                             <option
                                 class="form__option"
                                 value="5"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 5)
+                                @selected($user->settings->style === 5)
                             >
                                 Dark Purple
                             </option>
                             <option
                                 class="form__option"
                                 value="6"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 6)
+                                @selected($user->settings->style === 6)
                             >
                                 Dark Red
                             </option>
                             <option
                                 class="form__option"
                                 value="7"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 7)
+                                @selected($user->settings->style === 7)
                             >
                                 Dark Teal
                             </option>
                             <option
                                 class="form__option"
                                 value="8"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 8)
+                                @selected($user->settings->style === 8)
                             >
                                 Dark Yellow
                             </option>
                             <option
                                 class="form__option"
                                 value="9"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 9)
+                                @selected($user->settings->style === 9)
                             >
                                 Cosmic Void
                             </option>
                             <option
                                 class="form__option"
                                 value="10"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 10)
+                                @selected($user->settings->style === 10)
                             >
                                 Nord
                             </option>
                             <option
                                 class="form__option"
                                 value="11"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 11)
+                                @selected($user->settings->style === 11)
                             >
                                 Revel (Desktop only)
                             </option>
                             <option
                                 class="form__option"
                                 value="12"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 12)
+                                @selected($user->settings->style === 12)
                             >
                                 Material Design 3 Light
                             </option>
                             <option
                                 class="form__option"
                                 value="13"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 13)
+                                @selected($user->settings->style === 13)
                             >
                                 Material Design 3 Dark
                             </option>
                             <option
                                 class="form__option"
                                 value="15"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 15)
+                                @selected($user->settings->style === 15)
                             >
                                 Material Design 3 Navy
                             </option>
@@ -163,7 +163,7 @@
                             <option
                                 class="form__option"
                                 value="14"
-                                @selected(($user->settings?->style ?? config('other.default_style', 0)) === 14)
+                                @selected($user->settings->style === 14)
                             >
                                 Material Design 3 Amoled
                             </option>
@@ -177,7 +177,7 @@
                             name="custom_css"
                             placeholder=" "
                             type="url"
-                            value="{{ $user->settings?->custom_css }}"
+                            value="{{ $user->settings->custom_css }}"
                         />
                         <label class="form__label form__label--floating" for="custom_css">
                             External CSS Stylesheet (Stacks on top of above theme)
@@ -190,7 +190,7 @@
                             name="standalone_css"
                             placeholder=" "
                             type="url"
-                            value="{{ $user->settings?->standalone_css }}"
+                            value="{{ $user->settings->standalone_css }}"
                         />
                         <label class="form__label form__label--floating" for="standalone_css">
                             Standalone CSS Stylesheet (No site theme used)
@@ -207,7 +207,7 @@
                                 type="checkbox"
                                 name="censor"
                                 value="1"
-                                @checked($user->settings?->censor)
+                                @checked($user->settings->censor)
                             />
                             Language Censor Chat
                         </label>
@@ -223,7 +223,7 @@
                                 type="checkbox"
                                 name="news_visible"
                                 value="1"
-                                @checked($user->settings?->news_visible)
+                                @checked($user->settings->news_visible)
                             />
                             {{ __('user.homepage-block-news-visible') }}
                         </label>
@@ -236,7 +236,7 @@
                                 type="checkbox"
                                 name="chat_visible"
                                 value="1"
-                                @checked($user->settings?->chat_visible)
+                                @checked($user->settings->chat_visible)
                             />
                             {{ __('user.homepage-block-chat-visible') }}
                         </label>
@@ -249,7 +249,7 @@
                                 type="checkbox"
                                 name="featured_visible"
                                 value="1"
-                                @checked($user->settings?->featured_visible)
+                                @checked($user->settings->featured_visible)
                             />
                             {{ __('user.homepage-block-featured-visible') }}
                         </label>
@@ -262,7 +262,7 @@
                                 type="checkbox"
                                 name="random_media_visible"
                                 value="1"
-                                @checked($user->settings?->random_media_visible)
+                                @checked($user->settings->random_media_visible)
                             />
                             {{ __('user.homepage-block-random-media-visible') }}
                         </label>
@@ -275,7 +275,7 @@
                                 type="checkbox"
                                 name="poll_visible"
                                 value="1"
-                                @checked($user->settings?->poll_visible)
+                                @checked($user->settings->poll_visible)
                             />
                             {{ __('user.homepage-block-poll-visible') }}
                         </label>
@@ -288,7 +288,7 @@
                                 type="checkbox"
                                 name="top_torrents_visible"
                                 value="1"
-                                @checked($user->settings?->top_torrents_visible)
+                                @checked($user->settings->top_torrents_visible)
                             />
                             {{ __('user.homepage-block-top-torrents-visible') }}
                         </label>
@@ -301,7 +301,7 @@
                                 type="checkbox"
                                 name="top_users_visible"
                                 value="1"
-                                @checked($user->settings?->top_users_visible)
+                                @checked($user->settings->top_users_visible)
                             />
                             {{ __('user.homepage-block-top-users-visible') }}
                         </label>
@@ -314,7 +314,7 @@
                                 type="checkbox"
                                 name="latest_topics_visible"
                                 value="1"
-                                @checked($user->settings?->latest_topics_visible)
+                                @checked($user->settings->latest_topics_visible)
                             />
                             {{ __('user.homepage-block-latest-topics-visible') }}
                         </label>
@@ -327,7 +327,7 @@
                                 type="checkbox"
                                 name="latest_posts_visible"
                                 value="1"
-                                @checked($user->settings?->latest_posts_visible)
+                                @checked($user->settings->latest_posts_visible)
                             />
                             {{ __('user.homepage-block-latest-posts-visible') }}
                         </label>
@@ -340,7 +340,7 @@
                                 type="checkbox"
                                 name="latest_comments_visible"
                                 value="1"
-                                @checked($user->settings?->latest_comments_visible)
+                                @checked($user->settings->latest_comments_visible)
                             />
                             {{ __('user.homepage-block-latest-comments-visible') }}
                         </label>
@@ -353,7 +353,7 @@
                                 type="checkbox"
                                 name="online_visible"
                                 value="1"
-                                @checked($user->settings?->online_visible)
+                                @checked($user->settings->online_visible)
                             />
                             {{ __('user.homepage-block-online-visible') }}
                         </label>
@@ -371,28 +371,28 @@
                             <option
                                 class="form__option"
                                 value="0"
-                                @selected($user->settings === null || $user->settings?->torrent_layout === 0)
+                                @selected($user->settings->torrent_layout === 0)
                             >
                                 Torrent list
                             </option>
                             <option
                                 class="form__option"
                                 value="1"
-                                @selected($user->settings?->torrent_layout === 1)
+                                @selected($user->settings->torrent_layout === 1)
                             >
                                 Torrent cards
                             </option>
                             <option
                                 class="form__option"
                                 value="2"
-                                @selected($user->settings?->torrent_layout === 2)
+                                @selected($user->settings->torrent_layout === 2)
                             >
                                 Torrent groupings
                             </option>
                             <option
                                 class="form__option"
                                 value="3"
-                                @selected($user->settings?->torrent_layout === 3)
+                                @selected($user->settings->torrent_layout === 3)
                             >
                                 Torrent posters
                             </option>
@@ -411,14 +411,14 @@
                             <option
                                 class="form__option"
                                 value="bumped_at"
-                                @selected($user->settings === null || $user->settings?->torrent_sort_field === 'bumped_at')
+                                @selected($user->settings->torrent_sort_field === 'bumped_at')
                             >
                                 Most recently bumped
                             </option>
                             <option
                                 class="form__option"
                                 value="created_at"
-                                @selected($user->settings?->torrent_sort_field === 'created_at')
+                                @selected($user->settings->torrent_sort_field === 'created_at')
                             >
                                 Most recently uploaded
                             </option>
@@ -436,7 +436,7 @@
                                     type="checkbox"
                                     name="show_poster"
                                     value="1"
-                                    @checked($user->settings?->show_poster)
+                                    @checked($user->settings->show_poster)
                                 />
                                 Show Posters On Torrent List View
                             </label>
@@ -449,7 +449,7 @@
                                     type="checkbox"
                                     name="torrent_search_autofocus"
                                     value="1"
-                                    @checked($user->settings?->torrent_search_autofocus)
+                                    @checked($user->settings->torrent_search_autofocus)
                                 />
                                 Autofocus torrent search on page load
                             </label>
@@ -466,7 +466,7 @@
                                     type="checkbox"
                                     name="unbookmark_torrents_on_completion"
                                     value="1"
-                                    @checked($user->settings?->unbookmark_torrents_on_completion)
+                                    @checked($user->settings->unbookmark_torrents_on_completion)
                                 />
                                 Automatically unbookmark torrents upon completion
                             </label>


### PR DESCRIPTION
Cleans up the code to remove null coalescing on user_settings when it doesn't exist. Sometimes null was unintentionally being cast to false. Allowing the user_setting remain optional allows the site administration to configure and change defaults for their users without it affecting users who have explicitly chosen their existing user settings.

Alternative to #4789