### PR TITLE
(Fix) Download check logic

### DIFF
--- a/resources/views/torrent/download-check.blade.php
+++ b/resources/views/torrent/download-check.blade.php
@@ -73,7 +73,7 @@
     <section class="panelV2">
         <h2 class="panel__heading">{{ __('torrent.download-check') }}</h2>
         <div class="panel__body">
-            @if ($user->ratio < config('other.ratio') || $user->can_download == 0)
+            @if (($user->ratio < config('other.ratio') || $user->can_download == 0) && $torrent->user_id !== $user->id)
                 <h4>{{ __('torrent.no-privileges') }}</h4>
             @else
                 <h4>{{ __('torrent.ready') }}</h4>
@@ -143,8 +143,7 @@
             </div>
         </dl>
         <div class="panel__body">
-            @if ($user->ratio < config('other.ratio') ||
-                ($user->can_download == 0 && $torrent->user_id != $user->id))
+            @if (($user->ratio < config('other.ratio') || $user->can_download == 0) && $torrent->user_id != $user->id)
                 <span class="text-red text-bold">{{ __('torrent.no-privileges-desc') }}</span>
             @else
                 <p class="form__group form__group--horizontal">


### PR DESCRIPTION
This was never implemented correctly and should have been made obvious in #0fbbe6a, but the parentheses are surrounding the wrong section. This change matches the backend authorization in TorrentDownloadController.

fixes #4449