### PR TITLE
(Fix) Mediainfo parser broke in image sections

### DIFF
--- a/app/Helpers/MediaInfo.php
+++ b/app/Helpers/MediaInfo.php
@@ -71,7 +71,7 @@ namespace App\Helpers;
  */
 class MediaInfo
 {
-    private const REGEX_SECTION = "/^(?:(?:general|video|audio|text|menu)(?:\s\#\d+?)*)$/i";
+    private const REGEX_SECTION = "/^(?:(?:general|video|audio|text|image|menu)(?:\s\#\d+?)*)$/i";
 
     /**
      * @var string[]


### PR DESCRIPTION
Simple as adding `image` to the regex, even though we don't parse anything from it. It just ends up being a section with no data added.

fixes #5004