### PR TITLE
(Fix) Authenticated Image Controller needs to bypass torrent ApprovedScope.

### DIFF
--- a/app/Http/Controllers/AuthenticatedImageController.php
+++ b/app/Http/Controllers/AuthenticatedImageController.php
@@ -19,6 +19,7 @@ namespace App\Http\Controllers;
 use App\Models\Article;
 use App\Models\Category;
 use App\Models\Playlist;
+use App\Models\Scopes\ApprovedScope;
 use App\Models\Torrent;
 use App\Models\User;
 use Illuminate\Support\Facades\Storage;
@@ -62,8 +63,10 @@ class AuthenticatedImageController extends Controller
         return response()->file($path, self::HEADERS);
     }
 
-    public function torrentBanner(Torrent $torrent): \Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function torrentBanner(int $id): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+
         $path = Storage::disk('torrent-banners')->path("torrent-banner_{$torrent->id}.jpg");
 
         abort_unless(file_exists($path), 404);
@@ -71,8 +74,10 @@ class AuthenticatedImageController extends Controller
         return response()->file($path, self::HEADERS);
     }
 
-    public function torrentCover(Torrent $torrent): \Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function torrentCover(int $id): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+
         $path = Storage::disk('torrent-covers')->path("torrent-cover_{$torrent->id}.jpg");
 
         abort_unless(file_exists($path), 404);

--- a/resources/views/components/torrent/card.blade.php
+++ b/resources/views/components/torrent/card.blade.php
@@ -70,7 +70,7 @@
                     
                             @break
                         @case($torrent->category->no_meta && Storage::disk('torrent-covers')->exists("torrent-cover_$torrent->id.jpg"))
-                            src="{{ route('authenticated_images.torrent_cover', ['torrent' => $torrent]) }}"
+                            src="{{ route('authenticated_images.torrent_cover', ['id' => $torrent->id]) }}"
                     
                             @break
                     @endswitch

--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -70,7 +70,7 @@
                 @if ($torrent->category->no_meta)
                     @if (Storage::disk('torrent-covers')->exists("torrent-cover_$torrent->id.jpg"))
                         <img
-                            src="{{ route('authenticated_images.torrent_cover', ['torrent' => $torrent]) }}"
+                            src="{{ route('authenticated_images.torrent_cover', ['id' => $torrent->id]) }}"
                             class="torrent-search--list__poster-img"
                             loading="lazy"
                             alt="{{ __('torrent.similar') }}"

--- a/resources/views/torrent/partials/no-meta.blade.php
+++ b/resources/views/torrent/partials/no-meta.blade.php
@@ -2,14 +2,14 @@
     @if (Storage::disk('torrent-banners')->exists("torrent-banner_$torrent->id.jpg"))
         <img
             class="meta__backdrop"
-            src="{{ route('authenticated_images.torrent_banner', ['torrent' => $torrent->id]) }}"
+            src="{{ route('authenticated_images.torrent_banner', ['id' => $torrent->id]) }}"
             alt=""
         />
     @endif
 
     <span class="meta__poster-link">
         <img
-            src="{{ Storage::disk('torrent-covers')->exists("torrent-cover_$torrent->id.jpg") ? route('authenticated_images.torrent_cover', ['torrent' => $torrent]) : 'https://via.placeholder.com/400x600' }}"
+            src="{{ Storage::disk('torrent-covers')->exists("torrent-cover_$torrent->id.jpg") ? route('authenticated_images.torrent_cover', ['id' => $torrent->id]) : 'https://via.placeholder.com/400x600' }}"
             class="meta__poster"
         />
     </span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -112,8 +112,8 @@ Route::middleware('language')->group(function (): void {
             Route::get('/article-images/{article}', [App\Http\Controllers\AuthenticatedImageController::class, 'articleImage'])->name('article_image');
             Route::get('/category-images/{category}', [App\Http\Controllers\AuthenticatedImageController::class, 'categoryImage'])->name('category_image');
             Route::get('/playlist-images/{playlist}', [App\Http\Controllers\AuthenticatedImageController::class, 'playlistImage'])->name('playlist_image');
-            Route::get('/torrent-banners/{torrent}', [App\Http\Controllers\AuthenticatedImageController::class, 'torrentBanner'])->name('torrent_banner');
-            Route::get('/torrent-covers/{torrent}', [App\Http\Controllers\AuthenticatedImageController::class, 'torrentCover'])->name('torrent_cover');
+            Route::get('/torrent-banners/{id}', [App\Http\Controllers\AuthenticatedImageController::class, 'torrentBanner'])->name('torrent_banner');
+            Route::get('/torrent-covers/{id}', [App\Http\Controllers\AuthenticatedImageController::class, 'torrentCover'])->name('torrent_cover');
             Route::get('/user-avatars/{user:username}', [App\Http\Controllers\AuthenticatedImageController::class, 'userAvatar'])->name('user_avatar');
             Route::get('/user-icons/{user:username}', [App\Http\Controllers\AuthenticatedImageController::class, 'userIcon'])->name('user_icon');
         });


### PR DESCRIPTION
When a mod queue enabled user uploads a torrent and  adds a custom cover for a non movie/tv meta category as a mod i would expect to be able to view that cover image correctly when reviewing the torrent. Currently it 404s due to the  global ApprovedScope on the torrent model. This changes the AuthenticatedImageController to bypass that scope when retrieving images the same way the TorrentController handles accessing unapproved torrents. 