### PR TITLE
(Fix) Enforce searching `blu-ray`/`bluray` does not include typos

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -2,6 +2,32 @@
 
 declare(strict_types=1);
 
+/**
+ * @param  string       $word
+ * @return list<string>
+ */
+$generateCasePermutations = function (string $word): array {
+    $count = 2 ** mb_strlen($word);
+    $chars = mb_str_split($word);
+    $permutations = [];
+
+    for ($i = 0; $i < $count; $i++) {
+        $permutation = '';
+
+        foreach ($chars as $j => $char) {
+            if ($i & (1 << $j)) {
+                $permutation .= strtoupper($char);
+            } else {
+                $permutation .= strtolower($char);
+            }
+        }
+
+        $permutations[] = $permutation;
+    }
+
+    return $permutations;
+};
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -260,6 +286,16 @@ return [
                 ],
                 'facetSearch'        => false,
                 'proximityPrecision' => 'byAttribute',
+                'typoTolerance'      => [
+                    'disableOnWords' => [
+                        // cspell:ignore bluray
+                        'bluray',
+                        'blu-ray',
+                    ],
+                ],
+                "dictionary" => [
+                    ...$generateCasePermutations('blu-ray'),
+                ],
             ],
             'people' => [
                 'searchableAttributes' => [


### PR DESCRIPTION
Blu-ray and BluRay historically mean 2 different things, and meilisearch combines them together. To do this, we need to add the two words to be disabled in typos, as well as for all case permutations to be added to the dictionary. Related: https://www.github.com/meilisearch/meilisearch/issues/5934