### PR TITLE
(Refactor) Improve request relation fetching on request page

### DIFF
--- a/app/Models/TorrentRequest.php
+++ b/app/Models/TorrentRequest.php
@@ -196,6 +196,16 @@ class TorrentRequest extends Model
     }
 
     /**
+     * Belongs To A Game.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<IgdbGame, $this>
+     */
+    public function game(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(IgdbGame::class, 'igdb_game_id');
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany<Comment, $this>
      */
     public function comments(): \Illuminate\Database\Eloquent\Relations\MorphMany

--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -21,19 +21,19 @@
     @if ($user->can_request ?? $user->group->can_request)
         @switch(true)
             @case($torrentRequest->category->movie_meta)
-                @include('torrent.partials.movie-meta', ['torrent' => $torrentRequest, 'category' => $torrentRequest->category, 'tmdb' => $torrentRequest->tmdb_movie_id])
+                @include('torrent.partials.movie-meta', ['torrent' => $torrentRequest, 'category' => $torrentRequest->category, 'meta' => $torrentRequest->movie, 'tmdb' => $torrentRequest->tmdb_movie_id])
 
                 @break
             @case($torrentRequest->category->tv_meta)
-                @include('torrent.partials.tv-meta', ['torrent' => $torrentRequest, 'category' => $torrentRequest->category, 'tmdb' => $torrentRequest->tmdb_tv_id])
+                @include('torrent.partials.tv-meta', ['torrent' => $torrentRequest, 'category' => $torrentRequest->category, 'meta' => $torrentRequest->tv, 'tmdb' => $torrentRequest->tmdb_tv_id])
 
                 @break
             @case($torrentRequest->category->game_meta)
-                @include('torrent.partials.game-meta', ['torrent' => $torrentRequest, 'category' => $torrentRequest->category, 'igdb' => $torrentRequest->igdb])
+                @include('torrent.partials.game-meta', ['torrent' => $torrentRequest, 'category' => $torrentRequest->category, 'meta' => $torrentRequest->game, 'igdb' => $torrentRequest->igdb])
 
                 @break
             @default
-                @include('torrent.partials.no-meta', ['torrent' => $torrentRequest, 'category' => $torrentRequest->category])
+                @include('torrent.partials.no-meta', ['torrent' => $torrentRequest, 'category' => $torrentRequest->category, 'meta' => null])
 
                 @break
         @endswitch
@@ -231,7 +231,7 @@
                         </dd>
                     </div>
                 </dl>
-                @if ($torrentRequest->approved_when === null && ($torrentRequest->user_id == $user->id || auth()->user()->group->is_modo))
+                @if ($torrentRequest->approved_when === null && ($torrentRequest->user_id == $user->id || $user->group->is_modo))
                     <div class="panel__body">
                         <div class="form__group">
                             <form


### PR DESCRIPTION
Assume that each request only has one of (tmdb_movie_id, tmdb_tv_id, igdb_game_id) filled out, and just load all non-null relations for cleaner code.

As a point of reference, all database queries on this page only take 18ms. The rest of the 200+ ms is taken up mostly by blade rendering.