### PR TITLE
(Fix) Remove gaps between characters in nfo preview

### DIFF
--- a/resources/sass/pages/_torrent.scss
+++ b/resources/sass/pages/_torrent.scss
@@ -98,7 +98,14 @@
 ---------------------------------------------------------------------------- */
 
 .torrent__nfo {
-    line-height: 1;
+    line-height: 1 !important;
+    letter-spacing: -1px;
+    white-space: pre;
+}
+
+.torrent__nfo-pre {
+    width: max-content;
+    line-height: 1 !important;
 }
 
 /* Peer counts

--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -102,8 +102,8 @@
                 <div class="dialog__form" x-bind="dialogForm">
                     <div class="bbcode-rendered" style="text-align: left">
                         <pre
-                            style="width: max-content"
-                        ><code class="torrent__nfo" style="white-space: pre;">{{ iconv('cp437', 'utf8', $torrent->nfo) }}</code></pre>
+                            class="torrent__nfo-pre"
+                        ><code class="torrent__nfo">{{ iconv('cp437', 'utf8', $torrent->nfo) }}</code></pre>
                     </div>
                 </div>
             </dialog>


### PR DESCRIPTION
Probably the best that can be done without requiring a dedicated CP437 DOS font.

fixes #5130