### PR TITLE
(Update) Remove redundant group from internal and staff pages

### DIFF
--- a/resources/sass/components/_user-card.scss
+++ b/resources/sass/components/_user-card.scss
@@ -45,9 +45,3 @@
     margin: 0;
     padding: 0;
 }
-
-.user-card__group {
-    color: #fff;
-    margin: 0;
-    padding: 0;
-}

--- a/resources/views/page/internal.blade.php
+++ b/resources/views/page/internal.blade.php
@@ -30,9 +30,6 @@
                             {{ $user->username }}
                         </h3>
                         <i class="fal {{ $user->group->icon }} user-card__icon"></i>
-                        <p class="user-card__group">
-                            {{ __('page.staff-group') }}: {{ $internal->name }}
-                        </p>
                         @if ($user->title !== null)
                             <p class="user-card__title">
                                 {{ __('page.staff-title') }}: {{ $user->title }}

--- a/resources/views/page/staff.blade.php
+++ b/resources/views/page/staff.blade.php
@@ -24,9 +24,6 @@
                             {{ $user->username }}
                         </h3>
                         <i class="fal {{ $user->group->icon }} user-card__icon"></i>
-                        <p class="user-card__group">
-                            {{ __('page.staff-group') }}: {{ $group->name }}
-                        </p>
                         @if ($user->title !== null)
                             <p class="user-card__title">
                                 {{ __('page.staff-title') }}: {{ $user->title }}


### PR DESCRIPTION
The group is already included in the heading.