### PR TITLE
(Remove) Chatbox active message limit

### DIFF
--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -47,12 +47,6 @@ const messageHandler = {
                 ) {
                     context.messages.push(response.data.data);
                 }
-                if (context.messages.length > (context.config.message_limit || 100)) {
-                    context.messages.splice(
-                        0,
-                        context.messages.length - (context.config.message_limit || 100),
-                    );
-                }
                 if (context.$refs && context.$refs.message) {
                     context.$refs.message.value = '';
                 }


### PR DESCRIPTION
This functionality never worked in the vue.js chatbox and personally would rather chatbox not function like this. This functionality truncates the chatbox to the latest 100 messages every time you send a message.