### PR TITLE
(Update) Reset page to 1 when search query changes

### DIFF
--- a/app/Http/Livewire/TorrentRequestSearch.php
+++ b/app/Http/Livewire/TorrentRequestSearch.php
@@ -121,6 +121,8 @@ class TorrentRequestSearch extends Component
     final public function updating(string $field, mixed &$value): void
     {
         $this->castLivewireProperties($field, $value);
+
+        $this->resetPage();
     }
 
     /**

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -265,10 +265,7 @@ class TorrentSearch extends Component
     final public function updating(string $field, mixed &$value): void
     {
         $this->castLivewireProperties($field, $value);
-    }
 
-    final public function updatingName(): void
-    {
         $this->resetPage();
     }
 


### PR DESCRIPTION
Just for torrents and requests for now, but this could be expanded into a trait and used everywhere at a later point in time.