### PR TITLE
(Fix) Closing chatbox tab triggers chat status update

### DIFF
--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -203,7 +203,10 @@ document.addEventListener('alpine:init', () => {
                     this.state.ui.loading = false;
                 });
 
-            this.$watch('auth.chat_status_id', (status) => this.syncStatus());
+            this.$watch('auth.chat_status_id', (status, oldStatus) => {
+                if (status === oldStatus) return; // Closing a chatbox tab triggers this (alpinejs bug)
+                this.syncStatus();
+            });
 
             this.$cleanup = () => {
                 if (this.channel) {


### PR DESCRIPTION
For some reason, alpinejs triggers this even though the property doesn't change. Probably some bug. I looked into alpinejs, which itself uses vue's reactivity package, but I couldn't figure it out.