### PR TITLE
(Fix) Trending download count color on light themes

### DIFF
--- a/resources/sass/pages/_trending.scss
+++ b/resources/sass/pages/_trending.scss
@@ -19,6 +19,7 @@
     grid-area: 2 / 3 / 1 / 2;
     border-radius: 9999px;
     margin: 6px;
+    color: #ddd;
     background: #161a42;
     border: 2px solid #73904b;
     height: 36px;


### PR DESCRIPTION
All the other values are hardcoded, so the foreground color can't be dynamic. Otherwise, when the dynamic foreground color ends up being the same color as the hardcoded background, the text is illegible.