### PR TITLE
(Fix) Error 500 caused by search on game similar page

### DIFF
--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -378,7 +378,7 @@ class SimilarTorrent extends Component
             ->withExists('claim')
             ->when($this->category->movie_meta, fn ($query) => $query->where('tmdb_movie_id', '=', $this->tmdbId))
             ->when($this->category->tv_meta, fn ($query) => $query->where('tmdb_tv_id', '=', $this->tmdbId))
-            ->when($this->category->game_meta, fn ($query) => $query->where('igdb', '=', $this->tmdbId))
+            ->when($this->category->game_meta, fn ($query) => $query->where('igdb', '=', $this->igdbId))
             ->where('category_id', '=', $this->category->id)
             ->when(
                 $this->hideFilledRequests,
@@ -407,7 +407,7 @@ class SimilarTorrent extends Component
                     )
                     ->when($this->category->movie_meta, fn ($query) => $query->whereRelation('torrents', 'tmdb_movie_id', '=', $this->tmdbId))
                     ->when($this->category->tv_meta, fn ($query) => $query->whereRelation('torrents', 'tmdb_tv_id', '=', $this->tmdbId))
-                    ->when($this->category->game_meta, fn ($query) => $query->whereRelation('torrents', 'igdb', '=', $this->tmdbId))
+                    ->when($this->category->game_meta, fn ($query) => $query->whereRelation('torrents', 'igdb', '=', $this->igdbId))
                     ->when(!($this->category->movie_meta || $this->category->tv_meta || $this->category->game_meta), fn ($query) => $query->whereRaw('0 = 1'))
             ])
             ->orderBy('position')


### PR DESCRIPTION
We need to search by igdbId here, not the tmdbId. The tmdbId is not initialized sometimes which causes errors.