### PR TITLE
(Fix) Chatbox censoring

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace App\Helpers;
 
 use App\Models\WhitelistedImageUrl;
+use Illuminate\Support\Str;
 
 class Bbcode
 {
@@ -283,6 +284,19 @@ class Bbcode
     {
         $source ??= '';
         $source = htmlspecialchars($source, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+
+        // Censor words
+        foreach (config('censor.redact') as $word) {
+            if (preg_match(\sprintf('/\b%s(?=[.,]|$|\s)/mi', $word), (string) $source)) {
+                $source = str_replace($word, \sprintf("<span class='censor'>%s</span>", $word), (string) $source);
+            }
+        }
+
+        foreach (config('censor.replace') as $word => $replacementWord) {
+            if (Str::contains($source, $word)) {
+                $source = str_replace($word, $replacementWord, (string) $source);
+            }
+        }
 
         // Replace all void elements since they don't have closing tags
         $source = str_replace('[*]', '<li>', (string) $source);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -523,6 +523,12 @@ parameters:
 			path: app/Listeners/AchievementUnlocked.php
 
 		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
+			count: 1
+			path: app/Helpers/Bbcode.php
+
+		-
 			message: '#^Parameter \#1 \$view of function view expects view\-string\|null, string given\.$#'
 			identifier: argument.type
 			count: 2
@@ -597,12 +603,6 @@ parameters:
 		-
 			message: '#^Call to function is_int\(\) with string\|null will always evaluate to false\.$#'
 			identifier: function.impossibleType
-			count: 1
-			path: app/Repositories/ChatRepository.php
-
-		-
-			message: '#^Empty array passed to foreach\.$#'
-			identifier: foreach.emptyArray
 			count: 1
 			path: app/Repositories/ChatRepository.php
 

--- a/resources/sass/components/_bbcode-rendered.scss
+++ b/resources/sass/components/_bbcode-rendered.scss
@@ -534,4 +534,10 @@
             padding-right: 1ch;
         }
     }
+
+    /* Censor */
+
+    &.bbcode-rendered__censor .censor:not(:hover) {
+        filter: blur(0.5em);
+    }
 }

--- a/resources/views/blocks/chat.blade.php
+++ b/resources/views/blocks/chat.blade.php
@@ -1,5 +1,5 @@
 @php
-    $user = App\Models\User::with(['chatroom', 'group'])->find(auth()->id());
+    $user = App\Models\User::with(['chatroom', 'group', 'settings'])->find(auth()->id());
 @endphp
 
 <section
@@ -318,7 +318,11 @@
                                         </figure>
                                     </aside>
                                     <section
-                                        class="chatbox-message__content bbcode-rendered"
+                                        @class([
+                                            'bbcode-rendered',
+                                            'chatbox-message__content',
+                                            'bbcode-rendered__censor' => $user->settings->censor,
+                                        ])
                                         x-show="! (message.bot && message.bot.id >= 1 && (! message.user || message.user.id < 2))"
                                         x-html="message.message"
                                     ></section>


### PR DESCRIPTION
For years, chatbox has only censored messages based on the settings of the sender, not the recipient.

fixes #4982