### PR TITLE
(Fix) Searching for people shouldn't search their still link

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -261,6 +261,51 @@ return [
                 'facetSearch'        => false,
                 'proximityPrecision' => 'byAttribute',
             ],
+            'people' => [
+                'searchableAttributes' => [
+                    'name',
+                ],
+                'filterableAttributes' => [
+                    [
+                        'attributePatterns' => [
+                            'id',
+                        ],
+                        "features" => [
+                            "facetSearch" => false,
+                            "filter"      => [
+                                "equality"   => true,
+                                "comparison" => false,
+                            ],
+                        ]
+                    ],
+                    [
+                        'attributePatterns' => [
+                            'birthday',
+                        ],
+                        "features" => [
+                            "facetSearch" => false,
+                            "filter"      => [
+                                "equality"   => true,
+                                "comparison" => true,
+                            ],
+                        ]
+                    ],
+                ],
+                'sortableAttributes' => [
+                    'name',
+                    'birthday',
+                ],
+                'rankingRules' => [
+                    'sort',
+                    'attribute',
+                    'exactness',
+                    'words',
+                    'typo',
+                    'proximity',
+                ],
+                'facetSearch'        => false,
+                'proximityPrecision' => 'byAttribute',
+            ],
         ],
     ],
 


### PR DESCRIPTION
Searching for `https://...` would return any person.

`php artisan scout:sync-index-settings` has to be ran afterwards.

fixes #5006