### PR TITLE
(Fix) Remove browser outline on quick search result focus

### DIFF
--- a/resources/sass/components/_quick_search.scss
+++ b/resources/sass/components/_quick_search.scss
@@ -89,6 +89,7 @@
 
 .quick-search__result-link {
     padding: 4px 8px;
+    outline: 0;
 }
 
 .quick-search__result--empty,


### PR DESCRIPTION
We already have our own custom focus styles, and the browser's default styles mess with the appearance.