### PR TITLE
(Refactor) Simplify str_pad with imdb id generation

### DIFF
--- a/resources/views/rss/show.blade.php
+++ b/resources/views/rss/show.blade.php
@@ -43,7 +43,7 @@
                                 {{ __('common.anonymous') }} {{ __('torrent.uploader') }}
                             @endif<br>
                             @if (($torrent['category']['movie_meta'] || $torrent['category']['tv_meta']) && $torrent['imdb'] != 0)
-                                IMDB Link:<a href="https://anon.to?http://www.imdb.com/title/tt{{ \str_pad((string) $torrent['imdb'], \max(\strlen((string) $torrent['imdb']), 7), '0', STR_PAD_LEFT) }}"
+                                IMDB Link:<a href="https://anon.to?http://www.imdb.com/title/tt{{ \str_pad((string) $torrent['imdb'], 7, '0', STR_PAD_LEFT) }}"
                                              target="_blank">tt{{ $torrent['imdb'] }}</a><br>
                             @endif
                             @if ($torrent['category']['movie_meta'] && $torrent['tmdb_movie_id'] > 0)

--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -158,8 +158,8 @@
             <li class="meta__imdb">
                 <a
                     class="meta-id-tag"
-                    href="https://www.imdb.com/title/tt{{ \str_pad((string) $imdbId, \max(\strlen((string) $imdbId), 7), '0', STR_PAD_LEFT) }}"
-                    title="Internet Movie Database: {{ \str_pad((string) $imdbId, \max(\strlen((string) $imdbId), 7), '0', STR_PAD_LEFT) }}"
+                    href="https://www.imdb.com/title/tt{{ \str_pad((string) $imdbId, 7, '0', STR_PAD_LEFT) }}"
+                    title="Internet Movie Database: {{ \str_pad((string) $imdbId, 7, '0', STR_PAD_LEFT) }}"
                     target="_blank"
                 >
                     <img src="{{ url('/img/meta/imdb.svg') }}" />

--- a/resources/views/torrent/partials/no-meta.blade.php
+++ b/resources/views/torrent/partials/no-meta.blade.php
@@ -39,12 +39,12 @@
             <li class="meta__imdb">
                 <a
                     class="meta-id-tag"
-                    href="https://www.imdb.com/title/tt{{ \str_pad((int) $torrent->imdb, \max(\strlen((int) $torrent->imdb), 7), '0', STR_PAD_LEFT) }}"
+                    href="https://www.imdb.com/title/tt{{ \str_pad((int) $torrent->imdb, 7, '0', STR_PAD_LEFT) }}"
                     title="Internet Movie Database"
                     target="_blank"
                 >
                     IMDB:
-                    {{ \str_pad((int) $torrent->imdb, \max(\strlen((int) $torrent->imdb), 7), '0', STR_PAD_LEFT) }}
+                    {{ \str_pad((string) $torrent->imdb, 7, '0', STR_PAD_LEFT) }}
                 </a>
             </li>
         @endif


### PR DESCRIPTION
str_pad by default doesn't strip existing characters in the string if the given length is shorter than the length of the string (and doesn't add any padding either).