### PR TITLE
(Fix) Quick search errors on null query

### DIFF
--- a/app/Http/Controllers/API/QuickSearchController.php
+++ b/app/Http/Controllers/API/QuickSearchController.php
@@ -27,7 +27,11 @@ class QuickSearchController extends Controller
 {
     public function index(Request $request): \Illuminate\Http\JsonResponse
     {
-        $query = $request->input('query', '');
+        $query = $request->input('query');
+
+        if ($query === null || $query === '') {
+            return response()->json(['results' => []]);
+        }
 
         $filters = [
             'deleted_at IS NULL',


### PR DESCRIPTION
Some search queries are sending null for the queries. This breaks the regex searches causing 500 errors. So, return an empty response instead.