### PR TITLE
(Fix) Group cache

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -68,8 +68,6 @@ class CreateNewUser implements CreatesNewUsers
             ]
         ])->validate();
 
-        $validatingGroupId = cache()->rememberForever('group:validating:id', fn () => Group::query()->where('slug', '=', 'validating')->soleValue('id'));
-
         $user = User::create([
             'username'   => $input['username'],
             'email'      => $input['email'],
@@ -78,7 +76,7 @@ class CreateNewUser implements CreatesNewUsers
             'rsskey'     => md5(random_bytes(60)),
             'uploaded'   => config('other.default_upload'),
             'downloaded' => config('other.default_download'),
-            'group_id'   => $validatingGroupId,
+            'group_id'   => Group::query()->where('slug', '=', 'validating')->soleValue('id'),
         ]);
 
         $user->passkeys()->create(['content' => $user->passkey]);

--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -44,11 +44,10 @@ class ResetUserPassword implements ResetsUserPasswords
             'password' => Hash::make($input['password']),
         ]);
 
-        $validatingGroupId = cache()->rememberForever('group:validating:id', fn () => Group::query()->where('slug', '=', 'validating')->soleValue('id'));
-        $memberGroupId = cache()->rememberForever('group:user:id', fn () => Group::query()->where('slug', '=', 'user')->soleValue('id'));
+        $validatingGroupId = Group::query()->where('slug', '=', 'validating')->soleValue('id');
 
         if ($user->group_id === $validatingGroupId) {
-            $user->group_id = $memberGroupId;
+            $user->group_id = Group::query()->where('slug', '=', 'user')->soleValue('id');
 
             cache()->forget('user:'.$user->passkey);
 

--- a/app/Console/Commands/AutoBanDisposableUsers.php
+++ b/app/Console/Commands/AutoBanDisposableUsers.php
@@ -56,7 +56,7 @@ class AutoBanDisposableUsers extends Command
             return;
         }
 
-        $bannedGroupId = cache()->rememberForever('group:banned:id', fn () => Group::where('slug', '=', 'banned')->soleValue('id'));
+        $bannedGroupId = Group::where('slug', '=', 'banned')->soleValue('id');
 
         User::where('group_id', '!=', $bannedGroupId)->chunkById(100, function ($users) use ($bannedGroupId): void {
             foreach ($users as $user) {

--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -132,7 +132,8 @@ class RssController extends Controller
     {
         $user = $request->user();
 
-        $disabledGroupId = cache()->rememberForever('group:disabled:id', fn () => Group::where('slug', '=', 'disabled')->soleValue('id'));
+        // Redis returns ints as numeric strings!
+        $disabledGroupId = (int) cache()->rememberForever('group:disabled:id', fn () => Group::where('slug', '=', 'disabled')->soleValue('id'));
 
         abort_if($user->group_id === $disabledGroupId, 404);
 

--- a/app/Http/Middleware/CheckIfBanned.php
+++ b/app/Http/Middleware/CheckIfBanned.php
@@ -30,7 +30,8 @@ class CheckIfBanned
     public function handle(\Illuminate\Http\Request $request, Closure $next, ?string $guard = null): mixed
     {
         $user = $request->user();
-        $bannedGroupId = cache()->rememberForever('group:id:banned:id', fn () => Group::where('slug', '=', 'banned')->soleValue('id'));
+        // Redis returns ints as numeric strings!
+        $bannedGroupId = (int) cache()->rememberForever('group:banned:id', fn () => Group::where('slug', '=', 'banned')->soleValue('id'));
 
         if ($user && $user->group_id === $bannedGroupId) {
             if ($request->is('api/*')) {

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -56,7 +56,7 @@ class FortifyServiceProvider extends ServiceProvider
                 // Check if user is disabled
                 if ($user->group->slug === 'disabled') {
                     $user->group_id = Group::query()->where('slug', '=', 'user')->soleValue('id');
-                    $user->can_download = 1;
+                    $user->can_download = true;
                     $user->disabled_at = null;
                     $user->save();
 
@@ -111,7 +111,7 @@ class FortifyServiceProvider extends ServiceProvider
 
                 if ($user->group->slug !== 'banned') {
                     if ($user->group->slug === 'validating') {
-                        $user->can_download = 1;
+                        $user->can_download = true;
                         $user->group_id = Group::query()->where('slug', '=', 'user')->soleValue('id');
                         $user->save();
 

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -51,14 +51,11 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->instance(LoginResponse::class, new class () implements LoginResponse {
             public function toResponse($request): \Illuminate\Http\RedirectResponse
             {
-                $user = $request->user();
+                $user = $request->user()->load('group:id,slug');
 
                 // Check if user is disabled
-                $disabledGroupId = cache()->rememberForever('group:disabled:id', fn () => Group::query()->where('slug', '=', 'disabled')->soleValue('id'));
-                $memberGroupId = cache()->rememberForever('group:user:id', fn () => Group::query()->where('slug', '=', 'user')->soleValue('id'));
-
-                if ($user->group_id == $disabledGroupId) {
-                    $user->group_id = $memberGroupId;
+                if ($user->group->slug === 'disabled') {
+                    $user->group_id = Group::query()->where('slug', '=', 'user')->soleValue('id');
                     $user->can_download = 1;
                     $user->disabled_at = null;
                     $user->save();
@@ -110,16 +107,12 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->instance(VerifyEmailResponse::class, new class () implements VerifyEmailResponse {
             public function toResponse($request): \Illuminate\Http\RedirectResponse|\Illuminate\View\View
             {
-                $bannedGroupId = cache()->rememberForever('group:banned:id', fn () => Group::query()->where('slug', '=', 'banned')->soleValue('id'));
-                $validatingGroupId = cache()->rememberForever('group:validating:id', fn () => Group::query()->where('slug', '=', 'validating')->soleValue('id'));
-                $memberGroupId = cache()->rememberForever('group:user:id', fn () => Group::query()->where('slug', '=', 'user')->soleValue('id'));
+                $user = $request->user()->load('group:id,slug');
 
-                $user = $request->user();
-
-                if ($user->group_id !== $bannedGroupId) {
-                    if ($user->group_id === $validatingGroupId) {
+                if ($user->group->slug !== 'banned') {
+                    if ($user->group->slug === 'validating') {
                         $user->can_download = 1;
-                        $user->group_id = $memberGroupId;
+                        $user->group_id = Group::query()->where('slug', '=', 'user')->soleValue('id');
                         $user->save();
 
                         cache()->forget('user:'.$user->passkey);
@@ -207,10 +200,10 @@ class FortifyServiceProvider extends ServiceProvider
             }
 
             if ($password === true) {
-                // Check if user is activated
-                $validatingGroupId = cache()->rememberForever('group:validating:id', fn () => Group::query()->where('slug', '=', 'validating')->soleValue('id'));
+                $user->load('group:id,slug');
 
-                if ($user->email_verified_at === null || $user->group_id === $validatingGroupId) {
+                // Check if user is activated
+                if ($user->email_verified_at === null || $user->group->slug === 'validating') {
                     $request->session()->invalidate();
 
                     throw ValidationException::withMessages([
@@ -219,9 +212,7 @@ class FortifyServiceProvider extends ServiceProvider
                 }
 
                 // Check if user is banned
-                $bannedGroupId = cache()->rememberForever('group:banned:id', fn () => Group::query()->where('slug', '=', 'banned')->soleValue('id'));
-
-                if ($user->group_id === $bannedGroupId) {
+                if ($user->group->slug === 'banned') {
                     $request->session()->invalidate();
 
                     throw ValidationException::withMessages([

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -799,13 +799,13 @@ parameters:
 			path: app/Providers/FortifyServiceProvider.php
 
 		-
-			message: '#^Method Laravel\\Fortify\\Contracts\\RegisterViewResponse@anonymous/app/Providers/FortifyServiceProvider\.php\:99\:\:toResponse\(\) never returns Illuminate\\Http\\RedirectResponse so it can be removed from the return type\.$#'
+			message: '#^Method Laravel\\Fortify\\Contracts\\RegisterViewResponse@anonymous/app/Providers/FortifyServiceProvider\.php\:96\:\:toResponse\(\) never returns Illuminate\\Http\\RedirectResponse so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: app/Providers/FortifyServiceProvider.php
 
 		-
-			message: '#^Method Laravel\\Fortify\\Contracts\\VerifyEmailResponse@anonymous/app/Providers/FortifyServiceProvider\.php\:110\:\:toResponse\(\) never returns Illuminate\\View\\View so it can be removed from the return type\.$#'
+			message: '#^Method Laravel\\Fortify\\Contracts\\VerifyEmailResponse@anonymous/app/Providers/FortifyServiceProvider\.php\:107\:\:toResponse\(\) never returns Illuminate\\View\\View so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: app/Providers/FortifyServiceProvider.php


### PR DESCRIPTION
Laravel returns numeric strings when an int is saved to cache, which breaks a lot of the logic here. Fixed by removing cache everywhere except rss and middleware, and in those two spots, caching the whole group and not just the id of the group.