### PR TITLE
(Remove) Bon earning 30 minute time constraint on preview

### DIFF
--- a/app/Http/Livewire/UserEarnings.php
+++ b/app/Http/Livewire/UserEarnings.php
@@ -184,7 +184,6 @@ class UserEarnings extends Component
                 ->where('peers.seeder', '=', true)
                 ->where('peers.active', '=', true)
                 ->where('peers.user_id', '=', $this->user->id)
-                ->where('peers.created_at', '<', now()->subMinutes(30))
                 ->where('torrents.name', 'LIKE', '%'.str_replace(' ', '%', $this->torrentName).'%')
                 ->groupBy(['peers.torrent_id', 'peers.user_id']);
 


### PR DESCRIPTION
30 minutes of seeding is required for a bon earning to be allocated, to prevent users from starting torrents immediately before the hour change and stopping immediately after, but including this constraint in the user's bon earning preview is confusing if the user has just restarted their client. Keep the constraint in the actual calculation, but preview the bon earnings as if the constraint didn't exist on their bon earnings page.