### PR TITLE
(Fix) Audit log strings being utf-16 double encoded

### DIFF
--- a/resources/views/livewire/audit-log-search.blade.php
+++ b/resources/views/livewire/audit-log-search.blade.php
@@ -119,8 +119,10 @@
                                             overflow-wrap: break-word;
                                         "
                                     >
-                                        {{ $key }}: {{ Js::from($value['old']) }} &rarr;
-                                        {{ Js::from($value['new']) }}
+                                        {{ $key }}:
+                                        {{ json_encode($value['old'], JSON_THROW_ON_ERROR) }}
+                                        &rarr;
+                                        {{ json_encode($value['new'], JSON_THROW_ON_ERROR) }}
                                     </li>
                                 @endforeach
                             </ul>


### PR DESCRIPTION
The Js facade encodes html tags, apostrophes, ampersands and quotes by default. We're already escaping those through blade's {{}}, so remove the flags that result in those escapes and only keep JSON_THROW_ON_ERROR. Previously, any html text would be full of \u003E and \u003C.