### PR TITLE
(Refactor) Normalize request votes

### DIFF
--- a/app/Http/Controllers/BountyController.php
+++ b/app/Http/Controllers/BountyController.php
@@ -50,7 +50,6 @@ class BountyController extends Controller
 
         $torrentRequest->increment('bounty', $request->integer('seedbonus'));
 
-        $torrentRequest->votes++;
         $torrentRequest->created_at = now();
         $torrentRequest->save();
 

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -134,7 +134,7 @@ class RequestController extends Controller
 
         $user->decrement('seedbonus', $request->bounty);
 
-        $torrentRequest = TorrentRequest::create(['user_id' => $request->user()->id, 'votes' => 1] + $request->validated());
+        $torrentRequest = TorrentRequest::create(['user_id' => $request->user()->id] + $request->validated());
 
         TorrentRequestBounty::create([
             'user_id'     => $user->id,

--- a/app/Http/Livewire/TorrentRequestSearch.php
+++ b/app/Http/Livewire/TorrentRequestSearch.php
@@ -208,7 +208,7 @@ class TorrentRequestSearch extends Component
             && @preg_match($field, 'Validate regex') !== false;
 
         return TorrentRequest::with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
-            ->withCount(['comments'])
+            ->withCount(['comments', 'bounties'])
             ->withExists('claim')
             ->when(
                 $this->name !== '',

--- a/app/Models/TorrentRequest.php
+++ b/app/Models/TorrentRequest.php
@@ -35,8 +35,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property string                          $description
  * @property int                             $user_id
  * @property string                          $bounty
- * @property int                             $votes
- * @property int|null                        $claimed
  * @property bool                            $anon
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at

--- a/database/factories/TorrentRequestFactory.php
+++ b/database/factories/TorrentRequestFactory.php
@@ -49,7 +49,6 @@ class TorrentRequestFactory extends Factory
             'description'   => $this->faker->text(),
             'user_id'       => User::factory(),
             'bounty'        => $this->faker->randomFloat(),
-            'votes'         => $this->faker->randomNumber(),
             'anon'          => $this->faker->boolean(),
             'filled_by'     => User::factory(),
             'torrent_id'    => Torrent::factory(),

--- a/database/migrations/2025_06_21_234021_alter_requests_drop_votes.php
+++ b/database/migrations/2025_06_21_234021_alter_requests_drop_votes.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('requests', function (Blueprint $table): void {
+            $table->dropColumn('votes');
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -1432,7 +1432,6 @@ CREATE TABLE `requests` (
   `tmdb_movie_id` int unsigned DEFAULT NULL,
   `tmdb_tv_id` int unsigned DEFAULT NULL,
   `bounty` decimal(12,2) NOT NULL,
-  `votes` int NOT NULL DEFAULT '0',
   `anon` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
@@ -2993,3 +2992,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (352,'2025_06_17_08
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (353,'2025_06_17_092951_create_unread_articles_table',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (354,'2025_06_18_000000_add_homepage_block_settings_to_user_settings_table',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (355,'2025_06_18_040627_alter_requests_drop_claimed',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (356,'2025_06_21_234021_alter_requests_drop_votes',1);

--- a/resources/views/livewire/torrent-request-search.blade.php
+++ b/resources/views/livewire/torrent-request-search.blade.php
@@ -38,9 +38,9 @@
                                 {{ __('common.author') }}
                                 @include('livewire.includes._sort-icon', ['field' => 'user_id'])
                             </th>
-                            <th wire:click="sortBy('votes')" role="columnheader button">
+                            <th wire:click="sortBy('bounties_count')" role="columnheader button">
                                 <i class="{{ config('other.font-awesome') }} fa-thumbs-up"></i>
-                                @include('livewire.includes._sort-icon', ['field' => 'votes'])
+                                @include('livewire.includes._sort-icon', ['field' => 'bounties_count'])
                             </th>
                             <th>
                                 <i
@@ -77,7 +77,7 @@
                                         :anon="$torrentRequest->anon"
                                     />
                                 </td>
-                                <td>{{ $torrentRequest->votes }}</td>
+                                <td>{{ $torrentRequest->bounties_count }}</td>
                                 <td>{{ $torrentRequest->comments_count }}</td>
                                 <td>{{ number_format($torrentRequest->bounty) }}</td>
                                 <td>


### PR DESCRIPTION
Cleans up the code and better normalization practice. Should this ever be a performance issue (such as sorting by vote count on request search page), then it'd probably be better to use meilisearch, but currently with 60k bounties, the query time only takes ~300ms compared to the 40ms previously.