### PR TITLE
(Update) Hide email on password reset page

### DIFF
--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -33,9 +33,12 @@ class NewPasswordController extends Controller
     /**
      * Create new password.
      */
-    public function create(string $token): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+    public function create(Request $request, string $token): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
-        return view('auth.reset-password', ['token' => $token]);
+        return view('auth.reset-password', [
+            'token' => $token,
+            'email' => $request->query('email'),
+        ]);
     }
 
     /**

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -32,6 +32,7 @@
                 >
                     @csrf
                     <input type="hidden" name="token" value="{{ $token }}" />
+                    <input type="hidden" name="email" value="{{ $email }}" />
                     <a class="auth-form__branding" href="{{ route('home.index') }}">
                         <i class="fal fa-tv-retro"></i>
                         <span class="auth-form__site-logo">{{ \config('other.title') }}</span>
@@ -52,20 +53,6 @@
                         </ul>
                     @endif
 
-                    <p class="auth-form__text-input-group">
-                        <label class="auth-form__label" for="email">
-                            {{ __('auth.email') }}
-                        </label>
-                        <input
-                            id="email"
-                            class="auth-form__text-input"
-                            autofocus
-                            name="email"
-                            required
-                            type="email"
-                            value="{{ old('email') }}"
-                        />
-                    </p>
                     <p class="auth-form__text-input-group">
                         <label class="auth-form__label" for="password">
                             {{ __('auth.new-password') }}


### PR DESCRIPTION
The data is already provided in the url and is validated by laravel to ensure it matches the token on the database record.