### PR TITLE
(Update) unit3d-announce torrent peers api response validation

### DIFF
--- a/app/Services/Unit3dAnnounce.php
+++ b/app/Services/Unit3dAnnounce.php
@@ -111,7 +111,7 @@ class Unit3dAnnounce
      *             array{
      *                 ip_address: string,
      *                 user_id: int,
-     *                 torrent_id: int,
+     *                 peer_id: string,
      *                 port: int,
      *                 is_seeder: bool,
      *                 is_active: bool,
@@ -150,11 +150,9 @@ class Unit3dAnnounce
             return [];
         }
 
-        foreach ($torrent['peers'] as $peer) {
+        foreach ($torrent['peers'] as $userIdAndPeerId => &$peer) {
             if (
                 !\array_key_exists('ip_address', $peer) || !\is_string($peer['ip_address'])
-                || !\array_key_exists('user_id', $peer) || !\is_int($peer['user_id'])
-                || !\array_key_exists('torrent_id', $peer) || !\is_int($peer['torrent_id'])
                 || !\array_key_exists('port', $peer) || !\is_int($peer['port'])
                 || !\array_key_exists('is_seeder', $peer) || !\is_bool($peer['is_seeder'])
                 || !\array_key_exists('is_active', $peer) || !\is_bool($peer['is_active'])
@@ -163,6 +161,13 @@ class Unit3dAnnounce
                 || !\array_key_exists('uploaded', $peer) || !\is_int($peer['uploaded'])
                 || !\array_key_exists('downloaded', $peer) || !\is_int($peer['downloaded'])
             ) {
+                return [];
+            }
+
+            if (preg_match('/^(\d+)\-([0-9a-fA-F]{40})$/', $userIdAndPeerId, $matches)) {
+                $peer['user_id'] = $matches[1];
+                $peer['peer_id'] = hex2bin($matches[2]);
+            } else {
                 return [];
             }
         }

--- a/resources/views/torrent/external-tracker.blade.php
+++ b/resources/views/torrent/external-tracker.blade.php
@@ -107,7 +107,7 @@
                                     @endif
                                 </td>
                                 <td>
-                                    {{ implode('', array_map(fn ($char) => ctype_print($char) ? $char : '\x' . bin2hex($char), str_split(hex2bin(explode('-', $peerId)[1])))) }}
+                                    {{ implode('', array_map(fn ($char) => ctype_print($char) ? $char : '\x' . bin2hex($char), str_split($peer['peer_id']))) }}
                                 </td>
                                 <td>
                                     @if ($torrent === null)


### PR DESCRIPTION
Remove `torrent_id` and `user_id` fields, as they will be removed in a future update. Gather user_id and peer_id from the dict key instead.