### PR TITLE
(Add) Request url to context for debugging purposes

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -27,6 +27,7 @@ use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
@@ -52,7 +53,7 @@ class AppServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      */
-    public function boot(): void
+    public function boot(Request $request): void
     {
         // User Observer For Cache
         User::observe(UserObserver::class);
@@ -103,5 +104,7 @@ class AppServiceProvider extends ServiceProvider
         ]);
 
         Auth::viaRequest('rsskey', fn (Request $request) => User::query()->where('rsskey', '=', $request->route('rsskey'))->first());
+
+        Context::add('url', $request->url());
     }
 }


### PR DESCRIPTION
Knowing which specific url of a view template occurred on is really useful in case an error is dependent on the id in the url.