### PR TITLE
(Add) Indicator for private profiles in top-nav

### DIFF
--- a/lang/en/user.php
+++ b/lang/en/user.php
@@ -277,6 +277,7 @@ return [
     'profile'                       => 'Profile',
     'profile-desc'                  => 'User :user profile registered on :title',
     'profile-privacy'               => 'Profile settings',
+    'profile-is-private'            => 'Your profile is set to private',
     'profile-privacy-torrent-count' => 'Share your total number of downloads, uploads, seeds and leeches',
     'profile-privacy-torrent-ratio' => 'Share your total upload/download data along with recorded ratio',
     'profile-privacy-torrent-seed'  => 'Share your total seeding time and average',

--- a/resources/sass/layout/_top_nav.scss
+++ b/resources/sass/layout/_top_nav.scss
@@ -436,6 +436,16 @@
     border-radius: var(--top-nav-icon-bar-icon-border-radius);
 }
 
+.top-nav__profile-image-private-icon.top-nav__profile-image-private-icon {
+    position: absolute;
+    bottom: -2px;
+    right: -2px;
+    background: var(--top-nav-bg);
+    height: 17px;
+    line-height: 17px;
+    font-size: 12px;
+}
+
 /* Menu toggle
 ******************************************************************************/
 

--- a/resources/views/partials/top-nav.blade.php
+++ b/resources/views/partials/top-nav.blade.php
@@ -396,6 +396,12 @@
                         alt="{{ __('user.my-profile') }}"
                         class="top-nav__profile-image"
                     />
+                    @if (auth()->user()->privacy?->private_profile)
+                        <i
+                            class="{{ config('other.font-awesome') }} fa-ghost top-nav__profile-image-private-icon"
+                            title="{{ __('user.profile-is-private') }}"
+                        ></i>
+                    @endif
                 </a>
                 <a class="top-nav__dropdown--touch" tabindex="0">
                     <img
@@ -403,6 +409,12 @@
                         alt="{{ __('user.my-profile') }}"
                         class="top-nav__profile-image"
                     />
+                    @if (auth()->user()->privacy?->private_profile)
+                        <i
+                            class="{{ config('other.font-awesome') }} fa-ghost top-nav__profile-image-private-icon"
+                            title="{{ __('user.profile-is-private') }}"
+                        ></i>
+                    @endif
                 </a>
                 <ul>
                     <li>


### PR DESCRIPTION
Users should be able to check what their privacy settings are without navigating to their privacy settings every time.