### PR TITLE
(Remove) Unused topic `viewable()` function

### DIFF
--- a/app/Models/Topic.php
+++ b/app/Models/Topic.php
@@ -196,16 +196,4 @@ class Topic extends Model
             )
             ->when($canReplyTopic && !auth()->user()->group->is_modo, fn ($query) => $query->where('state', '=', 'open'));
     }
-
-    /**
-     * Does User Have Permission To View Topic.
-     */
-    public function viewable(): bool
-    {
-        if (auth()->user()->group->is_modo) {
-            return true;
-        }
-
-        return $this->forum->getPermission()?->read_topic ?? false;
-    }
 }

--- a/resources/views/blocks/latest-topics.blade.php
+++ b/resources/views/blocks/latest-topics.blade.php
@@ -9,11 +9,9 @@
     @if ($topics->count() > 0)
         <ul class="topic-listings">
             @foreach ($topics as $topic)
-                @if ($topic->viewable())
-                    <li class="topic-listings__item">
-                        <x-forum.topic-listing :topic="$topic" />
-                    </li>
-                @endif
+                <li class="topic-listings__item">
+                    <x-forum.topic-listing :topic="$topic" />
+                </li>
             @endforeach
         </ul>
     @else


### PR DESCRIPTION
The HomeController already has logic to ensure the user only receives topics from forums they have permission to read topics in.