### PR TITLE
(Add) Torrent count and single seed count to client stats

### DIFF
--- a/resources/views/stats/clients/clients.blade.php
+++ b/resources/views/stats/clients/clients.blade.php
@@ -24,6 +24,8 @@
                     <tr>
                         <th>Client</th>
                         <th>{{ __('common.users') }}</th>
+                        <th>{{ __('torrent.torrents') }}</th>
+                        <th>Single Seeds</th>
                         <th>{{ __('torrent.peers') }}</th>
                     </tr>
                 </thead>
@@ -31,7 +33,7 @@
                     @foreach ($clients as $prefix => $group)
                         <tbody x-data="toggle">
                             <tr x-on:click="toggle" style="cursor: pointer">
-                                <td>
+                                <td style="width: 50%">
                                     <a
                                         href="{{ route('staff.peers.index', ['agent' => $prefix]) }}"
                                         x-on:click.stop
@@ -40,18 +42,22 @@
                                     </a>
                                 </td>
                                 <td>{{ $group['user_count'] }}</td>
+                                <td>{{ $group['torrent_count'] }}</td>
+                                <td>{{ $group['single_seed_count'] ?? 0 }}</td>
                                 <td>{{ $group['peer_count'] }}</td>
                             </tr>
-                            @foreach ($group['clients'] as $client)
+                            @foreach ($group['clients'] as $agent => $client)
                                 <tr x-cloak x-show="isToggledOn">
-                                    <td style="padding: 0 0 0 24px">
+                                    <td style="padding: 0 0 0 24px; width: 50%">
                                         <a
-                                            href="{{ route('staff.peers.index', ['agent' => $client['agent']]) }}"
+                                            href="{{ route('staff.peers.index', ['agent' => $agent]) }}"
                                         >
-                                            {{ $client['agent'] }}
+                                            {{ $agent }}
                                         </a>
                                     </td>
                                     <td>{{ $client['user_count'] }}</td>
+                                    <td>{{ $client['torrent_count'] }}</td>
+                                    <td>{{ $client['single_seed_count'] ?? 0 }}</td>
                                     <td>{{ $client['peer_count'] }}</td>
                                 </tr>
                             @endforeach
@@ -63,12 +69,16 @@
                             <tr x-on:click="toggle" style="cursor: pointer">
                                 <td>{{ $prefix }}</td>
                                 <td>{{ $group['user_count'] }}</td>
+                                <td>{{ $group['torrent_count'] }}</td>
+                                <td>{{ $group['single_seed_count'] ?? 0 }}</td>
                                 <td>{{ $group['peer_count'] }}</td>
                             </tr>
-                            @foreach ($group['clients'] as $client)
+                            @foreach ($group['clients'] as $agent => $client)
                                 <tr x-cloak x-show="isToggledOn">
-                                    <td style="padding: 0 0 0 24px">{{ $client['agent'] }}</td>
+                                    <td style="padding: 0 0 0 24px">{{ $agent }}</td>
                                     <td>{{ $client['user_count'] }}</td>
+                                    <td>{{ $client['torrent_count'] }}</td>
+                                    <td>{{ $client['single_seed_count'] ?? 0 }}</td>
                                     <td>{{ $client['peer_count'] }}</td>
                                 </tr>
                             @endforeach


### PR DESCRIPTION
Makes it easy to see which clients are most/least responsible for keeping alive torrents on the site.