### PR TITLE
(Fix) Broken torrent bookmark button

### DIFF
--- a/resources/views/livewire/bookmark-button.blade.php
+++ b/resources/views/livewire/bookmark-button.blade.php
@@ -1,19 +1,17 @@
-@if ($this->isBookmarked)
-    <button
+<button
+    @if ($this->isBookmarked)
         wire:click="destroy({{ $torrent->id }})"
         class="form__button form__button--filled form__button--centered"
-        title="Bookmarked by {{ $bookmarksCount }} users"
-    >
-        <i class="{{ config('other.font-awesome') }} fa-bookmark-slash"></i>
-        {{ __('torrent.unbookmark') }} ({{ $bookmarksCount }})
-    </button>
-@else
-    <button
+    @else
         wire:click="store({{ $torrent->id }})"
         class="form__button form__button--outlined form__button--centered"
-        title="Bookmarked by {{ $bookmarksCount }} users"
-    >
+    @endif
+>
+    @if ($this->isBookmarked)
+        <i class="{{ config('other.font-awesome') }} fa-bookmark-slash"></i>
+        {{ __('torrent.unbookmark') }} ({{ $bookmarksCount }})
+    @else
         <i class="{{ config('other.font-awesome') }} fa-bookmark"></i>
         {{ __('torrent.bookmark') }} ({{ $bookmarksCount }})
-    </button>
-@endif
+    @endif
+</button>


### PR DESCRIPTION
This used to work fine, and we didn't recently update livewire, so not sure what happened to this. Hacky workaround, but at least it works now.