### PR TITLE
(Fix) Only show post/topic chatbox notifications for non-ranked forums

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -117,10 +117,17 @@ class PostController extends Controller
                 $staffer->notify(new NewPost('staff', $user, $post));
             }
         } else {
-            if ($post->anon) {
-                $this->chatRepository->systemMessage(\sprintf('An anonymous user has left a reply on topic [url=%s]%s[/url]', $postUrl, $topic->name));
-            } else {
-                $this->chatRepository->systemMessage(\sprintf('[url=%s]%s[/url] has left a reply on topic [url=%s]%s[/url]', $profileUrl, $user->username, $postUrl, $topic->name));
+            $isChatboxPrivy = $forum->permissions()
+                ->where('read_topic', '=', true)
+                ->whereRelation('group', 'slug', '=', 'user')
+                ->exists();
+
+            if ($isChatboxPrivy) {
+                if ($post->anon) {
+                    $this->chatRepository->systemMessage(\sprintf('An anonymous user has left a reply on topic [url=%s]%s[/url]', $postUrl, $topic->name));
+                } else {
+                    $this->chatRepository->systemMessage(\sprintf('[url=%s]%s[/url] has left a reply on topic [url=%s]%s[/url]', $profileUrl, $user->username, $postUrl, $topic->name));
+                }
             }
 
             $topicStarter = $topic->user;

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -158,10 +158,17 @@ class TopicController extends Controller
                 $staffer->notify(new NewTopic('staff', $user, $topic, $post));
             }
         } else {
-            if ($post->anon) {
-                $this->chatRepository->systemMessage(\sprintf('An anonymous user has created a new topic [url=%s]%s[/url]', $topicUrl, $topic->name));
-            } else {
-                $this->chatRepository->systemMessage(\sprintf('[url=%s]%s[/url] has created a new topic [url=%s]%s[/url]', $profileUrl, $user->username, $topicUrl, $topic->name));
+            $isChatboxPrivy = $forum->permissions()
+                ->where('read_topic', '=', true)
+                ->whereRelation('group', 'slug', '=', 'user')
+                ->exists();
+
+            if ($isChatboxPrivy) {
+                if ($post->anon) {
+                    $this->chatRepository->systemMessage(\sprintf('An anonymous user has created a new topic [url=%s]%s[/url]', $topicUrl, $topic->name));
+                } else {
+                    $this->chatRepository->systemMessage(\sprintf('[url=%s]%s[/url] has created a new topic [url=%s]%s[/url]', $profileUrl, $user->username, $topicUrl, $topic->name));
+                }
             }
 
             $subscribers = User::query()


### PR DESCRIPTION
The name of the topic is more important than the achievement count.