### PR TITLE
(Update) Log previous url in context and stack traces

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -106,5 +106,9 @@ class AppServiceProvider extends ServiceProvider
         Auth::viaRequest('rsskey', fn (Request $request) => User::query()->where('rsskey', '=', $request->route('rsskey'))->first());
 
         Context::add('url', $request->url());
+
+        if ($request->hasSession()) {
+            Context::add('previousUrl', $request->session()->previousUrl());
+        }
     }
 }


### PR DESCRIPTION
Helps debug error 500s where key information is in the previous url, but where the current request is a livewire/update request without any info in the url.