### PR TITLE
(Security) Randomize info_hash upon upload and hide it from users

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -48,6 +48,7 @@ class TorrentTools
 
         $result['info']['source'] = config('torrent.source');
         $result['info']['private'] = 1;
+        $result['info']['entropy'] = bin2hex(random_bytes(64));
 
         if (config('torrent.created_by_append') && \array_key_exists('created by', $result)) {
             $result['created by'] = trim((string) $result['created by'], '. ').'. '.config('torrent.created_by', '');

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -671,7 +671,6 @@ class TorrentController extends BaseController
                             'media_info'       => $hit['mediainfo'],
                             'bd_info'          => $hit['bdinfo'],
                             'description'      => $hit['description'],
-                            'info_hash'        => $hit['info_hash'],
                             'size'             => $hit['size'],
                             'num_file'         => $hit['num_file'],
                             'files'            => $hit['files'],

--- a/app/Http/Resources/TorrentResource.php
+++ b/app/Http/Resources/TorrentResource.php
@@ -47,7 +47,6 @@ class TorrentResource extends JsonResource
                 'media_info'   => $this->mediainfo,
                 'bd_info'      => $this->bdinfo,
                 'description'  => $this->description,
-                'info_hash'    => bin2hex($this->info_hash),
                 'size'         => $this->size,
                 'folder'       => $this->folder,
                 'num_file'     => $this->num_file,

--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -19,7 +19,7 @@
                     {{ __('common.download') }}
                 </a>
             @endif
-        @else
+        @elseif (config('torrent.magnet'))
             <a
                 href="magnet:?dn={{ $torrent->name }}&xt=urn:btih:{{ bin2hex($torrent->info_hash) }}&as={{ route('torrent.download.rsskey', ['id' => $torrent->id, 'rsskey' => $user->rsskey]) }}&tr={{ route('announce', ['passkey' => $user->passkey]) }}&xl={{ $torrent->size }}"
                 class="form__button form__button--filled form__button--centered"
@@ -180,12 +180,14 @@
                 <h4 class="dialog__heading">
                     {{ __('common.files') }}
                 </h4>
-                <div class="dialog__actions">
-                    <div class="dialog__action">
-                        {{ __('torrent.info-hash') }}:
-                        {{ bin2hex($torrent->info_hash) }}
+                @if ($user->group->is_modo)
+                    <div class="dialog__actions">
+                        <div class="dialog__action">
+                            {{ __('torrent.info-hash') }}:
+                            {{ bin2hex($torrent->info_hash) }}
+                        </div>
                     </div>
-                </div>
+                @endif
             </header>
             <div x-bind="dialogForm" x-data="tabs" data-default-tab="hierarchy">
                 <menu class="panel__tabs">


### PR DESCRIPTION
Require a user to download a .torrent file in order to view the info_hash.