### PR TITLE
(Remove) Chatbox connecting status

### DIFF
--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -93,7 +93,6 @@ const channelHandler = {
 
         context.channel
             .here((users) => {
-                context.state.ui.connecting = false;
                 context.users = users;
             })
             .joining((user) => {
@@ -140,7 +139,6 @@ document.addEventListener('alpine:init', () => {
     Alpine.data('chatbox', (user) => ({
         state: {
             ui: {
-                connecting: true,
                 loading: true,
                 fullscreen: false,
                 error: null,
@@ -306,23 +304,19 @@ document.addEventListener('alpine:init', () => {
 
         async fetchBotMessages(id) {
             try {
-                this.state.ui.connecting = true;
                 const response = await axios.get(`/api/chat/bot/${id}`);
                 // Process messages to add canMod property for each message and sanitize content
                 this.messages = response.data.data
                     .map((message) => this.processMessageCanMod(message))
                     .reverse();
-                this.state.ui.connecting = false;
             } catch (error) {
                 console.error('Error fetching bot messages:', error);
-                this.state.ui.connecting = false;
                 throw error;
             }
         },
 
         async fetchPrivateMessages() {
             try {
-                this.state.ui.connecting = true;
                 const response = await axios.get(
                     `/api/chat/private/messages/${this.state.chat.target}`,
                 );
@@ -330,26 +324,21 @@ document.addEventListener('alpine:init', () => {
                 this.messages = response.data.data
                     .map((message) => this.processMessageCanMod(message))
                     .reverse();
-                this.state.ui.connecting = false;
             } catch (error) {
                 console.error('Error fetching private messages:', error);
-                this.state.ui.connecting = false;
                 throw error;
             }
         },
 
         async fetchMessages() {
             try {
-                this.state.ui.connecting = true;
                 const response = await axios.get(`/api/chat/messages/${this.state.chat.room}`);
                 // Process messages to add canMod property for each message and sanitize content
                 this.messages = response.data.data
                     .map((message) => this.processMessageCanMod(message))
                     .reverse();
-                this.state.ui.connecting = false;
             } catch (error) {
                 console.error('Error fetching messages:', error);
-                this.state.ui.connecting = false;
                 throw error;
             }
         },

--- a/resources/views/blocks/chat.blade.php
+++ b/resources/views/blocks/chat.blade.php
@@ -229,7 +229,7 @@
                 </li>
             </template>
         </menu>
-        <div class="chatbox__chatroom" x-show="!state.ui.connecting">
+        <div class="chatbox__chatroom">
             <template x-if="state.chat.tab !== ''">
                 <div class="chatroom__messages--wrapper" x-ref="messagesWrapper">
                     <ul class="chatroom__messages">


### PR DESCRIPTION
It causes a flash of content disappearing and reappearing. It looks far better for the old messages to remain on the screen for an extra half second then to hide the messages when switching chatbox tabs. It also looks better when first loading the home page to have no messages at first and have a blank chatbox window for half a second instead of the chatbox window disappearing. When this happens, the featured torrents flash in to fill up the empty space which looks glitchy.