### PR TITLE
(Fix) Firefox v143 breaks bbcode spoiler styling

### DIFF
--- a/resources/sass/components/_bbcode-rendered.scss
+++ b/resources/sass/components/_bbcode-rendered.scss
@@ -99,7 +99,7 @@
         padding: 0 6px;
         margin-top: 0;
         margin-bottom: 2px;
-        display: inline;
+        display: inline-block;
         max-width: 100%;
 
         summary {


### PR DESCRIPTION
Firefox v143 changes the styling of `<details>` elements, forcing the inline horizontal padding to stretch onto the line above and below and add extra "vertical padding". This commit changes the `display` of the `<details>` element used in the bbcode spoiler to `inline-block` which mimics the original behaviour prior to the firefox change.