### PR TITLE
(Refactor) Remove torrent `notifyUploader()` function

### DIFF
--- a/app/Http/Livewire/ThankButton.php
+++ b/app/Http/Livewire/ThankButton.php
@@ -19,6 +19,7 @@ namespace App\Http\Livewire;
 use App\Models\Thank;
 use App\Models\Torrent;
 use App\Models\User;
+use App\Notifications\NewThank;
 use Livewire\Component;
 
 class ThankButton extends Component
@@ -51,7 +52,11 @@ class ThankButton extends Component
             'torrent_id' => $this->torrent->id,
         ]);
 
-        $this->torrent->notifyUploader('thank', $thank);
+        $uploader = $this->torrent->user;
+
+        if ($uploader->acceptsNotification($this->user, $uploader, 'torrent', 'show_torrent_thank')) {
+            $uploader->notify(new NewThank('torrent', $thank));
+        }
 
         $this->dispatch('success', type: 'success', message: 'Your Thank Was Successfully Applied!');
     }

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -19,8 +19,6 @@ namespace App\Models;
 use App\Enums\ModerationStatus;
 use App\Helpers\StringHelper;
 use App\Models\Scopes\ApprovedScope;
-use App\Notifications\NewComment;
-use App\Notifications\NewThank;
 use App\Traits\Auditable;
 use App\Traits\GroupedLastScope;
 use Illuminate\Database\Eloquent\Builder;
@@ -800,31 +798,6 @@ class Torrent extends Model
         $bytes = $this->size;
 
         return StringHelper::formatBytes($bytes, 2);
-    }
-
-    /**
-     * Notify Uploader When An Action Is Taken.
-     */
-    public function notifyUploader(string $type, Thank|Comment $payload): bool
-    {
-        $user = User::with('notification')->findOrFail($this->user_id);
-
-        switch (true) {
-            case $payload instanceof Thank:
-                if ($user->acceptsNotification(auth()->user(), $user, 'torrent', 'show_torrent_thank')) {
-                    $user->notify(new NewThank('torrent', $payload));
-                }
-
-                break;
-            case $payload instanceof Comment:
-                if ($user->acceptsNotification(auth()->user(), $user, 'torrent', 'show_torrent_comment')) {
-                    $user->notify(new NewComment($this, $payload));
-                }
-
-                break;
-        }
-
-        return true;
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -601,12 +601,6 @@ parameters:
 			path: app/Models/Rss.php
 
 		-
-			message: '#^Instanceof between App\\Models\\Comment and App\\Models\\Comment will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: app/Models/Torrent.php
-
-		-
 			message: '#^Strict comparison using \=\=\= between float\|null and 0 will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1


### PR DESCRIPTION
Comments notifications are already created directly when the comment is created, so the thank portion can just be inlined as well.