### PR TITLE
(Fix) Chatbox gift users command

### DIFF
--- a/app/Bots/SystemBot.php
+++ b/app/Bots/SystemBot.php
@@ -73,14 +73,13 @@ class SystemBot
     /**
      * Send Gift.
      *
-     * @param array<string> $note
+     * @param numeric-string $amount
      */
-    public function putGift(string $receiver = '', float $amount = 0, array $note = ['']): string
+    public function putGift(string $receiver, string $amount, string $note): string
     {
-        $output = implode(' ', $note);
-        $v = validator(['receiver' => $receiver, 'amount' => $amount, 'note' => $output], [
+        $v = validator(['receiver' => $receiver, 'amount' => $amount, 'note' => $note], [
             'receiver' => 'required|string|exists:users,username',
-            'amount'   => \sprintf('required|numeric|min:1|max:%s', $this->target->seedbonus),
+            'amount'   => \sprintf('required|decimal:0,2|min:1|max:%s', $this->target->seedbonus),
             'note'     => 'required|string',
         ]);
 
@@ -91,15 +90,16 @@ class SystemBot
                 return 'Your BON gift could not be sent.';
             }
 
-            $value = $amount;
-            $recipient->increment('seedbonus', $value);
-            $this->target->decrement('seedbonus', $value);
+            $amount = (float) $amount;
+
+            $recipient->increment('seedbonus', $amount);
+            $this->target->decrement('seedbonus', $amount);
 
             $gift = Gift::create([
                 'sender_id'    => $this->target->id,
                 'recipient_id' => $recipient->id,
-                'bon'          => $value,
-                'message'      => $output,
+                'bon'          => $amount,
+                'message'      => $note,
             ]);
 
             if ($this->target->id !== $recipient->id && $recipient->acceptsNotification($this->target, $recipient, 'bon', 'show_bon_gift')) {
@@ -110,7 +110,7 @@ class SystemBot
             $recipientUrl = href_profile($recipient);
 
             $this->chatRepository->systemMessage(
-                \sprintf('[url=%s]%s[/url] has gifted %s BON to [url=%s]%s[/url]', $profileUrl, $this->target->username, $value, $recipientUrl, $recipient->username)
+                \sprintf('[url=%s]%s[/url] has gifted %s BON to [url=%s]%s[/url]', $profileUrl, $this->target->username, $amount, $recipientUrl, $recipient->username)
             );
 
             return 'Your gift to '.$recipient->username.' for '.$amount.' BON has been sent!';


### PR DESCRIPTION
There were a few type errors here.

I don't like that I'm casting the $amount to a float, but the only alternatives are not using the query builder, by either using `->update(['seedbonus' => DB::raw("seedbonus + $amount")])` after regex validation, or using `DB::update("update users set seedbonus = seedbonus + ? where id = ?", [$amount, $recipient->id])`. This is an issue in other parts of the code base as well.

I'm open to any feedback.