### PR TITLE
(Remove) Thanks count from torrent icons

### DIFF
--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -243,10 +243,6 @@ class SimilarTorrent extends Component
                         'leeches' => fn ($query) => $query->where('active', '=', true)->where('visible', '=', true),
                     ]),
                 )
-                ->when(
-                    config('other.thanks-system.is-enabled'),
-                    fn ($query) => $query->withCount('thanks')
-                )
                 ->withExists([
                     'featured as featured',
                     'freeleechTokens'    => fn ($query) => $query->where('user_id', '=', auth()->id()),

--- a/app/Http/Livewire/TmdbPersonCredit.php
+++ b/app/Http/Livewire/TmdbPersonCredit.php
@@ -173,10 +173,6 @@ class TmdbPersonCredit extends Component
                         'leeches' => fn ($query) => $query->where('active', '=', true)->where('visible', '=', true),
                     ]),
                 )
-                ->when(
-                    config('other.thanks-system.is-enabled'),
-                    fn ($query) => $query->withCount('thanks')
-                )
                 ->withExists([
                     'featured as featured',
                     'freeleechTokens'    => fn ($query) => $query->where('user_id', '=', auth()->id()),

--- a/app/Http/Livewire/TopTorrents.php
+++ b/app/Http/Livewire/TopTorrents.php
@@ -72,7 +72,7 @@ class TopTorrents extends Component
                         WHEN category_id IN (SELECT id FROM categories WHERE no_meta = 1) THEN 'no'
                     END AS meta
                 SQL)
-                ->withCount(['thanks', 'comments'])
+                ->withCount(['comments'])
                 ->when($this->tab === 'newest', fn ($query) => $query->orderByDesc('id'))
                 ->when($this->tab === 'seeded', fn ($query) => $query->orderByDesc('seeders'))
                 ->when(

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -455,7 +455,6 @@ class TorrentSearch extends Component
             $eagerLoads = fn (Builder $query) => $query
                 ->with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
                 ->withCount([
-                    'thanks',
                     'comments',
                     'seeds'   => fn ($query) => $query->where('active', '=', true)->where('visible', '=', true),
                     'leeches' => fn ($query) => $query->where('active', '=', true)->where('visible', '=', true),
@@ -615,10 +614,6 @@ class TorrentSearch extends Component
                         'seeds'   => fn ($query) => $query->where('active', '=', true)->where('visible', '=', true),
                         'leeches' => fn ($query) => $query->where('active', '=', true)->where('visible', '=', true),
                     ]),
-                )
-                ->when(
-                    config('other.thanks-system.is-enabled'),
-                    fn ($query) => $query->withCount('thanks')
                 )
                 ->withExists([
                     'featured as featured',

--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -53,10 +53,6 @@
     gap: 10px;
 }
 
-.torrent-icons__thanks {
-    font: inherit;
-    color: var(--torrent-row-thanks-fg);
-}
 .torrent-icons__comments {
     font: inherit;
     color: var(--torrent-row-comments-fg);

--- a/resources/sass/themes/_cosmic-void.scss
+++ b/resources/sass/themes/_cosmic-void.scss
@@ -346,7 +346,6 @@
     --torrent-row-seeders-fg: #ddd;
     --torrent-row-leechers-fg: #ddd;
     --torrent-row-completed-fg: #ddd;
-    --torrent-row-thanks-fg: #ddd;
     --torrent-row-comments-fg: #ddd;
     --torrent-row-internal-fg: #ddd;
     --torrent-row-personal-fg: #ddd;

--- a/resources/sass/themes/_dark-base.scss
+++ b/resources/sass/themes/_dark-base.scss
@@ -41,7 +41,6 @@ For example dark blue,
     --torrent-row-seeders-fg: #3fb618;
     --torrent-row-leechers-fg: var(--color-light-red);
     --torrent-row-completed-fg: var(--color-400);
-    --torrent-row-thanks-fg: var(--color-400);
     --torrent-row-comments-fg: #3fb618;
     --torrent-row-internal-fg: #baaf92;
     --torrent-row-personal-fg: #865be9;

--- a/resources/sass/themes/_galactic.scss
+++ b/resources/sass/themes/_galactic.scss
@@ -386,7 +386,6 @@
     --torrent-row-seeders-fg: #3fb618;
     --torrent-row-leechers-fg: #996666;
     --torrent-row-completed-fg: #42a5f5;
-    --torrent-row-thanks-fg: #805e70;
     --torrent-row-comments-fg: #669966;
     --torrent-row-internal-fg: #baaf92;
     --torrent-row-personal-fg: #865be9;

--- a/resources/sass/themes/_light.scss
+++ b/resources/sass/themes/_light.scss
@@ -358,7 +358,6 @@
     --torrent-row-seeders-fg: #3fb618;
     --torrent-row-leechers-fg: #ff0039;
     --torrent-row-completed-fg: #42a5f5;
-    --torrent-row-thanks-fg: #f92672;
     --torrent-row-comments-fg: #3fb618;
     --torrent-row-internal-fg: #baaf94;
     --torrent-row-personal-fg: #865be9;

--- a/resources/sass/themes/_material-design-v3-amoled.scss
+++ b/resources/sass/themes/_material-design-v3-amoled.scss
@@ -357,7 +357,6 @@
     --torrent-row-seeders-fg: #7ad17f;
     --torrent-row-leechers-fg: #e95140;
     --torrent-row-completed-fg: #4f84d7;
-    --torrent-row-thanks-fg: #f92672;
     --torrent-row-comments-fg: #3fb618;
     --torrent-row-internal-fg: #baaf94;
     --torrent-row-personal-fg: #865be9;

--- a/resources/sass/themes/_material-design-v3-dark.scss
+++ b/resources/sass/themes/_material-design-v3-dark.scss
@@ -359,7 +359,6 @@
     --torrent-row-seeders-fg: #7ad17f;
     --torrent-row-leechers-fg: #e95140;
     --torrent-row-completed-fg: #4f84d7;
-    --torrent-row-thanks-fg: #f92672;
     --torrent-row-comments-fg: #3fb618;
     --torrent-row-internal-fg: #baaf94;
     --torrent-row-personal-fg: #865be9;

--- a/resources/sass/themes/_material-design-v3-light.scss
+++ b/resources/sass/themes/_material-design-v3-light.scss
@@ -358,7 +358,6 @@
     --torrent-row-seeders-fg: #3fb618;
     --torrent-row-leechers-fg: #ff0039;
     --torrent-row-completed-fg: #42a5f5;
-    --torrent-row-thanks-fg: #f92672;
     --torrent-row-comments-fg: #3fb618;
     --torrent-row-internal-fg: #baaf94;
     --torrent-row-personal-fg: #865be9;

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -360,7 +360,6 @@
     --torrent-row-seeders-fg: #7ad17f;
     --torrent-row-leechers-fg: #e95140;
     --torrent-row-completed-fg: #4f84d7;
-    --torrent-row-thanks-fg: #f92672;
     --torrent-row-comments-fg: #3fb618;
     --torrent-row-internal-fg: #baaf94;
     --torrent-row-personal-fg: #865be9;

--- a/resources/sass/themes/_nord.scss
+++ b/resources/sass/themes/_nord.scss
@@ -373,7 +373,6 @@
     --torrent-row-seeders-fg: #a3be8c;
     --torrent-row-leechers-fg: #bf616a;
     --torrent-row-completed-fg: #88c0d0;
-    --torrent-row-thanks-fg: #bf616a;
     --torrent-row-comments-fg: #a3be8c;
     --torrent-row-internal-fg: #baaf94;
     --torrent-row-personal-fg: #b48ead;

--- a/resources/sass/themes/_revel.scss
+++ b/resources/sass/themes/_revel.scss
@@ -377,7 +377,6 @@
     --torrent-row-seeders-fg: #3fb618;
     --torrent-row-leechers-fg: #996666;
     --torrent-row-completed-fg: #42a5f5;
-    --torrent-row-thanks-fg: #805e70;
     --torrent-row-comments-fg: #669966;
     --torrent-row-internal-fg: #baaf92;
     --torrent-row-personal-fg: #865be9;

--- a/resources/views/components/partials/_torrent-icons.blade.php
+++ b/resources/views/components/partials/_torrent-icons.blade.php
@@ -27,15 +27,6 @@
         ></i>
     @endif
 
-    @if (config('other.thanks-system.is-enabled') && isset($torrent->thanks_count))
-        <i
-            class="{{ config('other.font-awesome') }} fa-heartbeat torrent-icons__thanks"
-            title="{{ __('torrent.thanks-given') }}"
-        >
-            {{ $torrent->thanks_count }}
-        </i>
-    @endif
-
     @isset($torrent->comments_count)
         <a href="{{ route('torrents.show', ['id' => $torrent->id]) }}#comments">
             <i


### PR DESCRIPTION
Significantly cleans up the listing and isn't needed to see in bulk. Some sites disable thanks completely and don't want to see it. I plan to also move the comment count and the seeding/leeching indicators elsewhere in a separate PR to clean it up further. The count is still shown on the individual torrent page itself.