### PR TITLE
(Remove) Chatbox frozen attribute

### DIFF
--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -182,7 +182,6 @@ document.addEventListener('alpine:init', () => {
         audibles: [],
         boot: 0,
         activePeer: new Map(),
-        frozen: false,
         scroll: true,
         channel: null,
         chatter: null,


### PR DESCRIPTION
This attribute was used to prevent chatbox scrolling while hovering over it and new messages are received back when JS was used to prevent this. In 7487869, it was changed from JS to a combination of HTML and CSS, so it's no longer needed.