### PR TITLE
(Remove) Timestamps from wiki and page indexes

### DIFF
--- a/resources/views/page/index.blade.php
+++ b/resources/views/page/index.blade.php
@@ -11,13 +11,6 @@
         <h2 class="panel__heading">Pages</h2>
         <div class="data-table-wrapper">
             <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>{{ __('common.name') }}</th>
-                        <th>Created</th>
-                        <th>Updated</th>
-                    </tr>
-                </thead>
                 <tbody>
                     @foreach ($pages as $page)
                         <tr>
@@ -25,22 +18,6 @@
                                 <a href="{{ route('pages.show', ['page' => $page]) }}">
                                     {{ $page->name }}
                                 </a>
-                            </td>
-                            <td>
-                                <time
-                                    datetime="{{ $page->created_at }}"
-                                    title="{{ $page->created_at }}"
-                                >
-                                    {{ $page->created_at }}
-                                </time>
-                            </td>
-                            <td>
-                                <time
-                                    datetime="{{ $page->updated_at }}"
-                                    title="{{ $page->updated_at }}"
-                                >
-                                    {{ $page->updated_at }}
-                                </time>
                             </td>
                         </tr>
                     @endforeach

--- a/resources/views/wiki/index.blade.php
+++ b/resources/views/wiki/index.blade.php
@@ -22,13 +22,6 @@
             </h2>
             <div class="data-table-wrapper">
                 <table class="data-table">
-                    <thead>
-                        <tr>
-                            <th>{{ __('common.name') }}</th>
-                            <th>Created</th>
-                            <th>Updated</th>
-                        </tr>
-                    </thead>
                     <tbody>
                         @forelse ($category->wikis->sortBy('name') as $wiki)
                             <tr>
@@ -37,16 +30,10 @@
                                         {{ $wiki->name }}
                                     </a>
                                 </td>
-                                <td>
-                                    {{ $wiki->created_at }}
-                                </td>
-                                <td>
-                                    {{ $wiki->updated_at }}
-                                </td>
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="3">No wikis in category.</td>
+                                <td>No wikis in category.</td>
                             </tr>
                         @endforelse
                     </tbody>


### PR DESCRIPTION
Each table align the timestamps differently where it looks weird. "Fix" by removing the timestamps and having each row be a single table cell. The timestamps are still visible on their respective pages.