### PR TITLE
(Fix) Only reset unapproved requests when torrent is deleted

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -298,7 +298,7 @@ class TorrentController extends Controller
         );
 
         // Reset Requests
-        $torrent->requests()->update([
+        $torrent->requests()->whereNull('approved_when')->update([
             'torrent_id' => null,
         ]);
 

--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -489,7 +489,7 @@ class SimilarTorrent extends Component
             }
 
             // Reset Requests
-            $torrent->requests()->update([
+            $torrent->requests()->whereNull('approved_when')->update([
                 'torrent_id' => null,
             ]);
 


### PR DESCRIPTION
If the request has already been paid out, it should not be reset.