### PR TITLE
(Fix) Rotten Tomatoes search generation

### DIFF
--- a/.cspell/brands.txt
+++ b/.cspell/brands.txt
@@ -10,6 +10,7 @@ limewire
 mal
 mediainfo
 phpstorm
+rottentomatoes
 shareaza
 tmdb
 tvdb

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -56,6 +56,16 @@ if (!\function_exists('href_request')) {
     }
 }
 
+if (!\function_exists('href_rottentomatoes')) {
+    function href_rottentomatoes(string|null $title, string|null $date): string
+    {
+        $year = substr($date ?? '', 0, 4);
+        $query = "{$title}  ({$year}) site:rottentomatoes.com";
+
+        return "https://html.duckduckgo.com/html/?q=\\".rawurlencode($query);
+    }
+}
+
 if (!\function_exists('href_poll')) {
     function href_poll(App\Models\Poll $poll): string
     {

--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -197,8 +197,7 @@
             <li class="meta__rotten">
                 <a
                     class="meta-id-tag"
-                    {{-- cspell:disable-next-line --}}
-                    href="https://html.duckduckgo.com/html/?q=\{{ $meta->title ?? '' }}  ({{ substr($meta->release_date ?? '', 0, 4) ?? '' }})+site%3Arottentomatoes.com"
+                    href="{{ href_rottentomatoes($meta->name, $meta->release_date) }}"
                     title="Rotten Tomatoes: {{ $meta->title ?? '' }}  ({{ substr($meta->release_date ?? '', 0, 4) ?? '' }})"
                     target="_blank"
                     rel="noreferrer"

--- a/resources/views/torrent/partials/tv-meta.blade.php
+++ b/resources/views/torrent/partials/tv-meta.blade.php
@@ -196,8 +196,7 @@
             <li class="meta__rotten">
                 <a
                     class="meta-id-tag"
-                    {{-- cspell:disable-next-line --}}
-                    href="https://html.duckduckgo.com/html/?q=\{{ $meta->name ?? '' }}  ({{ substr($meta->first_air_date ?? '', 0, 4) ?? '' }})+site%3Arottentomatoes.com"
+                    href="{{ href_rottentomatoes($meta->name, $meta->first_air_date) }}"
                     title="Rotten Tomatoes: {{ $meta->name ?? '' }}  ({{ substr($meta->first_air_date ?? '', 0, 4) ?? '' }})"
                     target="_blank"
                     rel="noreferrer"


### PR DESCRIPTION
The previous form was not URL encoded meaning that a title with "special" characters like "&" would result in a broken URL that lead to confusing destinations.

Warning: This code isn't tested at all.