### PR TITLE
(Refactor) Improve torrent relation fetching on torrent page

### DIFF
--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -563,6 +563,16 @@ class Torrent extends Model
     }
 
     /**
+     * Belongs To A Game.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<IgdbGame, $this>
+     */
+    public function game(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(IgdbGame::class, 'igdb_game_id');
+    }
+
+    /**
      * Belongs To A Playlist.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<Playlist, $this, PlaylistTorrent>
@@ -751,6 +761,16 @@ class Torrent extends Model
     public function reports(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(Report::class);
+    }
+
+    /**
+     * Has Many Downloads.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<TorrentDownload, $this>
+     */
+    public function downloads(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(TorrentDownload::class);
     }
 
     /**

--- a/resources/views/livewire/thank-button.blade.php
+++ b/resources/views/livewire/thank-button.blade.php
@@ -3,5 +3,5 @@
     class="form__button form__button--outlined form__button--centered"
 >
     <i class="{{ config('other.font-awesome') }} fa-heart text-pink"></i>
-    {{ __('torrent.thank') }} ({{ $torrent->thanks()->count() }})
+    {{ __('torrent.thank') }} ({{ $torrent->thanks_count }})
 </button>

--- a/resources/views/torrent/partials/downloads.blade.php
+++ b/resources/views/torrent/partials/downloads.blade.php
@@ -1,8 +1,7 @@
 <section class="panelV2" x-data="toggle">
     <h2 class="panel__heading" style="cursor: pointer" x-on:click="toggle">
         <i class="{{ config('other.font-awesome') }} fa-clipboard-list"></i>
-        Torrent File Downloads
-        ({{ App\Models\TorrentDownload::where('torrent_id', '=', $torrent->id)->count() }} Total)
+        Torrent File Downloads ({{ $torrent->downloads_count }} Total)
         <i
             class="{{ config('other.font-awesome') }} fa-plus-circle fa-pull-right"
             x-show="isToggledOff"
@@ -23,7 +22,7 @@
                 </tr>
             </thead>
             <tbody>
-                @foreach (App\Models\TorrentDownload::with(['user:id,username,group_id' => ['group:id,name,color,icon,effect']])->where('torrent_id', '=', $torrent->id)->latest()->get() as $download)
+                @foreach ($torrent->downloads as $download)
                     <tr>
                         <td>
                             <x-user-tag :user="$download->user" :anon="false" />

--- a/resources/views/torrent/partials/general.blade.php
+++ b/resources/views/torrent/partials/general.blade.php
@@ -113,7 +113,7 @@
         <li class="torrent__activity">
             <span class="torrent__activity-link">
                 {{ __('torrent.last-seed-activity') }}:
-                {{ $last_seed_activity->updated_at ?? __('common.unknown') }}
+                {{ $torrent->history_max_updated_at ?? __('common.unknown') }}
             </span>
         </li>
     @endif

--- a/resources/views/torrent/show.blade.php
+++ b/resources/views/torrent/show.blade.php
@@ -29,15 +29,15 @@
 @section('main')
     @switch(true)
         @case($torrent->category->movie_meta)
-            @include('torrent.partials.movie-meta', ['category' => $torrent->category, 'tmdb' => $torrent->tmdb_movie_id])
+            @include('torrent.partials.movie-meta', ['category' => $torrent->category, 'meta' => $torrent->movie, 'tmdb' => $torrent->tmdb_movie_id])
 
             @break
         @case($torrent->category->tv_meta)
-            @include('torrent.partials.tv-meta', ['category' => $torrent->category, 'tmdb' => $torrent->tmdb_tv_id])
+            @include('torrent.partials.tv-meta', ['category' => $torrent->category, 'meta' => $torrent->tv, 'tmdb' => $torrent->tmdb_tv_id])
 
             @break
         @case($torrent->category->game_meta)
-            @include('torrent.partials.game-meta', ['category' => $torrent->category, 'igdb' => $torrent->igdb])
+            @include('torrent.partials.game-meta', ['category' => $torrent->category, 'meta' => $torrent->game, 'igdb' => $torrent->igdb])
 
             @break
         @default
@@ -82,7 +82,7 @@
     @endif
 
     {{-- Extra Meta Block --}}
-    @include('torrent.partials.extra-meta')
+    @include('torrent.partials.extra-meta', ['meta' => $torrent->movie ?? $torrent->tv ?? $torrent->game ?? null])
 
     {{-- Comments Block --}}
     @include('torrent.partials.comments')


### PR DESCRIPTION
Rely more on eloquent relations instead of using raw queries inside of the views.

As a point of reference, all database queries on this page only take 23 ms. The rest of the ~200+ ms is taken up mostly by blade rendering