### PR TITLE
(Update) Deny tilde as folder/filename in .torrent files

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -173,6 +173,8 @@ class TorrentTools
             || preg_match('/^\.?____padding.*$/i', $filename)
             // BEP 47 torrent padding files that many clients aren't able to handle
             || str_starts_with($filename, '.pad')
+            // Tilde home expansion on linux
+            || str_starts_with($filename, '~')
         );
     }
 


### PR DESCRIPTION
Tildes inside the filename are fine as long as the filename or folder doesn't start with a tilde.