### PR TITLE
(Update) Arch linux install wiki to copy .env.example

### DIFF
--- a/book/src/local_development_arch_linux.md
+++ b/book/src/local_development_arch_linux.md
@@ -13,8 +13,9 @@ This guide outlines the steps to set up UNIT3D using Laravel Sail on Arch Linux.
 
 For local development, HTTP is commonly used instead of HTTPS. To prevent mixed content issues, adjust your `.env` file as follows:
 
-1. **Modify the `.env` Config:**
-    - Open your `.env` file in the root directory of your UNIT3D project.
+1. **Create the `.env` Config:**
+    - Create a `.env` file in the root directory of your UNIT3D project.
+    - Copy and paste the contents from `.env.example` into the `.env` file.
     - Add or modify the following environment variables:
 
         ```dotenv


### PR DESCRIPTION
The .env file doesn't already exist. The user has to first create it and copy and paste the contents from .env.example into it.