### PR TITLE
(Fix) Meilisearch using different logic when searching by uploader

### DIFF
--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -448,7 +448,10 @@ readonly class TorrentSearchFiltersDTO
             $filters[] = 'user.username = '.json_encode($this->uploader);
 
             if (!$group->is_modo) {
-                $filters[] = 'anon = false';
+                $filters[] = [
+                    'anon = false',
+                    'user.username = '.json_encode($this->user->username),
+                ];
             }
         }
 


### PR DESCRIPTION
If the uploader is searching for themselves, then include their anon torrents. This is how the SQL search works.