### PR TITLE
(Remove) Redundant chatbox bbcode size validation

### DIFF
--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -27,7 +27,6 @@ const messageHandler = {
     },
 
     create(message, context, save = true, user_id = 1, receiver_id = null, bot_id = null) {
-        if (/\[size=[0-9]{3,}\]/.test(message)) return;
         if (!message || message.trim() === '') return;
 
         return axios


### PR DESCRIPTION
We already clamp the font size when converting the bbcode to html. Also, we don't validate this anywhere else such as forum posts or torrent descriptions.