### PR TITLE
(Fix) Typo in torrent.php

### DIFF
--- a/lang/en/torrent.php
+++ b/lang/en/torrent.php
@@ -184,7 +184,7 @@ return [
     'search-by-name'           => 'Search by name',
     'season-number'            => 'Season number',
     'season'                   => 'Season',
-    'seed-time'                => 'Seed yime',
+    'seed-time'                => 'Seed time',
     'seeder'                   => 'Seeder',
     'seeders'                  => 'Seeders',
     'seeding'                  => 'Seeding',


### PR DESCRIPTION
"Seed yime" to "Seed time". Realized when translating.