### PR TITLE
(Fix) Error 500 on similar page when filter returns 0 results

### DIFF
--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -337,12 +337,9 @@ class SimilarTorrent extends Component
                 ->get();
 
             return match ($this->work::class) {
-                /** @phpstan-ignore offsetAccess.notFound ('movie' offset exists if the torrent is a movie) */
-                TmdbMovie::class => self::groupTorrents($torrents)['movie'][$this->tmdbId]['Movie'],
-                /** @phpstan-ignore offsetAccess.notFound ('tv' offset exists if the torrent is a tv) */
-                TmdbTv::class => self::groupTorrents($torrents)['tv'][$this->tmdbId],
-                /** @phpstan-ignore offsetAccess.notFound ('game' offset exists if the torrent is a game) */
-                IgdbGame::class => self::groupTorrents($torrents)['game'][$this->igdbId]['Game'],
+                TmdbMovie::class => self::groupTorrents($torrents)['movie'][$this->tmdbId]['Movie'] ?? [],
+                TmdbTv::class    => self::groupTorrents($torrents)['tv'][$this->tmdbId] ?? [],
+                IgdbGame::class  => self::groupTorrents($torrents)['game'][$this->igdbId]['Game'] ?? [],
             };
         }
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -421,24 +421,6 @@ parameters:
 			path: app/Http/Livewire/MissingMediaSearch.php
 
 		-
-			message: '#^Offset ''game'' might not exist on array\{movie\?\: non\-empty\-array\<int, array\{Movie\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, category_id\: int\}\>, tv\?\: non\-empty\-array\<int, array\{''Complete Pack''\?\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, Specials\?\: non\-empty\-array\<string, array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>\>, Seasons\?\: non\-empty\-array\<string, array\{''Season Pack''\?\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, Episodes\?\: non\-empty\-array\<string, array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>\>\}\>, category_id\: int\}\>, game\?\: non\-empty\-array\<int, array\{Game\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, category_id\: int\}\>\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: app/Http/Livewire/SimilarTorrent.php
-
-		-
-			message: '#^Offset ''movie'' might not exist on array\{movie\?\: non\-empty\-array\<int, array\{Movie\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, category_id\: int\}\>, tv\?\: non\-empty\-array\<int, array\{''Complete Pack''\?\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, Specials\?\: non\-empty\-array\<string, array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>\>, Seasons\?\: non\-empty\-array\<string, array\{''Season Pack''\?\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, Episodes\?\: non\-empty\-array\<string, array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>\>\}\>, category_id\: int\}\>, game\?\: non\-empty\-array\<int, array\{Game\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, category_id\: int\}\>\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: app/Http/Livewire/SimilarTorrent.php
-
-		-
-			message: '#^Offset ''tv'' might not exist on array\{movie\?\: non\-empty\-array\<int, array\{Movie\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, category_id\: int\}\>, tv\?\: non\-empty\-array\<int, array\{''Complete Pack''\?\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, Specials\?\: non\-empty\-array\<string, array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>\>, Seasons\?\: non\-empty\-array\<string, array\{''Season Pack''\?\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, Episodes\?\: non\-empty\-array\<string, array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>\>\}\>, category_id\: int\}\>, game\?\: non\-empty\-array\<int, array\{Game\: non\-empty\-array\<string, non\-empty\-list\<App\\Models\\Torrent\>\>, category_id\: int\}\>\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: app/Http/Livewire/SimilarTorrent.php
-
-		-
 			message: '#^Anonymous function should return Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\> but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Group\>\.$#'
 			identifier: return.type
 			count: 1


### PR DESCRIPTION
The similar page assumes that a torrent exists for a torrent, otherwise returning a 404. However, if a user uses the search on the similar page, and uses a search query that returns 0 torrents, the assumption that a torrent exists breaks. In this case, we now fall back to an empty array instead.