### PR TITLE
(Fix) Stop removal of bumped torrents updating entire torrents table

### DIFF
--- a/app/Console/Commands/AutoRemoveTimedTorrentBuffs.php
+++ b/app/Console/Commands/AutoRemoveTimedTorrentBuffs.php
@@ -71,9 +71,13 @@ class AutoRemoveTimedTorrentBuffs extends Command
             Unit3dAnnounce::addTorrent($torrent);
         }
 
-        Torrent::query()->whereNotNull('bumped_at')->where('bumped_at', '<', now()->subWeek())->update([
-            'bumped_at' => DB::raw('created_at'),
-        ]);
+        Torrent::query()
+            ->whereNotNull('bumped_at')
+            ->where('bumped_at', '<', now()->subWeek())
+            ->whereColumn('bumped_at', '!=', 'created_at')
+            ->update([
+                'bumped_at' => DB::raw('created_at'),
+            ]);
 
         $this->comment('Automated Removal Of Expired Torrent Buffs Command Complete');
     }


### PR DESCRIPTION
Eloquent automatically updates the updated_at timestamp, even if the bumped_at field doesn't change. This results in meilisearch reimporting all the torrents once every hour, which is not necessary and causes increased load.