### PR TITLE
(Fix) Deleting blocked ip address isn't immediate

### DIFF
--- a/app/Http/Livewire/BlockIpAddress.php
+++ b/app/Http/Livewire/BlockIpAddress.php
@@ -67,6 +67,8 @@ class BlockIpAddress extends Component
         if (auth()->user()->group->is_modo) {
             $blockedIp->delete();
 
+            cache()->forget('blocked-ips');
+
             $this->dispatch('success', type: 'success', message: 'IP has successfully been deleted!');
         } else {
             $this->dispatch('error', type: 'error', message: 'Permission denied!');


### PR DESCRIPTION
We already flush the cache when blocking a new ip address. We should also flush it when a blocked ip is deleted.