### PR TITLE
(Update) Don't show comment if 0 on torrent listing

### DIFF
--- a/resources/views/components/partials/_torrent-icons.blade.php
+++ b/resources/views/components/partials/_torrent-icons.blade.php
@@ -1,12 +1,19 @@
 <span class="torrent-icons">
     @isset($torrent->comments_count)
         <a href="{{ route('torrents.show', ['id' => $torrent->id]) }}#comments">
-            <i
-                class="{{ config('other.font-awesome') }} fa-comment-alt-lines torrent-icons__comments"
-                title="{{ __('torrent.comments-left') }}"
-            >
-                {{ $torrent->comments_count }}
-            </i>
+            @if ($torrent->comments_count === 0)
+                <i
+                    class="{{ config('other.font-awesome') }} fa-comment-alt-plus torrent-icons__comments"
+                    title="{{ __('torrent.comments-left') }}"
+                ></i>
+            @else
+                <i
+                    class="{{ config('other.font-awesome') }} fa-comment-alt-lines torrent-icons__comments"
+                    title="{{ __('torrent.comments-left') }}"
+                >
+                    {{ $torrent->comments_count }}
+                </i>
+            @endif
         </a>
     @endisset
 


### PR DESCRIPTION
More cleaner in an already information-dense view while not limiting functionality. I've tried putting the count inside of the comment, but the text is pretty small. This could probably be further looked into in the future, but this is a decent enough stopgap with low chance of fallout.