### PR TITLE
(Update) Laravel pint dev dependency

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -28,7 +28,7 @@ class Bbcode
      *         closeBbcode: string,
      *         openHtml: string,
      *         closeHtml: string,
-     *         block: boolean
+     *         block: bool
      *     }
      * > $parsers.
      */

--- a/app/Services/Tmdb/Client/Collection.php
+++ b/app/Services/Tmdb/Client/Collection.php
@@ -31,7 +31,7 @@ class Collection
      *     parts: ?array<
      *         int<0, max>,
      *         array{
-     *             adult: ?boolean,
+     *             adult: ?bool,
      *             backdrop_path: ?string,
      *             id: ?int,
      *             title: ?string,
@@ -43,7 +43,7 @@ class Collection
      *             genre_ids: array<int>,
      *             popularity: ?float,
      *             release_date: ?string,
-     *             video: ?boolean,
+     *             video: ?bool,
      *             vote_average: ?float,
      *             vote_count: ?int,
      *         },

--- a/app/Services/Tmdb/Client/Person.php
+++ b/app/Services/Tmdb/Client/Person.php
@@ -23,7 +23,7 @@ class Person
 {
     /**
      * @var array{
-     *     adult: ?boolean,
+     *     adult: ?bool,
      *     also_known_as: ?array<string>,
      *     biography: ?string,
      *     birthday: ?string,

--- a/app/Services/Unit3dAnnounce.php
+++ b/app/Services/Unit3dAnnounce.php
@@ -32,20 +32,20 @@ class Unit3dAnnounce
 {
     /**
      * @return bool|array{}|array{
-     *     created_at: double,
-     *     last_request_at: double,
-     *     last_announce_response_at: double,
-     *     requests_per_1s: double,
-     *     requests_per_10s: double,
-     *     requests_per_60s: double,
-     *     requests_per_900s: double,
-     *     requests_per_7200s: double,
-     *     announce_responses_per_1s: double,
-     *     announce_responses_per_10s: double,
-     *     announce_responses_per_60s: double,
-     *     announce_responses_per_900s: double,
-     *     announce_responses_per_7200s: double,
-     *     announce_responses_per_second: double,
+     *     created_at: float,
+     *     last_request_at: float,
+     *     last_announce_response_at: float,
+     *     requests_per_1s: float,
+     *     requests_per_10s: float,
+     *     requests_per_60s: float,
+     *     requests_per_900s: float,
+     *     requests_per_7200s: float,
+     *     announce_responses_per_1s: float,
+     *     announce_responses_per_10s: float,
+     *     announce_responses_per_60s: float,
+     *     announce_responses_per_900s: float,
+     *     announce_responses_per_7200s: float,
+     *     announce_responses_per_second: float,
      * }
      */
     public static function getStats(): bool|array
@@ -225,7 +225,7 @@ class Unit3dAnnounce
      *             count: int,
      *             max_count: int,
      *             window: int,
-     *             updated_at: double,
+     *             updated_at: float,
      *         }
      *     },
      *     receive_leech_list_rates: array{
@@ -233,7 +233,7 @@ class Unit3dAnnounce
      *             count: int,
      *             max_count: int,
      *             window: int,
-     *             updated_at: double,
+     *             updated_at: float,
      *         }
      *     },
      * }

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "calebdw/larastan-livewire": "^2.3.0",
         "fakerphp/faker": "^1.24.1",
         "jasonmccreary/laravel-test-assertions": "^2.8.0",
-        "laravel/pint": "v1.24.0",
+        "laravel/pint": "^1.26.0",
         "laravel/sail": "^1.45.0",
         "mockery/mockery": "^1.6.12",
         "nunomaduro/collision": "^8.8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa6748cb945c26750567cab9a26bb2d3",
+    "content-hash": "584c406149cfba22c7fc31de2de730d9",
     "packages": [
         {
             "name": "assada/laravel-achievements",
@@ -9586,16 +9586,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.24.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "0345f3b05f136801af8c339f9d16ef29e6b4df8a"
+                "reference": "69dcca060ecb15e4b564af63d1f642c81a241d6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/0345f3b05f136801af8c339f9d16ef29e6b4df8a",
-                "reference": "0345f3b05f136801af8c339f9d16ef29e6b4df8a",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/69dcca060ecb15e4b564af63d1f642c81a241d6f",
+                "reference": "69dcca060ecb15e4b564af63d1f642c81a241d6f",
                 "shasum": ""
             },
             "require": {
@@ -9606,22 +9606,19 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.82.2",
-                "illuminate/view": "^11.45.1",
-                "larastan/larastan": "^3.5.0",
-                "laravel-zero/framework": "^11.45.0",
+                "friendsofphp/php-cs-fixer": "^3.90.0",
+                "illuminate/view": "^12.40.1",
+                "larastan/larastan": "^3.8.0",
+                "laravel-zero/framework": "^12.0.4",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.1",
-                "pestphp/pest": "^2.36.0"
+                "nunomaduro/termwind": "^2.3.3",
+                "pestphp/pest": "^3.8.4"
             },
             "bin": [
                 "builds/pint"
             ],
             "type": "project",
             "autoload": {
-                "files": [
-                    "overrides/Runner/Parallel/ProcessFactory.php"
-                ],
                 "psr-4": {
                     "App\\": "app/",
                     "Database\\Seeders\\": "database/seeders/",
@@ -9641,6 +9638,7 @@
             "description": "An opinionated code formatter for PHP.",
             "homepage": "https://laravel.com",
             "keywords": [
+                "dev",
                 "format",
                 "formatter",
                 "lint",
@@ -9651,7 +9649,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2025-07-10T18:09:32+00:00"
+            "time": "2025-11-25T21:15:52+00:00"
         },
         {
             "name": "laravel/sail",


### PR DESCRIPTION
The latest version adds stdin support for use in IDEs that integrate with formatters if the formatter accepts input on stdin and outputs on stdout. Zed is one example of such an IDE.