### PR TITLE
(Fix) Quicksearch searching by null throws error

### DIFF
--- a/app/Http/Controllers/API/QuickSearchController.php
+++ b/app/Http/Controllers/API/QuickSearchController.php
@@ -27,7 +27,7 @@ class QuickSearchController extends Controller
 {
     public function index(Request $request): \Illuminate\Http\JsonResponse
     {
-        $query = $request->input('query');
+        $query = $request->input('query', '');
 
         $filters = [
             'deleted_at IS NULL',


### PR DESCRIPTION
The middleware automatically converts empty strings to null. We want to accept empty strings here for the search to work. Currently, the regex throws an error when a null is passed to it.