### PR TITLE
(Fix) Add sizes to animation notification when styles don't load

### DIFF
--- a/resources/views/components/animation/notification.blade.php
+++ b/resources/views/components/animation/notification.blade.php
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 100 100">
+<svg viewBox="0 0 100 100" width="17px" height="17px">
     <circle fill="transparent" stroke="#b6b6b6" stroke-width="10" cx="50" cy="50" r="15">
         <animate attributeName="r" values="0;5;25;40;50" dur="1s" repeatCount="indefinite" />
         <animate attributeName="opacity" values="0;.1;.3;.5;0" dur="1s" repeatCount="indefinite" />


### PR DESCRIPTION
That way you don't have a blinking dot the size of the page width. I added the same dimensions that the css currently styles it as.