### PR TITLE
(Update) Non full width torrents page and narrower site margins

### DIFF
--- a/resources/sass/components/_user-active.scss
+++ b/resources/sass/components/_user-active.scss
@@ -1,5 +1,5 @@
 .user-peers {
-    margin: 0 calc(-1 * max(0px, 10vw - 60px, 25vw - 300px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
+    margin: 0 calc(-1 * max(0px, 10vw - 100px, 25vw - 320px, 45vw - 820px)); /* Inverses the magic numbers used in the main layout styles */
     width: max-content;
     max-width: 100vw;
     align-self: center;

--- a/resources/sass/components/_user-resurrections.scss
+++ b/resources/sass/components/_user-resurrections.scss
@@ -1,5 +1,5 @@
 .user-resurrections {
-    margin: 0 calc(-1 * max(0px, 10vw - 60px, 25vw - 300px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
+    margin: 0 calc(-1 * max(0px, 10vw - 100px, 25vw - 320px, 45vw - 820px)); /* Inverses the magic numbers used in the main layout styles */
     width: max-content;
     max-width: 100vw;
     align-self: center;

--- a/resources/sass/components/_user-torrents.scss
+++ b/resources/sass/components/_user-torrents.scss
@@ -1,5 +1,5 @@
 .user-torrents {
-    margin: 0 calc(-1 * max(0px, 10vw - 60px, 25vw - 300px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
+    margin: 0 calc(-1 * max(0px, 10vw - 100px, 25vw - 320px, 45vw - 820px)); /* Inverses the magic numbers used in the main layout styles */
     width: max-content;
     max-width: 100vw;
     align-self: center;

--- a/resources/sass/components/_user-uploads.scss
+++ b/resources/sass/components/_user-uploads.scss
@@ -1,5 +1,5 @@
 .user-uploads {
-    margin: 0 calc(-1 * max(0px, 10vw - 60px, 25vw - 300px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
+    margin: 0 calc(-1 * max(0px, 10vw - 100px, 25vw - 320px, 45vw - 820px)); /* Inverses the magic numbers used in the main layout styles */
     width: max-content;
     max-width: 100vw;
     align-self: center;

--- a/resources/sass/layout/_footer.scss
+++ b/resources/sass/layout/_footer.scss
@@ -4,7 +4,7 @@ body {
 }
 
 .footer {
-    padding: 20px max(20px, 10vw - 60px, 25vw - 300px, 45vw - 800px); /* Magic numbers - slightly increases the margins as you go from 0 to 600px to 1600px to 2500px to beyond */
+    padding: 20px max(20px, 10vw - 100px, 25vw - 320px, 45vw - 820px); /* Magic numbers - slightly increases the margins as you go from 0 to 600px to 1600px to 2500px to beyond */
 }
 
 .footer {

--- a/resources/sass/layout/_main.scss
+++ b/resources/sass/layout/_main.scss
@@ -1,5 +1,5 @@
 main {
-    margin: 0 max(0px, 10vw - 60px, 25vw - 300px, 45vw - 800px); /* Magic numbers - slightly increases the margins as you go from 0 to 600px to 1600px to 2500px to beyond */
+    margin: 0 max(0px, 10vw - 100px, 25vw - 320px, 45vw - 820px); /* Magic numbers - slightly increases the margins as you go from 0 to 600px to 1600px to 2500px to beyond */
 }
 
 main > article {

--- a/resources/sass/pages/_requests.scss
+++ b/resources/sass/pages/_requests.scss
@@ -5,7 +5,7 @@
 }
 
 .request-search__filters {
-    margin: 0 calc(-1 * max(0px, 45vw - 800px) + max(12px, 45vw - 600px)); /* Inverses the magic numbers used in main layout styles for high resolution then adds own magic numbers */
+    margin: 0 calc(-1 * max(0px, 45vw - 820px) + max(12px, 45vw - 600px)); /* Inverses the magic numbers used in main layout styles for high resolution then adds own magic numbers */
 }
 
 @media only screen and (max-width: 767px) {

--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -3,7 +3,7 @@
             .torrent-search--card__results,
             .torrent-search--poster__results
         ) {
-        margin: 0 calc(-1 * max(0px, 10vw - 60px, 25vw - 300px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
+        margin: 0 calc(-1 * max(0px, 10vw - 100px, 25vw - 320px, 45vw - 820px)); /* Inverses the magic numbers used in the main layout styles */
     }
 }
 
@@ -24,13 +24,13 @@
                     + .torrent-search__results .torrent-search--poster__results
                 )
         ) {
-        margin: 0 calc(-1 * max(0px, 45vw - 800px) + max(12px, 45vw - 600px)); /* Inverses the magic numbers used in main layout styles for high resolution then adds own magic numbers */
+        margin: 0 calc(-1 * max(0px, 45vw - 820px) + max(12px, 45vw - 600px)); /* Inverses the magic numbers used in main layout styles for high resolution then adds own magic numbers */
     }
 }
 
 @supports not selector(:has(.torrent-search-grouped_-results)) {
     .torrent-search__filters {
-        margin: 0 calc(-1 * max(0px, 45vw - 800px) + max(12px, 45vw - 600px));
+        margin: 0 calc(-1 * max(0px, 45vw - 820px) + max(12px, 45vw - 600px));
     }
 }
 
@@ -952,7 +952,7 @@ td.torrent-search--grouped__age time {
 }
 
 .similar-torrents__filters {
-    margin: 0 calc(-1 * max(0px, 45vw - 800px) + max(12px, 45vw - 600px)); /* Inverses the magic numbers used in main layout styles for high resolution then adds own magic numbers */
+    margin: 0 calc(-1 * max(0px, 45vw - 820px) + max(12px, 45vw - 600px)); /* Inverses the magic numbers used in main layout styles for high resolution then adds own magic numbers */
 }
 
 .similar-torrents__torrents tbody:nth-child(odd) {

--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -1,5 +1,8 @@
 @supports selector(:has(.torrent-search-grouped__results)) {
-    .page__torrents:not(:has(.torrent-search--grouped__results)) {
+    .page__torrents:has(
+            .torrent-search--card__results,
+            .torrent-search--poster__results
+        ) {
         margin: 0 calc(-1 * max(0px, 10vw - 60px, 25vw - 300px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
     }
 }
@@ -15,8 +18,11 @@
         margin: 0 max(12px, 45vw - 600px); /* Adds magic numbers to shrink the advanced search a shorter width than the results on higher resolutions. */
     }
 
-    .torrent-search__filters:has(
-            + .torrent-search__results .torrent-search--grouped__results
+    .torrent-search__filters:not(
+            :has(
+                    + .torrent-search__results .torrent-search--card__results,
+                    + .torrent-search__results .torrent-search--poster__results
+                )
         ) {
         margin: 0 calc(-1 * max(0px, 45vw - 800px) + max(12px, 45vw - 600px)); /* Inverses the magic numbers used in main layout styles for high resolution then adds own magic numbers */
     }

--- a/resources/sass/pages/_trending.scss
+++ b/resources/sass/pages/_trending.scss
@@ -1,5 +1,5 @@
 .trending--weekly {
-    margin: 0 calc(-1 * max(0px, 10vw - 60px, 25vw - 300px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
+    margin: 0 calc(-1 * max(0px, 10vw - 100px, 25vw - 320px, 45vw - 820px)); /* Inverses the magic numbers used in the main layout styles */
     width: max-content;
     max-width: 100vw;
     align-self: center;


### PR DESCRIPTION
Times have changed and the average p2p user's desktop monitor resolution has increased. The torrent listings page is too stretched out on large desktop monitor resolutions. Let's constrain its width to the same width used currently for every other page.

A significant majority of users use two browser windows side by side on 1080p or 1440p displays which a narrower margin suits better.