### PR TITLE
(Remove) Vue from .editorconfig and .prettierrc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,3 @@ charset = utf-8
 spelling_language = en-US
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.vue]
-indent_size = 2

--- a/.prettierrc
+++ b/.prettierrc
@@ -26,16 +26,6 @@
     },
     {
       "files": [
-        "*.vue"
-      ],
-      "options": {
-        "printWidth": 100,
-        "semi": true,
-        "singleQuote": true
-      }
-    },
-    {
-      "files": [
         "*.scss"
       ],
       "options": {


### PR DESCRIPTION
We don't use vue anymore. It was last used for the chatbox, but that uses alpinejs now.