### PR TITLE
(Fix) Grouped search pagination

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -554,22 +554,22 @@ class TorrentSearch extends Component
                 END) AS meta
             SQL)
             ->havingNotNull('meta')
-            ->where(fn ($query) => $query->where('tmdb_movie_id', '>', 0)->orWhere('tmdb_tv_id', '>', 0))
-            ->where('imdb', '>', 0)
-            ->where($this->filters()->toSqlQueryBuilder())
+            ->where(fn ($query) => $query->whereNotNull('tmdb_movie_id')->orWhereNotNull('tmdb_tv_id'))
+            ->whereNotNull('imdb')
             ->groupBy('tmdb_movie_id', 'tmdb_tv_id')
             ->latest('sticky')
             ->orderBy($this->sortField, $this->sortDirection);
 
         if ($isSqlAllowed) {
             $groups = $groupQuery
+                ->where($this->filters()->toSqlQueryBuilder())
                 ->paginate(min($this->perPage, 100));
         } else {
             $results = (new Client(config('scout.meilisearch.host'), config('scout.meilisearch.key')))
                 ->index(config('scout.prefix').'torrents')
                 ->search($this->name, [
                     'sort'                 => ['sticky:desc', $this->sortField.':'.$this->sortDirection,],
-                    'filter'               => [...$this->filters()->toMeilisearchFilter(), 'imdb != 0', ['tmdb_movie_id != 0', 'tmdb_tv_id != 0']],
+                    'filter'               => [...$this->filters()->toMeilisearchFilter(), 'imdb IS NOT NULL', ['tmdb_movie_id IS NOT NULL', 'tmdb_tv_id IS NOT NULL']],
                     'matchingStrategy'     => 'all',
                     'page'                 => (int) $this->getPage(),
                     'hitsPerPage'          => min($this->perPage, 100),
@@ -689,7 +689,7 @@ class TorrentSearch extends Component
                             ->whereIntegerInRaw('tmdb_tv_id', $tvIds)
                     )
             )
-            ->where($this->filters()->toSqlQueryBuilder())
+            ->when($isSqlAllowed, fn ($query) => $query->where($this->filters()->toSqlQueryBuilder()))
             ->get();
 
         $groupedTorrents = [];
@@ -866,7 +866,7 @@ class TorrentSearch extends Component
                 END) AS meta
             SQL)
             ->havingNotNull('meta')
-            ->where(fn ($query) => $query->where('tmdb_movie_id', '!=', 0)->orWhere('tmdb_tv_id', '!=', 0))
+            ->where(fn ($query) => $query->whereNotNull('tmdb_movie_id')->orWhereNotNull('tmdb_tv_id'))
             ->where($this->filters()->toSqlQueryBuilder())
             ->groupBy('tmdb_movie_id', 'tmdb_tv_id')
             ->latest('sticky')


### PR DESCRIPTION
Caused by the mysql and meilisearch filters not matching. The mysql filters were being applied to the torrent fetching, even though meilisearch was intended to be used to find the works, and mysql was to be used to find all torrents belonging to each word by its id. The main problem was any field using LIKE didn't match with meilisearch's search engine. This was fixed by appropriate conditionally applying the sql filters. Additionally, the torrents were filtering by `imdb > 0`, but meilisearch was including null imdbs when searching by `>` unlike mysql. Fixed that by changing it to `IS NOT NULL` instead.