### PR TITLE
(Fix) Search for tmdb != 0 instead of tmdb > 0

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -569,7 +569,7 @@ class TorrentSearch extends Component
                 ->index(config('scout.prefix').'torrents')
                 ->search($this->name, [
                     'sort'                 => ['sticky:desc', $this->sortField.':'.$this->sortDirection,],
-                    'filter'               => [...$this->filters()->toMeilisearchFilter(), 'imdb != 0', ['tmdb_movie_id > 0', 'tmdb_tv_id > 0']],
+                    'filter'               => [...$this->filters()->toMeilisearchFilter(), 'imdb != 0', ['tmdb_movie_id != 0', 'tmdb_tv_id != 0']],
                     'matchingStrategy'     => 'all',
                     'page'                 => (int) $this->getPage(),
                     'hitsPerPage'          => min($this->perPage, 100),


### PR DESCRIPTION
We changed the indexes in #4458 to not use orderable filters for this field anymore.