### PR TITLE
(Refactor) Use php set property hooks for livewire lifecycle hooks

### DIFF
--- a/app/Http/Livewire/TorrentDownloadSearch.php
+++ b/app/Http/Livewire/TorrentDownloadSearch.php
@@ -44,10 +44,18 @@ class TorrentDownloadSearch extends Component
     public string $torrentDownloadType = '';
 
     #[Url(history: true)]
-    public string $from = '';
+    public string $from = '' {
+        set(string $value) {
+            $this->from = $value === '' ? '' : Carbon::parse($value)->format('Y-m-d');
+        }
+    }
 
     #[Url(history: true)]
-    public string $until = '';
+    public string $until = '' {
+        set(string $value) {
+            $this->until = $value === '' ? '' : Carbon::parse($value)->format('Y-m-d');
+        }
+    }
 
     #[Url(history: true)]
     public string $groupBy = 'none';
@@ -70,20 +78,6 @@ class TorrentDownloadSearch extends Component
             // to load the page if it gets the values for all time
             $this->from = now()->subWeek()->format('Y-m-d');
         }
-    }
-
-    final public function updatingFrom(string &$value): void
-    {
-        $value = $value === '' ? '' : Carbon::parse($value)->format('Y-m-d');
-
-        $this->from = $value;
-    }
-
-    final public function updatingUntil(string &$value): void
-    {
-        $value = $value === '' ? '' : Carbon::parse($value)->format('Y-m-d');
-
-        $this->until = $value;
     }
 
     /**

--- a/app/Http/Livewire/Trending.php
+++ b/app/Http/Livewire/Trending.php
@@ -44,27 +44,25 @@ class Trending extends Component
 
     #[Url(history: true)]
     #[Validate('sometimes|date_format:Y-m-d')]
-    public string $from = '';
-
-    #[Url(history: true)]
-    #[Validate('sometimes|date_format:Y-m-d')]
-    public string $until = '';
-
-    public function updatingFrom(string &$value): void
-    {
-        try {
-            $value = Carbon::parse($value)->format('Y-m-d');
-        } catch (Throwable) {
-            $value = now()->subDay()->format('Y-m-d');
+    public string $from = '' {
+        set(string $value) {
+            try {
+                $this->from = Carbon::parse($value)->format('Y-m-d');
+            } catch (Throwable) {
+                $this->from = now()->subDay()->format('Y-m-d');
+            }
         }
     }
 
-    public function updatingUntil(string &$value): void
-    {
-        try {
-            $value = Carbon::parse($value)->format('Y-m-d');
-        } catch (Throwable) {
-            $value = now()->format('Y-m-d');
+    #[Url(history: true)]
+    #[Validate('sometimes|date_format:Y-m-d')]
+    public string $until = '' {
+        set(string $value) {
+            try {
+                $this->until = Carbon::parse($value)->format('Y-m-d');
+            } catch (Throwable) {
+                $this->until = now()->format('Y-m-d');
+            }
         }
     }
 


### PR DESCRIPTION
In cases where the property is modified by reference, we can use native php property hooks.