### PR TITLE
(Fix) Meter styles on chromium and safari browsers

### DIFF
--- a/resources/sass/components/form/_meter.scss
+++ b/resources/sass/components/form/_meter.scss
@@ -11,3 +11,11 @@
 .form__meter::-moz-meter-bar {
     background: var(--meter-fg);
 }
+
+.form__meter::-webkit-meter-bar {
+    background: var(--meter-bg);
+}
+
+.form__meter::-webkit-meter-optimum-value {
+    background: var(--meter-fg);
+}


### PR DESCRIPTION
It's not a perfect match from the intended styles in firefox, but it's better than the early 2000s styles that were there before.