### PR TITLE
(Fix) Load thanks count after thanking on torrent page

### DIFF
--- a/app/Http/Livewire/ThankButton.php
+++ b/app/Http/Livewire/ThankButton.php
@@ -59,6 +59,8 @@ class ThankButton extends Component
         }
 
         $this->dispatch('success', type: 'success', message: 'Your thank was successfully applied!');
+
+        $this->torrent->loadCount('thanks');
     }
 
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application


### PR DESCRIPTION
Livewire doesn't reload the relations when the button is clicked and the number disappears.