### PR TITLE
(Refactor) Save request last bounty timestamp separately

### DIFF
--- a/app/Http/Controllers/BountyController.php
+++ b/app/Http/Controllers/BountyController.php
@@ -50,7 +50,7 @@ class BountyController extends Controller
 
         $torrentRequest->increment('bounty', $request->integer('seedbonus'));
 
-        $torrentRequest->created_at = now();
+        $torrentRequest->bumped_at = now();
         $torrentRequest->save();
 
         if ($request->boolean('anon') == 0) {

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -134,7 +134,10 @@ class RequestController extends Controller
 
         $user->decrement('seedbonus', $request->bounty);
 
-        $torrentRequest = TorrentRequest::query()->create(['user_id' => $request->user()->id] + $request->validated());
+        $torrentRequest = TorrentRequest::query()->create([
+            'user_id'   => $request->user()->id,
+            'bumped_at' => now(),
+        ] + $request->validated());
 
         TorrentRequestBounty::query()->create([
             'user_id'     => $user->id,

--- a/app/Http/Livewire/TorrentRequestSearch.php
+++ b/app/Http/Livewire/TorrentRequestSearch.php
@@ -113,7 +113,7 @@ class TorrentRequestSearch extends Component
     public int $perPage = 25;
 
     #[Url(history: true)]
-    public string $sortField = 'created_at';
+    public string $sortField = 'bumped_at';
 
     #[Url(history: true)]
     public string $sortDirection = 'desc';

--- a/app/Models/TorrentRequest.php
+++ b/app/Models/TorrentRequest.php
@@ -43,6 +43,7 @@ use AllowDynamicProperties;
  * @property bool                            $anon
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $bumped_at
  * @property int|null                        $filled_by
  * @property int|null                        $torrent_id
  * @property \Illuminate\Support\Carbon|null $filled_when
@@ -94,6 +95,7 @@ final class TorrentRequest extends Model
         return [
             'filled_when'   => 'datetime',
             'approved_when' => 'datetime',
+            'bumped_at'     => 'datetime',
             'tmdb_movie_id' => 'int',
             'tmdb_tv_id'    => 'int',
             'igdb'          => 'int',

--- a/database/factories/TorrentRequestFactory.php
+++ b/database/factories/TorrentRequestFactory.php
@@ -58,6 +58,7 @@ class TorrentRequestFactory extends Factory
             'approved_when' => $this->faker->dateTime(),
             'type_id'       => Type::factory(),
             'resolution_id' => Resolution::factory(),
+            'bumped_at'     => $this->faker->dateTime(),
         ];
     }
 }

--- a/database/migrations/2026_03_10_033755_migrate_request_bounty_created_at_to_updated_at.php
+++ b/database/migrations/2026_03_10_033755_migrate_request_bounty_created_at_to_updated_at.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('requests', function (Blueprint $table): void {
+            $table->timestamp('bumped_at')->after('updated_at')->index();
+        });
+
+        DB::table('requests')
+            ->leftJoinSub(
+                DB::table('request_bounty')
+                    ->select([
+                        'requests_id',
+                        DB::raw('MIN(created_at) AS min_created_at'),
+                        DB::raw('MAX(created_at) AS max_created_at'),
+                    ])
+                    ->groupBy('requests_id'),
+                'bounties',
+                fn ($join) => $join->on('requests_id', '=', 'requests.id'),
+            )
+            ->update([
+                'requests.created_at' => DB::raw('COALESCE(bounties.min_created_at, NOW())'),
+                'requests.bumped_at'  => DB::raw('COALESCE(bounties.max_created_at, NOW())'),
+            ]);
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -1487,6 +1487,7 @@ CREATE TABLE `requests` (
   `anon` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
+  `bumped_at` timestamp NOT NULL,
   `filled_by` int unsigned DEFAULT NULL,
   `torrent_id` int unsigned DEFAULT NULL,
   `filled_when` datetime DEFAULT NULL,
@@ -1511,6 +1512,7 @@ CREATE TABLE `requests` (
   KEY `requests_tv_id_index` (`tmdb_tv_id`),
   KEY `requests_season_number_episode_number_index` (`season_number`,`episode_number`),
   KEY `requests_episode_number_index` (`episode_number`),
+  KEY `requests_bumped_at_index` (`bumped_at`),
   CONSTRAINT `requests_approved_by_foreign` FOREIGN KEY (`approved_by`) REFERENCES `users` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `requests_category_id_foreign` FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`) ON DELETE RESTRICT,
   CONSTRAINT `requests_filled_by_foreign` FOREIGN KEY (`filled_by`) REFERENCES `users` (`id`) ON UPDATE CASCADE,
@@ -3125,3 +3127,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (375,'2026_02_02_18
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (376,'2026_02_03_012707_drop_keys_from_seedboxes',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (377,'2026_02_04_184040_combine_user_audibles_echoes',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (378,'2026_02_18_023757_change_donation_dates_to_timestamps',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (379,'2026_03_10_033755_migrate_request_bounty_created_at_to_updated_at',1);

--- a/resources/views/livewire/torrent-request-search.blade.php
+++ b/resources/views/livewire/torrent-request-search.blade.php
@@ -336,9 +336,9 @@
                             <i class="{{ config('other.font-awesome') }} fa-coins"></i>
                             @include('livewire.includes._sort-icon', ['field' => 'bounty'])
                         </th>
-                        <th wire:click="sortBy('created_at')" role="columnheader button">
+                        <th wire:click="sortBy('bumped_at')" role="columnheader button">
                             {{ __('common.created_at') }}
-                            @include('livewire.includes._sort-icon', ['field' => 'created_at'])
+                            @include('livewire.includes._sort-icon', ['field' => 'bumped_at'])
                         </th>
                         <th>{{ __('common.status') }}</th>
                     </tr>
@@ -367,10 +367,10 @@
                             <td>{{ number_format($torrentRequest->bounty) }}</td>
                             <td>
                                 <time
-                                    datetime="{{ $torrentRequest->created_at }}"
-                                    title="{{ $torrentRequest->created_at }}"
+                                    datetime="{{ $torrentRequest->bumped_at }}"
+                                    title="{{ $torrentRequest->bumped_at }}"
                                 >
-                                    {{ $torrentRequest->created_at->diffForHumans() }}
+                                    {{ $torrentRequest->bumped_at->diffForHumans() }}
                                 </time>
                             </td>
                             <td>


### PR DESCRIPTION
created_at is the wrong field to save this value in because the initial created_at date is lost. Using updated_at also doesn't work since updating the request fields will bump the request even if more bounty isn't added. So, we use a new field for this info. We use a field on the requests table and not the request_bounty table so that we can use an index to sort.