### PR TITLE
(Fix) Fetch chatbox messages when switching from channel -> pm -> channel

### DIFF
--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -390,7 +390,11 @@ document.addEventListener('alpine:init', () => {
 
                 let currentRoom = this.echoes.find((o) => o.room && o.room.id == newVal);
                 if (currentRoom) {
-                    this.state.chat.room = currentRoom.room.id;
+                    if (this.state.chat.room === currentRoom.room.id) {
+                        this.fetchMessages();
+                    } else {
+                        this.state.chat.room = currentRoom.room.id;
+                    }
                     this.state.message.receiver_id = null;
                     this.state.message.bot_id = null;
                 }


### PR DESCRIPTION
`state.chat.room` is not changed when moving to a pm, so when returning back to a channel, it remains unchanged. When the room id doesn't change, it doesn't trigger `fetchMessages` so the messages remain on the pm instead of the channel.