### PR TITLE
(Refactor) Prefer `::query()` over laravel eloquent magic

### DIFF
--- a/app/Achievements/UserUploadedFirstSubtitle.php
+++ b/app/Achievements/UserUploadedFirstSubtitle.php
@@ -51,7 +51,7 @@ class UserUploadedFirstSubtitle extends Achievement
     //    {
     //        $achiever = $progress->achiever;
     //
-    //        $user = User::findOrFail($achiever->id);
+    //        $user = User::query()->findOrFail($achiever->id);
     //        $user->seedbonus += 1000;
     //        $user->save();
     //    }

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -68,7 +68,7 @@ class CreateNewUser implements CreatesNewUsers
             ]
         ])->validate();
 
-        $user = User::create([
+        $user = User::query()->create([
             'username'   => $input['username'],
             'email'      => $input['email'],
             'password'   => Hash::make($input['password']),
@@ -86,7 +86,7 @@ class CreateNewUser implements CreatesNewUsers
         $user->emailUpdates()->create();
 
         if (config('other.invite-only') === true) {
-            $invite = Invite::where('code', '=', $input['code'])->first();
+            $invite = Invite::query()->where('code', '=', $input['code'])->first();
             $invite->update([
                 'accepted_by' => $user->id,
                 'accepted_at' => now(),

--- a/app/Bots/IRCAnnounceBotExternal.php
+++ b/app/Bots/IRCAnnounceBotExternal.php
@@ -64,9 +64,9 @@ class IRCAnnounceBotExternal
 
         if ($torrent->tmdb_movie_id > 0 || $torrent->tmdb_tv_id > 0) {
             $meta = match (true) {
-                $category->tv_meta    => TmdbTv::find($torrent->tmdb_tv_id),
-                $category->movie_meta => TmdbMovie::find($torrent->tmdb_movie_id),
-                $category->game_meta  => IgdbGame::find($torrent->igdb),
+                $category->tv_meta    => TmdbTv::query()->find($torrent->tmdb_tv_id),
+                $category->movie_meta => TmdbMovie::query()->find($torrent->tmdb_movie_id),
+                $category->game_meta  => IgdbGame::query()->find($torrent->igdb),
                 default               => null,
             };
         }

--- a/app/Bots/NerdBot.php
+++ b/app/Bots/NerdBot.php
@@ -50,7 +50,7 @@ class NerdBot
 
     public function __construct(private readonly ChatRepository $chatRepository)
     {
-        $this->bot = Bot::findOrFail(2);
+        $this->bot = Bot::query()->findOrFail(2);
         $this->expiresAt = Carbon::now()->addMinutes(60);
         $this->current = Carbon::now();
         $this->site = config('other.title');
@@ -62,7 +62,7 @@ class NerdBot
 
         if (str_contains((string) $output, '{bots}')) {
             $botHelp = '';
-            $bots = Bot::where('active', '=', 1)->where('id', '!=', $this->bot->id)->orderBy('position')->get();
+            $bots = Bot::query()->where('active', '=', 1)->where('id', '!=', $this->bot->id)->orderBy('position')->get();
 
             foreach ($bots as $bot) {
                 $botHelp .= '( ! | / | @)'.$bot->command.' help triggers help file for '.$bot->name."\n";
@@ -79,7 +79,7 @@ class NerdBot
         $banker = cache()->remember(
             'nerdbot-banker',
             $this->expiresAt,
-            fn () => User::orderByDesc('seedbonus')->first()
+            fn () => User::query()->orderByDesc('seedbonus')->first()
         );
 
         return "Currently [url=/users/{$banker->username}]{$banker->username}[/url] is the top BON holder on {$this->site}!";
@@ -90,7 +90,7 @@ class NerdBot
         $snatched = cache()->remember(
             'nerdbot-snatched',
             $this->expiresAt,
-            fn () => Torrent::orderByDesc('times_completed')->first()
+            fn () => Torrent::query()->orderByDesc('times_completed')->first()
         );
 
         return "Currently [url=/torrents/{$snatched->id}]{$snatched->name}[/url] is the most snatched torrent on {$this->site}!";
@@ -101,7 +101,7 @@ class NerdBot
         $leeched = cache()->remember(
             'nerdbot-leeched',
             $this->expiresAt,
-            fn () => Torrent::orderByDesc('leechers')->first()
+            fn () => Torrent::query()->orderByDesc('leechers')->first()
         );
 
         return "Currently [url=/torrents/{$leeched->id}]{$leeched->name}[/url] is the most leeched torrent on {$this->site}!";
@@ -112,7 +112,7 @@ class NerdBot
         $seeded = cache()->remember(
             'nerdbot-seeded',
             $this->expiresAt,
-            fn () => Torrent::orderByDesc('seeders')->first()
+            fn () => Torrent::query()->orderByDesc('seeders')->first()
         );
 
         return "Currently [url=/torrents/{$seeded->id}]{$seeded->name}[/url] is the most seeded torrent on {$this->site}!";
@@ -123,7 +123,7 @@ class NerdBot
         $freeleech = cache()->remember(
             'nerdbot-freeleech',
             $this->expiresAt,
-            fn () => Torrent::where('free', '=', 1)->count()
+            fn () => Torrent::query()->where('free', '=', 1)->count()
         );
 
         return "There are currently {$freeleech} freeleech torrents on {$this->site}!";
@@ -134,7 +134,7 @@ class NerdBot
         $doubleUpload = cache()->remember(
             'nerdbot-doubleupload',
             $this->expiresAt,
-            fn () => Torrent::where('doubleup', '=', 1)->count()
+            fn () => Torrent::query()->where('doubleup', '=', 1)->count()
         );
 
         return "There are currently {$doubleUpload} double upload torrents on {$this->site}!";
@@ -145,7 +145,7 @@ class NerdBot
         $peers = cache()->remember(
             'nerdbot-peers',
             $this->expiresAt,
-            fn () => Peer::where('active', '=', 1)->count()
+            fn () => Peer::query()->where('active', '=', 1)->count()
         );
 
         return "Currently there are {$peers} peers on {$this->site}!";
@@ -156,8 +156,10 @@ class NerdBot
         $bans = cache()->remember(
             'nerdbot-bans',
             $this->expiresAt,
-            fn () => Ban::whereNotNull('ban_reason')
-                ->where('created_at', '>', $this->current->subDay())->count()
+            fn () => Ban::query()
+                ->whereNotNull('ban_reason')
+                ->where('created_at', '>', $this->current->subDay())
+                ->count()
         );
 
         return "In the last 24 hours, {$bans} users have been banned from {$this->site}";
@@ -168,8 +170,10 @@ class NerdBot
         $unbans = cache()->remember(
             'nerdbot-unbans',
             $this->expiresAt,
-            fn () => Ban::whereNotNull('unban_reason')
-                ->where('removed_at', '>', $this->current->subDay())->count()
+            fn () => Ban::query()
+                ->whereNotNull('unban_reason')
+                ->where('removed_at', '>', $this->current->subDay())
+                ->count()
         );
 
         return "In the last 24 hours, {$unbans} users have been unbanned from {$this->site}";
@@ -180,7 +184,7 @@ class NerdBot
         $warnings = cache()->remember(
             'nerdbot-warnings',
             $this->expiresAt,
-            fn () => Warning::where('created_at', '>', $this->current->subDay())->count()
+            fn () => Warning::query()->where('created_at', '>', $this->current->subDay())->count()
         );
 
         return "In the last 24 hours, {$warnings} hit and run warnings have been issued on {$this->site}!";
@@ -191,7 +195,7 @@ class NerdBot
         $uploads = cache()->remember(
             'nerdbot-uploads',
             $this->expiresAt,
-            fn () => Torrent::where('created_at', '>', $this->current->subDay())->count()
+            fn () => Torrent::query()->where('created_at', '>', $this->current->subDay())->count()
         );
 
         return "In the last 24 hours, {$uploads} torrents have been uploaded to {$this->site}!";
@@ -202,7 +206,7 @@ class NerdBot
         $logins = cache()->remember(
             'nerdbot-logins',
             $this->expiresAt,
-            fn () => User::whereNotNull('last_login')->where('last_login', '>', $this->current->subDay())->count()
+            fn () => User::query()->whereNotNull('last_login')->where('last_login', '>', $this->current->subDay())->count()
         );
 
         return "In The Last 24 Hours, {$logins} Unique Users Have Logged Into {$this->site}!";
@@ -213,7 +217,7 @@ class NerdBot
         $registrations = cache()->remember(
             'nerdbot-users',
             $this->expiresAt,
-            fn () => User::where('created_at', '>', $this->current->subDay())->count()
+            fn () => User::query()->where('created_at', '>', $this->current->subDay())->count()
         );
 
         return "In the last 24 hours, {$registrations} users have registered to {$this->site}!";

--- a/app/Bots/SystemBot.php
+++ b/app/Bots/SystemBot.php
@@ -41,7 +41,7 @@ class SystemBot
 
     public function __construct(private readonly ChatRepository $chatRepository)
     {
-        $this->bot = Bot::where('is_systembot', '=', true)->sole();
+        $this->bot = Bot::query()->where('is_systembot', '=', true)->sole();
     }
 
     public function replaceVars(string $output): string
@@ -50,7 +50,7 @@ class SystemBot
 
         if (str_contains($output, '{bots}')) {
             $botHelp = '';
-            $bots = Bot::where('active', '=', 1)->where('id', '!=', $this->bot->id)->oldest('position')->get();
+            $bots = Bot::query()->where('active', '=', 1)->where('id', '!=', $this->bot->id)->oldest('position')->get();
 
             foreach ($bots as $bot) {
                 $botHelp .= '( ! | / | @)'.$bot->command.' help triggers help file for '.$bot->name."\n";
@@ -84,7 +84,7 @@ class SystemBot
         ]);
 
         if ($v->passes()) {
-            $recipient = User::where('username', 'LIKE', $receiver)->first();
+            $recipient = User::query()->where('username', 'LIKE', $receiver)->first();
 
             if (!$recipient || $recipient->id === $this->target->id) {
                 return 'Your BON gift could not be sent.';
@@ -95,7 +95,7 @@ class SystemBot
             $recipient->increment('seedbonus', $amount);
             $this->target->decrement('seedbonus', $amount);
 
-            $gift = Gift::create([
+            $gift = Gift::query()->create([
                 'sender_id'    => $this->target->id,
                 'recipient_id' => $recipient->id,
                 'bon'          => $amount,

--- a/app/Console/Commands/AutoBanDisposableUsers.php
+++ b/app/Console/Commands/AutoBanDisposableUsers.php
@@ -56,9 +56,9 @@ class AutoBanDisposableUsers extends Command
             return;
         }
 
-        $bannedGroupId = Group::where('slug', '=', 'banned')->soleValue('id');
+        $bannedGroupId = Group::query()->where('slug', '=', 'banned')->soleValue('id');
 
-        User::where('group_id', '!=', $bannedGroupId)->chunkById(100, function ($users) use ($bannedGroupId): void {
+        User::query()->where('group_id', '!=', $bannedGroupId)->chunkById(100, function ($users) use ($bannedGroupId): void {
             foreach ($users as $user) {
                 $v = validator([
                     'email' => $user->email,
@@ -82,7 +82,7 @@ class AutoBanDisposableUsers extends Command
                     // Log The Ban To Ban Log
                     $domain = substr((string) strrchr((string) $user->email, '@'), 1);
 
-                    $ban = Ban::create([
+                    $ban = Ban::query()->create([
                         'owned_by'     => $user->id,
                         'created_by'   => User::SYSTEM_USER_ID,
                         'ban_reason'   => 'Detected disposable email, '.$domain.' not allowed.',

--- a/app/Console/Commands/AutoBonAllocation.php
+++ b/app/Console/Commands/AutoBonAllocation.php
@@ -48,7 +48,7 @@ class AutoBonAllocation extends Command
     {
         $now = now();
 
-        $bonEarnings = BonEarning::with('conditions')->orderBy('position')->get();
+        $bonEarnings = BonEarning::query()->with('conditions')->orderBy('position')->get();
 
         $earningsQuery = str_repeat('(', $bonEarnings->count()).'0';
 

--- a/app/Console/Commands/AutoCacheUserLeechCounts.php
+++ b/app/Console/Commands/AutoCacheUserLeechCounts.php
@@ -44,7 +44,8 @@ class AutoCacheUserLeechCounts extends Command
      */
     final public function handle(): void
     {
-        $peerCounts = User::withoutGlobalScopes()
+        $peerCounts = User::query()
+            ->withoutGlobalScopes()
             ->selectRaw("'user-leeching-count:' || id as cacheKey")
             ->selectRaw('(select COUNT(*) from peers where peers.user_id = users.id and seeder = FALSE and active = TRUE and visible = TRUE) as count')
             ->pluck('count', 'cacheKey')

--- a/app/Console/Commands/AutoDeactivateWarning.php
+++ b/app/Console/Commands/AutoDeactivateWarning.php
@@ -80,7 +80,8 @@ class AutoDeactivateWarning extends Command
         }
 
         // Calculate User Warning Count and Enable DL Priv If Required.
-        Warning::with('user')
+        Warning::query()
+            ->with('user')
             ->select(DB::raw('user_id, SUM(active = TRUE) as value'))
             ->groupBy('user_id')
             ->having('value', '<', config('hitrun.max_warnings'))

--- a/app/Console/Commands/AutoDisableInactiveUsers.php
+++ b/app/Console/Commands/AutoDisableInactiveUsers.php
@@ -52,7 +52,7 @@ class AutoDisableInactiveUsers extends Command
             return;
         }
 
-        $disabledGroupId = Group::where('slug', '=', 'disabled')->soleValue('id');
+        $disabledGroupId = Group::query()->where('slug', '=', 'disabled')->soleValue('id');
 
         $current = Carbon::now();
 

--- a/app/Console/Commands/AutoFlushPeers.php
+++ b/app/Console/Commands/AutoFlushPeers.php
@@ -48,7 +48,8 @@ class AutoFlushPeers extends Command
     final public function handle(): void
     {
         $carbon = new Carbon();
-        $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'seeder', 'updated_at'])
+        $peers = Peer::query()
+            ->select(['torrent_id', 'user_id', 'peer_id', 'seeder', 'updated_at'])
             ->where('updated_at', '<', $carbon->copy()->subHours(2))
             ->where('active', '=', 1)
             ->get();
@@ -81,7 +82,8 @@ class AutoFlushPeers extends Command
                 ->where('active', '=', 0)
                 ->delete();
         } else {
-            $peers = Peer::select(['torrent_id', 'user_id', 'peer_id'])
+            $peers = Peer::query()
+                ->select(['torrent_id', 'user_id', 'peer_id'])
                 ->where('updated_at', '<', $carbon->copy()->subDays(2))
                 ->where('active', '=', 0)
                 ->get();

--- a/app/Console/Commands/AutoHighspeedTag.php
+++ b/app/Console/Commands/AutoHighspeedTag.php
@@ -53,9 +53,11 @@ class AutoHighspeedTag extends Command
             ->filter(fn ($ip) => filter_var($ip, FILTER_VALIDATE_IP) !== false)
             ->map(fn ($ip) => inet_pton($ip));
 
-        Torrent::withoutGlobalScope(ApprovedScope::class)
+        Torrent::query()
+            ->withoutGlobalScope(ApprovedScope::class)
             ->leftJoinSub(
-                Peer::where('seeder', '=', 1)
+                Peer::query()
+                    ->where('seeder', '=', 1)
                     ->where('active', '=', 1)
                     ->distinct()
                     ->select('torrent_id')

--- a/app/Console/Commands/AutoPreWarning.php
+++ b/app/Console/Commands/AutoPreWarning.php
@@ -50,7 +50,8 @@ class AutoPreWarning extends Command
             return;
         }
 
-        $prewarn = History::with(['user'])
+        $prewarn = History::query()
+            ->with(['user'])
             ->whereNull('prewarned_at')
             ->where('hitrun', '=', 0)
             ->where('immune', '=', 0)

--- a/app/Console/Commands/AutoRemoveExpiredDonors.php
+++ b/app/Console/Commands/AutoRemoveExpiredDonors.php
@@ -48,7 +48,8 @@ class AutoRemoveExpiredDonors extends Command
      */
     final public function handle(): void
     {
-        $expiredDonors = User::where('is_donor', '=', true)
+        $expiredDonors = User::query()
+            ->where('is_donor', '=', true)
             ->where('is_lifetime', '=', false)
             ->whereHas('donations')
             ->whereDoesntHave('donations', function ($query): void {

--- a/app/Console/Commands/AutoRemoveFeaturedTorrent.php
+++ b/app/Console/Commands/AutoRemoveFeaturedTorrent.php
@@ -57,7 +57,7 @@ class AutoRemoveFeaturedTorrent extends Command
     final public function handle(): void
     {
         $current = Carbon::now();
-        $featuredTorrents = FeaturedTorrent::with('torrent')->where('created_at', '<', $current->copy()->subDays(7))->get();
+        $featuredTorrents = FeaturedTorrent::query()->with('torrent')->where('created_at', '<', $current->copy()->subDays(7))->get();
 
         foreach ($featuredTorrents as $featuredTorrent) {
             // Find The Torrent

--- a/app/Console/Commands/AutoRemovePersonalFreeleech.php
+++ b/app/Console/Commands/AutoRemovePersonalFreeleech.php
@@ -50,7 +50,7 @@ class AutoRemovePersonalFreeleech extends Command
     final public function handle(): void
     {
         $current = Carbon::now();
-        $personalFreeleech = PersonalFreeleech::where('created_at', '<', $current->copy()->subDays(1))->get();
+        $personalFreeleech = PersonalFreeleech::query()->where('created_at', '<', $current->copy()->subDays(1))->get();
 
         foreach ($personalFreeleech as $pfl) {
             Notification::send(new User(['id' => $pfl->user_id]), new PersonalFreeleechDeleted());

--- a/app/Console/Commands/AutoRemoveTimedTorrentBuffs.php
+++ b/app/Console/Commands/AutoRemoveTimedTorrentBuffs.php
@@ -47,7 +47,7 @@ class AutoRemoveTimedTorrentBuffs extends Command
      */
     final public function handle(): void
     {
-        $flTorrents = Torrent::whereNotNull('fl_until')->where('fl_until', '<', Carbon::now())->get();
+        $flTorrents = Torrent::query()->whereNotNull('fl_until')->where('fl_until', '<', Carbon::now())->get();
 
         foreach ($flTorrents as $torrent) {
             $torrent->update([
@@ -59,7 +59,7 @@ class AutoRemoveTimedTorrentBuffs extends Command
             Unit3dAnnounce::addTorrent($torrent);
         }
 
-        $duTorrents = Torrent::whereNotNull('du_until')->where('du_until', '<', Carbon::now())->get();
+        $duTorrents = Torrent::query()->whereNotNull('du_until')->where('du_until', '<', Carbon::now())->get();
 
         foreach ($duTorrents as $torrent) {
             $torrent->update([

--- a/app/Console/Commands/AutoResetUserFlushes.php
+++ b/app/Console/Commands/AutoResetUserFlushes.php
@@ -45,7 +45,7 @@ class AutoResetUserFlushes extends Command
     final public function handle(): void
     {
         // Updates own_flushes for each user
-        User::where('own_flushes', '<', 2)->update(['own_flushes' => 2]);
+        User::query()->where('own_flushes', '<', 2)->update(['own_flushes' => 2]);
 
         $this->comment('Automated reset user flushes command complete');
     }

--- a/app/Console/Commands/AutoRewardUploadContestPrize.php
+++ b/app/Console/Commands/AutoRewardUploadContestPrize.php
@@ -49,7 +49,8 @@ class AutoRewardUploadContestPrize extends Command
     final public function handle(): void
     {
         // Get all active upload contests
-        $activeUploadContests = UploadContest::where('ends_at', '<', now()->toDateString())
+        $activeUploadContests = UploadContest::query()
+            ->where('ends_at', '<', now()->toDateString())
             ->where('awarded', '=', 0)
             ->get();
 
@@ -88,7 +89,7 @@ class AutoRewardUploadContestPrize extends Command
                 }
 
                 // Persist the winners
-                UploadContestWinner::create([
+                UploadContestWinner::query()->create([
                     'upload_contest_id' => $activeUploadContest->id,
                     'user_id'           => $winner->user->id,
                     'place_number'      => $i + 1,

--- a/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
+++ b/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
@@ -65,7 +65,7 @@ class AutoSoftDeleteDisabledUsers extends Command
             return;
         }
 
-        $users = User::whereRelation('group', 'slug', '=', 'disabled')
+        $users = User::query()->whereRelation('group', 'slug', '=', 'disabled')
             ->where('disabled_at', '<', now()->copy()->subDays(config('pruning.soft_delete')))
             ->get();
 
@@ -76,44 +76,44 @@ class AutoSoftDeleteDisabledUsers extends Command
                 'deleted_by'   => User::SYSTEM_USER_ID,
             ]);
 
-            Torrent::withoutGlobalScope(ApprovedScope::class)->where('user_id', '=', $user->id)->update([
+            Torrent::query()->withoutGlobalScope(ApprovedScope::class)->where('user_id', '=', $user->id)->update([
                 'user_id' => User::SYSTEM_USER_ID,
             ]);
 
-            Comment::where('user_id', '=', $user->id)->update([
+            Comment::query()->where('user_id', '=', $user->id)->update([
                 'user_id' => User::SYSTEM_USER_ID,
             ]);
 
-            Post::where('user_id', '=', $user->id)->update([
+            Post::query()->where('user_id', '=', $user->id)->update([
                 'user_id' => User::SYSTEM_USER_ID,
             ]);
 
-            Topic::where('first_post_user_id', '=', $user->id)->update([
+            Topic::query()->where('first_post_user_id', '=', $user->id)->update([
                 'first_post_user_id' => User::SYSTEM_USER_ID,
             ]);
 
-            Topic::where('last_post_user_id', '=', $user->id)->update([
+            Topic::query()->where('last_post_user_id', '=', $user->id)->update([
                 'last_post_user_id' => User::SYSTEM_USER_ID,
             ]);
 
-            PrivateMessage::where('sender_id', '=', $user->id)->update([
+            PrivateMessage::query()->where('sender_id', '=', $user->id)->update([
                 'sender_id' => User::SYSTEM_USER_ID,
             ]);
 
-            Participant::where('user_id', '=', $user->id)->delete();
-            Message::where('user_id', '=', $user->id)->delete();
-            Like::where('user_id', '=', $user->id)->delete();
-            Thank::where('user_id', '=', $user->id)->delete();
-            Peer::where('user_id', '=', $user->id)->delete();
-            History::where('user_id', '=', $user->id)->delete();
-            FailedLoginAttempt::where('user_id', '=', $user->id)->delete();
+            Participant::query()->where('user_id', '=', $user->id)->delete();
+            Message::query()->where('user_id', '=', $user->id)->delete();
+            Like::query()->where('user_id', '=', $user->id)->delete();
+            Thank::query()->where('user_id', '=', $user->id)->delete();
+            Peer::query()->where('user_id', '=', $user->id)->delete();
+            History::query()->where('user_id', '=', $user->id)->delete();
+            FailedLoginAttempt::query()->where('user_id', '=', $user->id)->delete();
 
             // Removes all follows for user
             $user->followers()->detach();
             $user->following()->detach();
 
             // Removes all FL Tokens for user
-            foreach (FreeleechToken::where('user_id', '=', $user->id)->get() as $token) {
+            foreach (FreeleechToken::query()->where('user_id', '=', $user->id)->get() as $token) {
                 $token->delete();
                 cache()->forget('freeleech_token:'.$user->id.':'.$token->torrent_id);
             }

--- a/app/Console/Commands/AutoUpsertAnnounces.php
+++ b/app/Console/Commands/AutoUpsertAnnounces.php
@@ -76,7 +76,7 @@ class AutoUpsertAnnounces extends Command
 
             $announces = array_map('unserialize', $announces);
 
-            DB::transaction(static fn () => Announce::insert($announces), 5);
+            DB::transaction(static fn () => Announce::query()->insert($announces), 5);
         }
 
         $this->comment('Automated upsert announce command complete');

--- a/app/Console/Commands/AutoUpsertHistories.php
+++ b/app/Console/Commands/AutoUpsertHistories.php
@@ -82,7 +82,7 @@ class AutoUpsertHistories extends Command
             $histories = array_map('unserialize', $histories);
 
             DB::transaction(function () use ($histories): void {
-                History::upsert(
+                History::query()->upsert(
                     $histories,
                     ['user_id', 'torrent_id'],
                     [

--- a/app/Console/Commands/AutoUpsertPeers.php
+++ b/app/Console/Commands/AutoUpsertPeers.php
@@ -66,7 +66,7 @@ class AutoUpsertPeers extends Command
             $peers = array_map('unserialize', $peers);
 
             DB::transaction(function () use ($peers): void {
-                Peer::upsert(
+                Peer::query()->upsert(
                     $peers,
                     ['user_id', 'torrent_id', 'peer_id'],
                     [

--- a/app/Console/Commands/AutoWarning.php
+++ b/app/Console/Commands/AutoWarning.php
@@ -55,7 +55,8 @@ class AutoWarning extends Command
         }
 
         $carbon = new Carbon();
-        $hitrun = History::with(['user', 'torrent'])
+        $hitrun = History::query()
+            ->with(['user', 'torrent'])
             ->where('actual_downloaded', '>', 0)
             ->where('prewarned_at', '<=', now()->subDays(config('hitrun.prewarn')))
             ->where('hitrun', '=', 0)
@@ -72,7 +73,7 @@ class AutoWarning extends Command
         $usersWithWarnings = [];
 
         foreach ($hitrun as $hr) {
-            Warning::create([
+            Warning::query()->create([
                 'user_id'    => $hr->user->id,
                 'warned_by'  => User::SYSTEM_USER_ID,
                 'torrent_id' => $hr->torrent->id,

--- a/app/Console/Commands/CleanTorrentFiles.php
+++ b/app/Console/Commands/CleanTorrentFiles.php
@@ -48,7 +48,7 @@ class CleanTorrentFiles extends Command
     {
         $this->alert('Torrent file cleaning started');
 
-        Torrent::withoutGlobalScopes()->select('file_name')->orderBy('id')->chunk(100, function ($torrents): void {
+        Torrent::query()->withoutGlobalScopes()->select('file_name')->orderBy('id')->chunk(100, function ($torrents): void {
             foreach ($torrents as $torrent) {
                 if (Storage::disk('torrent-files')->exists($torrent->file_name)) {
                     $filePath = Storage::disk('torrent-files')->path($torrent->file_name);

--- a/app/Console/Commands/SyncPeers.php
+++ b/app/Console/Commands/SyncPeers.php
@@ -49,7 +49,8 @@ class SyncPeers extends Command
     final public function handle(): void
     {
         DB::transaction(function (): void {
-            Torrent::withoutGlobalScope(ApprovedScope::class)
+            Torrent::query()
+                ->withoutGlobalScope(ApprovedScope::class)
                 ->leftJoinSub(
                     Peer::query()
                         ->select('torrent_id')
@@ -71,7 +72,8 @@ class SyncPeers extends Command
         }, 5);
 
         DB::transaction(function (): void {
-            Torrent::withoutGlobalScope(ApprovedScope::class)
+            Torrent::query()
+                ->withoutGlobalScope(ApprovedScope::class)
                 ->leftJoinSub(
                     History::query()
                         ->select('torrent_id')

--- a/app/Console/Commands/SyncTorrentSeasonEpisode.php
+++ b/app/Console/Commands/SyncTorrentSeasonEpisode.php
@@ -45,7 +45,7 @@ class SyncTorrentSeasonEpisode extends Command
      */
     final public function handle(): void
     {
-        foreach (Torrent::withoutGlobalScope(ApprovedScope::class)->with(['category'])->whereNull('season_number')->orWhereNull('episode_number')->get() as $torrent) {
+        foreach (Torrent::query()->withoutGlobalScope(ApprovedScope::class)->with(['category'])->whereNull('season_number')->orWhereNull('episode_number')->get() as $torrent) {
             // Skip if not TV
             if (!$torrent->category->tv_meta) {
                 continue;

--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -245,7 +245,8 @@ readonly class TorrentSearchFiltersDTO
                 fn ($query) => $query
                     ->whereIn(
                         'id',
-                        PlaylistTorrent::select('torrent_id')
+                        PlaylistTorrent::query()
+                            ->select('torrent_id')
                             ->where('playlist_id', '=', $this->playlistId)
                             ->when(
                                 $this->user === null,
@@ -383,12 +384,12 @@ readonly class TorrentSearchFiltersDTO
                             ->where(
                                 fn ($query) => $query
                                     ->whereRelation('category', 'movie_meta', '=', true)
-                                    ->whereIn('tmdb_movie_id', Wish::select('tmdb_movie_id')->where('user_id', '=', $this->user->id))
+                                    ->whereIn('tmdb_movie_id', Wish::query()->select('tmdb_movie_id')->where('user_id', '=', $this->user->id))
                             )
                             ->orWhere(
                                 fn ($query) => $query
                                     ->whereRelation('category', 'tv_meta', '=', true)
-                                    ->whereIn('tmdb_tv_id', Wish::select('tmdb_tv_id')->where('user_id', '=', $this->user->id))
+                                    ->whereIn('tmdb_tv_id', Wish::query()->select('tmdb_tv_id')->where('user_id', '=', $this->user->id))
                             )
                     )
             )

--- a/app/Events/MessageEdited.php
+++ b/app/Events/MessageEdited.php
@@ -40,7 +40,7 @@ class MessageEdited implements ShouldBroadcastNow
      */
     public function __construct(Message $message)
     {
-        $message = Message::with(['bot', 'user.group', 'user.chatStatus'])->find($message->id);
+        $message = Message::query()->with(['bot', 'user.group', 'user.chatStatus'])->find($message->id);
         $this->message = new ChatMessageResource($message);
     }
 

--- a/app/Events/MessageSent.php
+++ b/app/Events/MessageSent.php
@@ -40,7 +40,7 @@ class MessageSent implements ShouldBroadcastNow
      */
     public function __construct(Message $message)
     {
-        $message = Message::with([
+        $message = Message::query()->with([
             'bot',
             'user.group',
             'user.chatStatus',

--- a/app/Helpers/CacheUser.php
+++ b/app/Helpers/CacheUser.php
@@ -22,6 +22,6 @@ class CacheUser
 {
     public static function user(mixed $id): ?User
     {
-        return cache()->remember('cachedUser.'.$id, 30, fn () => User::find($id));
+        return cache()->remember('cachedUser.'.$id, 30, fn () => User::query()->find($id));
     }
 }

--- a/app/Helpers/TorrentHelper.php
+++ b/app/Helpers/TorrentHelper.php
@@ -48,7 +48,7 @@ class TorrentHelper
     {
         $appurl = config('app.url');
 
-        $torrent = Torrent::with('user')->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->with('user')->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrent->created_at = Carbon::now();
         $torrent->bumped_at = Carbon::now();
         $torrent->status = ModerationStatus::APPROVED;
@@ -129,8 +129,8 @@ class TorrentHelper
 
             if ($torrent->tmdb_movie_id > 0 || $torrent->tmdb_tv_id > 0) {
                 $meta = match (true) {
-                    $category->tv_meta    => TmdbTv::find($torrent->tmdb_tv_id),
-                    $category->movie_meta => TmdbMovie::find($torrent->tmdb_movie_id),
+                    $category->tv_meta    => TmdbTv::query()->find($torrent->tmdb_tv_id),
+                    $category->movie_meta => TmdbMovie::query()->find($torrent->tmdb_movie_id),
                     default               => null,
                 };
             }

--- a/app/Http/Controllers/API/ChatController.php
+++ b/app/Http/Controllers/API/ChatController.php
@@ -64,7 +64,7 @@ class ChatController extends Controller
             ->get();
 
         if ($echoes->isEmpty()) {
-            $echoes->push(UserEcho::create([
+            $echoes->push(UserEcho::query()->create([
                 'user_id' => $request->user()->id,
                 'room_id' => 1,
             ]));
@@ -83,7 +83,7 @@ class ChatController extends Controller
             ->get();
 
         if ($audibles->isEmpty()) {
-            $audibles->prepend(UserAudible::create([
+            $audibles->prepend(UserAudible::query()->create([
                 'user_id' => $request->user()->id,
                 'room_id' => 1,
                 'status'  => true,
@@ -125,7 +125,7 @@ class ChatController extends Controller
     /* MESSAGES */
     public function botMessages(Request $request, int $botId): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
     {
-        $bot = Bot::findOrFail($botId);
+        $bot = Bot::query()->findOrFail($botId);
         $user = $request->user();
 
         // Create echo for user if missing
@@ -176,13 +176,13 @@ class ChatController extends Controller
             return response('error', 401);
         }
 
-        $bots = cache()->remember('bots', 3600, fn () => Bot::where('active', '=', 1)->orderByDesc('position')->get());
+        $bots = cache()->remember('bots', 3600, fn () => Bot::query()->where('active', '=', 1)->orderByDesc('position')->get());
 
         if (str_starts_with($message, '/msg')) {
             [, $username, $message] = mb_split(' +', trim($message), 3) + [null, null, ''];
 
             if ($username !== null) {
-                $receiverId = User::where('username', '=', $username)->soleValue('id');
+                $receiverId = User::query()->where('username', '=', $username)->soleValue('id');
             }
 
             $botId = 1;
@@ -264,7 +264,7 @@ class ChatController extends Controller
 
     public function deleteMessage(Request $request, int $id): \Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response
     {
-        $message = Message::findOrFail($id);
+        $message = Message::query()->findOrFail($id);
 
         abort_unless($request->user()->id === $message->user_id || $request->user()->group->is_modo, 403);
 
@@ -282,17 +282,17 @@ class ChatController extends Controller
     public function deleteRoomEcho(Request $request): \Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response
     {
         $user = $request->user();
-        UserEcho::where('user_id', '=', $user->id)->where('room_id', '=', $request->integer('room_id'))->delete();
+        UserEcho::query()->where('user_id', '=', $user->id)->where('room_id', '=', $request->integer('room_id'))->delete();
 
         $user->load(['chatStatus', 'chatroom', 'group', 'echoes']);
-        $room = Chatroom::findOrFail($request->integer('room_id'));
+        $room = Chatroom::query()->findOrFail($request->integer('room_id'));
 
         $user->chatroom()->dissociate();
         $user->chatroom()->associate($room);
 
         $user->save();
 
-        $senderEchoes = UserEcho::with(['room', 'target', 'bot'])->where('user_id', $user->id)->get();
+        $senderEchoes = UserEcho::query()->with(['room', 'target', 'bot'])->where('user_id', $user->id)->get();
 
         event(new Chatter('echo', $user->id, UserEchoResource::collection($senderEchoes)));
 
@@ -306,10 +306,10 @@ class ChatController extends Controller
     public function deleteTargetEcho(Request $request): \Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response
     {
         $user = $request->user();
-        UserEcho::where('user_id', '=', $user->id)->where('target_id', '=', $request->input('target_id'))->delete();
+        UserEcho::query()->where('user_id', '=', $user->id)->where('target_id', '=', $request->input('target_id'))->delete();
 
         $user->load(['chatStatus', 'chatroom', 'group', 'echoes']);
-        $senderEchoes = UserEcho::with(['room', 'target', 'bot'])->where('user_id', $user->id)->get();
+        $senderEchoes = UserEcho::query()->with(['room', 'target', 'bot'])->where('user_id', $user->id)->get();
 
         event(new Chatter('echo', $user->id, UserEchoResource::collection($senderEchoes)));
 
@@ -323,10 +323,10 @@ class ChatController extends Controller
     public function deleteBotEcho(Request $request): \Illuminate\Http\JsonResponse
     {
         $user = $request->user();
-        UserEcho::where('user_id', '=', $user->id)->where('bot_id', '=', $request->input('bot_id'))->delete();
+        UserEcho::query()->where('user_id', '=', $user->id)->where('bot_id', '=', $request->input('bot_id'))->delete();
 
         $user->load(['chatStatus', 'chatroom', 'group', 'echoes']);
-        $senderEchoes = UserEcho::with(['room', 'target', 'bot'])->where('user_id', $user->id)->get();
+        $senderEchoes = UserEcho::query()->with(['room', 'target', 'bot'])->where('user_id', $user->id)->get();
 
         event(new Chatter('echo', $user->id, UserEchoResource::collection($senderEchoes)));
 
@@ -336,12 +336,12 @@ class ChatController extends Controller
     public function toggleRoomAudible(Request $request): \Illuminate\Http\JsonResponse
     {
         $user = $request->user();
-        $echo = UserAudible::where('user_id', '=', $user->id)->where('room_id', '=', $request->input('room_id'))->sole();
+        $echo = UserAudible::query()->where('user_id', '=', $user->id)->where('room_id', '=', $request->input('room_id'))->sole();
         $echo->status = !$echo->status;
         $echo->save();
 
         $user->load(['chatStatus', 'chatroom', 'group', 'audibles', 'audibles']);
-        $senderAudibles = UserAudible::with(['room', 'target', 'bot'])->where('user_id', $user->id)->get();
+        $senderAudibles = UserAudible::query()->with(['room', 'target', 'bot'])->where('user_id', $user->id)->get();
 
         event(new Chatter('audible', $user->id, UserAudibleResource::collection($senderAudibles)));
 
@@ -351,12 +351,12 @@ class ChatController extends Controller
     public function toggleTargetAudible(Request $request): \Illuminate\Http\JsonResponse
     {
         $user = $request->user();
-        $echo = UserAudible::where('user_id', '=', $user->id)->where('target_id', '=', $request->input('target_id'))->sole();
+        $echo = UserAudible::query()->where('user_id', '=', $user->id)->where('target_id', '=', $request->input('target_id'))->sole();
         $echo->status = !$echo->status;
         $echo->save();
 
         $user->load(['chatStatus', 'chatroom', 'group', 'audibles', 'audibles']);
-        $senderAudibles = UserAudible::with(['target', 'room', 'bot'])->where('user_id', $user->id)->get();
+        $senderAudibles = UserAudible::query()->with(['target', 'room', 'bot'])->where('user_id', $user->id)->get();
 
         event(new Chatter('audible', $user->id, UserAudibleResource::collection($senderAudibles)));
 
@@ -366,12 +366,12 @@ class ChatController extends Controller
     public function toggleBotAudible(Request $request): \Illuminate\Http\JsonResponse
     {
         $user = $request->user();
-        $echo = UserAudible::where('user_id', '=', $user->id)->where('bot_id', '=', $request->input('bot_id'))->sole();
+        $echo = UserAudible::query()->where('user_id', '=', $user->id)->where('bot_id', '=', $request->input('bot_id'))->sole();
         $echo->status = !$echo->status;
         $echo->save();
 
         $user->load(['chatStatus', 'chatroom', 'group', 'audibles', 'audibles'])->findOrFail($user->id);
-        $senderAudibles = UserAudible::with(['bot', 'room', 'bot'])->where('user_id', $user->id)->get();
+        $senderAudibles = UserAudible::query()->with(['bot', 'room', 'bot'])->where('user_id', $user->id)->get();
 
         event(new Chatter('audible', $user->id, UserAudibleResource::collection($senderAudibles)));
 
@@ -382,7 +382,7 @@ class ChatController extends Controller
     public function updateUserChatStatus(Request $request): \Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response
     {
         $user = $request->user();
-        $status = ChatStatus::findOrFail($request->integer('status_id'));
+        $status = ChatStatus::query()->findOrFail($request->integer('status_id'));
 
         $this->chatRepository->systemMessage('[url=/users/'.$user->username.']'.$user->username.'[/url] has updated their status to [b]'.$status->name.'[/b]');
 
@@ -396,7 +396,7 @@ class ChatController extends Controller
     public function updateUserRoom(Request $request): \Illuminate\Http\JsonResponse
     {
         $user = $request->user();
-        $room = Chatroom::findOrFail($request->integer('room_id'));
+        $room = Chatroom::query()->findOrFail($request->integer('room_id'));
 
         $user->chatroom()->dissociate();
         $user->chatroom()->associate($room);

--- a/app/Http/Controllers/API/DislikeController.php
+++ b/app/Http/Controllers/API/DislikeController.php
@@ -25,17 +25,17 @@ class DislikeController extends Controller
     public function store(int $postId): \Illuminate\Http\JsonResponse
     {
         $user = auth()->user();
-        $post = Post::findOrFail($postId);
+        $post = Post::query()->findOrFail($postId);
 
         if ($user->id === $post->user_id) {
             abort(400, 'You cannot dislike your own post!');
         }
 
-        if (Like::where('user_id', '=', $user->id)->where('post_id', '=', $post->id)->exists()) {
+        if (Like::query()->where('user_id', '=', $user->id)->where('post_id', '=', $post->id)->exists()) {
             abort(400, 'You have already liked or disliked this post!');
         }
 
-        Like::create([
+        Like::query()->create([
             'user_id' => $user->id,
             'post_id' => $post->id,
             'dislike' => true,

--- a/app/Http/Controllers/API/LikeController.php
+++ b/app/Http/Controllers/API/LikeController.php
@@ -25,17 +25,17 @@ class LikeController extends Controller
     public function store(int $postId): \Illuminate\Http\JsonResponse
     {
         $user = auth()->user();
-        $post = Post::findOrFail($postId);
+        $post = Post::query()->findOrFail($postId);
 
         if ($user->id === $post->user_id) {
             abort(400, 'You cannot like your own post!');
         }
 
-        if (Like::where('user_id', '=', $user->id)->where('post_id', '=', $post->id)->exists()) {
+        if (Like::query()->where('user_id', '=', $user->id)->where('post_id', '=', $post->id)->exists()) {
             abort(400, 'You have already liked or disliked this post!');
         }
 
-        Like::create([
+        Like::query()->create([
             'user_id' => $user->id,
             'post_id' => $post->id,
             'like'    => true,

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -71,9 +71,16 @@ class TorrentController extends BaseController
     public function index(): TorrentsResource
     {
         $torrents = cache()->flexible('torrent-api-index', [60 * 5, 60 * 6], function () {
-            $torrents = Torrent::with(
-                ['user:id,username', 'category', 'type', 'resolution', 'region', 'distributor', 'files']
-            )
+            $torrents = Torrent::query()
+                ->with([
+                    'user:id,username',
+                    'category',
+                    'type',
+                    'resolution',
+                    'region',
+                    'distributor',
+                    'files'
+                ])
                 ->withExists([
                     'featured as featured'
                 ])
@@ -140,7 +147,7 @@ class TorrentController extends BaseController
         Storage::disk('torrent-files')->put($fileName, Bencode::bencode($decodedTorrent));
 
         // Find the right category
-        $category = Category::withCount('torrents')->findOrFail($request->integer('category_id'));
+        $category = Category::query()->withCount('torrents')->findOrFail($request->integer('category_id'));
 
         // Create the torrent (DB)
         $torrent = app()->make(Torrent::class);
@@ -379,7 +386,7 @@ class TorrentController extends BaseController
         // Can't insert them all at once since some torrents have more files than mysql supports placeholders.
         // Divide by 3 since we're inserting 3 fields: name, size and torrent_id
         foreach (collect($files)->chunk(intdiv(65_000, 3)) as $files) {
-            TorrentFile::insert($files->toArray());
+            TorrentFile::query()->insert($files->toArray());
         }
 
         // Set torrent to featured
@@ -415,7 +422,7 @@ class TorrentController extends BaseController
         }
 
         foreach (collect($keywords)->chunk(intdiv(65_000, 2)) as $keywords) {
-            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name']);
+            Keyword::query()->upsert($keywords->toArray(), ['torrent_id', 'name']);
         }
 
         // check for trusted user & mod queue isn't opted in and update torrent
@@ -496,7 +503,8 @@ class TorrentController extends BaseController
      */
     public function show(int $id): TorrentResource
     {
-        $torrent = Torrent::with(['user:id,username', 'category', 'type', 'resolution', 'region', 'distributor', 'files'])
+        $torrent = Torrent::query()
+            ->with(['user:id,username', 'category', 'type', 'resolution', 'region', 'distributor', 'files'])
             ->select('*')
             ->selectRaw("
                 CASE
@@ -512,15 +520,15 @@ class TorrentController extends BaseController
         $torrent->setAttribute('meta', null);
 
         if ($torrent->category->tv_meta && $torrent->tmdb_tv_id) {
-            $torrent->setAttribute('meta', TmdbTv::with(['genres'])->find($torrent->tmdb_tv_id));
+            $torrent->setAttribute('meta', TmdbTv::query()->with(['genres'])->find($torrent->tmdb_tv_id));
         }
 
         if ($torrent->category->movie_meta && $torrent->tmdb_movie_id) {
-            $torrent->setAttribute('meta', TmdbMovie::with(['genres'])->find($torrent->tmdb_movie_id));
+            $torrent->setAttribute('meta', TmdbMovie::query()->with(['genres'])->find($torrent->tmdb_movie_id));
         }
 
         if ($torrent->category->game_meta && $torrent->igdb) {
-            $torrent->setAttribute('meta', IgdbGame::with(['genres'])->find($torrent->igdb));
+            $torrent->setAttribute('meta', IgdbGame::query()->with(['genres'])->find($torrent->igdb));
         }
 
         TorrentResource::withoutWrapping();

--- a/app/Http/Controllers/API/TorrentRequestController.php
+++ b/app/Http/Controllers/API/TorrentRequestController.php
@@ -61,7 +61,8 @@ class TorrentRequestController extends Controller
      */
     public function show(int $id): \Illuminate\Http\JsonResponse
     {
-        $request = TorrentRequest::with(['user', 'claim.user', 'filler'])
+        $request = TorrentRequest::query()
+            ->with(['user', 'claim.user', 'filler'])
             ->withSum('bounties', 'seedbonus')
             ->findOrFail($id);
 

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -183,7 +183,7 @@ final class AnnounceController extends Controller
         }
 
         // Block Blacklisted Clients
-        $blacklistedPeerIdPrefixes = cache()->rememberForever('client_blacklist', fn () => BlacklistClient::pluck('peer_id_prefix')->toArray());
+        $blacklistedPeerIdPrefixes = cache()->rememberForever('client_blacklist', fn () => BlacklistClient::query()->pluck('peer_id_prefix')->toArray());
 
         $peerId = $request->query->getString('peer_id');
 
@@ -391,7 +391,8 @@ final class AnnounceController extends Controller
         $torrent = cache()->remember(
             'announce-torrents:by-infohash:'.$infoHash,
             8 * 3600,
-            fn () => Torrent::withoutGlobalScope(ApprovedScope::class)
+            fn () => Torrent::query()
+                ->withoutGlobalScope(ApprovedScope::class)
                 ->select(['id', 'free', 'doubleup', 'seeders', 'leechers', 'times_completed', 'status'])
                 ->where('info_hash', '=', $infoHash)
                 ->firstOr(fn (): string => '-1')
@@ -399,7 +400,7 @@ final class AnnounceController extends Controller
 
         // If Torrent Doesn't Exist Return Error to Client
         if ($torrent === '-1') {
-            UnregisteredInfoHash::upsert([
+            UnregisteredInfoHash::query()->upsert([
                 'user_id'   => $user->id,
                 'info_hash' => $infoHash,
             ], ['info_hash', 'user_id']);
@@ -426,7 +427,8 @@ final class AnnounceController extends Controller
         // If we use eager loading, then laravel will use `where torrent_id in (123)` instead of `where torrent_id = ?`
         $torrent->setRelation(
             'peers',
-            Peer::select(['torrent_id', 'peer_id', 'user_id', 'downloaded', 'uploaded', 'left', 'seeder', 'active', 'visible', 'ip', 'port', 'updated_at'])
+            Peer::query()
+                ->select(['torrent_id', 'peer_id', 'user_id', 'downloaded', 'uploaded', 'left', 'seeder', 'active', 'visible', 'ip', 'port', 'updated_at'])
                 ->where('torrent_id', '=', $torrent->id)
                 ->get()
         );

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -30,7 +30,7 @@ class ArticleController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('article.index', [
-            'articles' => Article::latest()->paginate(6),
+            'articles' => Article::query()->latest()->paginate(6),
         ]);
     }
 

--- a/app/Http/Controllers/AuthenticatedImageController.php
+++ b/app/Http/Controllers/AuthenticatedImageController.php
@@ -65,7 +65,7 @@ class AuthenticatedImageController extends Controller
 
     public function torrentBanner(int $id): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         $path = Storage::disk('torrent-banners')->path("torrent-banner_{$torrent->id}.jpg");
 
@@ -76,7 +76,7 @@ class AuthenticatedImageController extends Controller
 
     public function torrentCover(int $id): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         $path = Storage::disk('torrent-covers')->path("torrent-cover_{$torrent->id}.jpg");
 

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -40,7 +40,7 @@ class ContactController extends Controller
     public function store(Request $request): \Illuminate\Http\RedirectResponse
     {
         // Fetch owner account
-        $user = User::where('username', config('unit3d.owner-username'))->first();
+        $user = User::query()->where('username', config('unit3d.owner-username'))->first();
 
         Mail::to($user->email)->send(new Contact($request->string('email')));
 

--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -29,8 +29,8 @@ class DonationController extends Controller
      */
     public function index(): \Illuminate\Contracts\View\View|\Illuminate\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\Foundation\Application
     {
-        $packages = DonationPackage::where('is_active', '=', true)->orderBy('position')->get();
-        $gateways = DonationGateway::where('is_active', '=', true)->orderBy('position')->get();
+        $packages = DonationPackage::query()->where('is_active', '=', true)->orderBy('position')->get();
+        $gateways = DonationGateway::query()->where('is_active', '=', true)->orderBy('position')->get();
 
         return view('donation.index', ['packages' => $packages, 'gateways' => $gateways]);
     }
@@ -40,7 +40,7 @@ class DonationController extends Controller
      */
     public function store(StoreDonationRequest $request)
     {
-        Donation::create([
+        Donation::query()->create([
             'status'      => ModerationStatus::PENDING,
             'package_id'  => $request->package_id,
             'user_id'     => auth()->user()->id,

--- a/app/Http/Controllers/ExternalTorrentController.php
+++ b/app/Http/Controllers/ExternalTorrentController.php
@@ -28,7 +28,7 @@ class ExternalTorrentController extends Controller
     {
         return view('torrent.external-tracker', [
             'id'              => $id,
-            'torrent'         => Torrent::find($id),
+            'torrent'         => Torrent::query()->find($id),
             'externalTorrent' => Unit3dAnnounce::getTorrent($id),
         ]);
     }

--- a/app/Http/Controllers/GiveawayClaimedPrizeController.php
+++ b/app/Http/Controllers/GiveawayClaimedPrizeController.php
@@ -79,7 +79,7 @@ class GiveawayClaimedPrizeController extends Controller
                     break;
             }
 
-            GiveawayClaimedPrize::create([
+            GiveawayClaimedPrize::query()->create([
                 'user_id'     => $request->user()->id,
                 'giveaway_id' => $giveaway->id,
                 'bon'         => $bon_won,

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -67,7 +67,8 @@ class HomeController extends Controller
             'users' => cache()->flexible(
                 'online_users:by-group:'.auth()->user()->group_id,
                 $expiresAt,
-                fn () => User::with('group', 'privacy')
+                fn () => User::query()
+                    ->with('group', 'privacy')
                     ->withCount([
                         'warnings' => function (Builder $query): void {
                             $query->whereNotNull('torrent_id')->where('active', true);
@@ -81,13 +82,14 @@ class HomeController extends Controller
             'groups' => cache()->flexible(
                 'user-groups',
                 $expiresAt,
-                fn () => Group::select([
-                    'id',
-                    'name',
-                    'color',
-                    'effect',
-                    'icon',
-                ])
+                fn () => Group::query()
+                    ->select([
+                        'id',
+                        'name',
+                        'color',
+                        'effect',
+                        'icon',
+                    ])
                     ->oldest('position')
                     ->get()
             ),
@@ -132,13 +134,13 @@ class HomeController extends Controller
             'featured' => cache()->flexible(
                 'latest_featured',
                 $expiresAt,
-                fn () => FeaturedTorrent::with([
+                fn () => FeaturedTorrent::query()->with([
                     'torrent' => ['resolution', 'type', 'category'],
                     'user.group',
                 ])->get(),
             ),
             'poll' => cache()->flexible('latest_poll', $expiresAt, function () {
-                return Poll::where(function ($query): void {
+                return Poll::query()->where(function ($query): void {
                     $query->where('expires_at', '>', now())
                         ->orWhereNull('expires_at');
                 })->latest()->first();

--- a/app/Http/Controllers/MediaHub/HomeController.php
+++ b/app/Http/Controllers/MediaHub/HomeController.php
@@ -34,15 +34,15 @@ class HomeController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('mediahub.index', [
-            'tv'               => TmdbTv::count(),
-            'movies'           => TmdbMovie::count(),
-            'movieCategoryIds' => Category::where('movie_meta', '=', 1)->pluck('id')->toArray(),
-            'tvCategoryIds'    => Category::where('tv_meta', '=', 1)->pluck('id')->toArray(),
-            'collections'      => TmdbCollection::count(),
-            'persons'          => TmdbPerson::whereNotNull('still')->count(),
-            'genres'           => TmdbGenre::count(),
-            'networks'         => TmdbNetwork::count(),
-            'companies'        => TmdbCompany::count(),
+            'tv'               => TmdbTv::query()->count(),
+            'movies'           => TmdbMovie::query()->count(),
+            'movieCategoryIds' => Category::query()->where('movie_meta', '=', 1)->pluck('id')->toArray(),
+            'tvCategoryIds'    => Category::query()->where('tv_meta', '=', 1)->pluck('id')->toArray(),
+            'collections'      => TmdbCollection::query()->count(),
+            'persons'          => TmdbPerson::query()->whereNotNull('still')->count(),
+            'genres'           => TmdbGenre::query()->count(),
+            'networks'         => TmdbNetwork::query()->count(),
+            'companies'        => TmdbCompany::query()->count(),
         ]);
     }
 }

--- a/app/Http/Controllers/MediaHub/TmdbCollectionController.php
+++ b/app/Http/Controllers/MediaHub/TmdbCollectionController.php
@@ -35,7 +35,7 @@ class TmdbCollectionController extends Controller
     public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('mediahub.collection.show', [
-            'collection' => TmdbCollection::with(['movies' => fn ($query) => $query->has('torrents'), 'comments'])->findOrFail($id),
+            'collection' => TmdbCollection::query()->with(['movies' => fn ($query) => $query->has('torrents'), 'comments'])->findOrFail($id),
         ]);
     }
 }

--- a/app/Http/Controllers/MediaHub/TmdbGenreController.php
+++ b/app/Http/Controllers/MediaHub/TmdbGenreController.php
@@ -27,7 +27,7 @@ class TmdbGenreController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('mediahub.genre.index', [
-            'genres' => TmdbGenre::withCount(['tv', 'movie'])->orderBy('name')->get(),
+            'genres' => TmdbGenre::query()->withCount(['tv', 'movie'])->orderBy('name')->get(),
         ]);
     }
 }

--- a/app/Http/Controllers/MediaHub/TmdbPersonController.php
+++ b/app/Http/Controllers/MediaHub/TmdbPersonController.php
@@ -35,7 +35,7 @@ class TmdbPersonController extends Controller
     public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('mediahub.person.show', [
-            'person' => TmdbPerson::findOrFail($id),
+            'person' => TmdbPerson::query()->findOrFail($id),
         ]);
     }
 }

--- a/app/Http/Controllers/PlaylistController.php
+++ b/app/Http/Controllers/PlaylistController.php
@@ -77,7 +77,7 @@ class PlaylistController extends Controller
             Image::make($image->getRealPath())->fit(400, 225)->encode('png', 100)->save($path);
         }
 
-        $playlist = Playlist::create([
+        $playlist = Playlist::query()->create([
             'user_id'     => $request->user()->id,
             'cover_image' => $filename ?? null
         ] + $request->validated());
@@ -124,8 +124,8 @@ class PlaylistController extends Controller
         return view('playlist.show', [
             'playlist' => $playlist->load(['user.group', 'suggestions' => ['user.group', 'torrent']]),
             'meta'     => match (true) {
-                $randomTorrent?->category?->tv_meta    => TmdbTv::find($randomTorrent->tmdb_tv_id),
-                $randomTorrent?->category?->movie_meta => TmdbMovie::find($randomTorrent->tmdb_movie_id),
+                $randomTorrent?->category?->tv_meta    => TmdbTv::query()->find($randomTorrent->tmdb_tv_id),
+                $randomTorrent?->category?->movie_meta => TmdbMovie::query()->find($randomTorrent->tmdb_movie_id),
                 default                                => null,
             },
             'latestPlaylistTorrent' => $playlist->torrents()->orderByPivot('created_at', 'desc')->first(),

--- a/app/Http/Controllers/PlaylistSuggestionController.php
+++ b/app/Http/Controllers/PlaylistSuggestionController.php
@@ -46,7 +46,7 @@ class PlaylistSuggestionController extends Controller
             'torrent_id.unique' => 'This torrent ID/URL ":input" entered is already suggested and awaiting moderation.',
         ])->validate();
 
-        $playlistSuggestion = PlaylistSuggestion::create([
+        $playlistSuggestion = PlaylistSuggestion::query()->create([
             'playlist_id' => $playlist->id,
             'torrent_id'  => basename($request->torrent_url),
             'user_id'     => $request->user()->id,
@@ -68,7 +68,7 @@ class PlaylistSuggestionController extends Controller
 
         switch (ModerationStatus::from($request->integer('status'))) {
             case ModerationStatus::APPROVED:
-                $playlistTorrent = PlaylistTorrent::create([
+                $playlistTorrent = PlaylistTorrent::query()->create([
                     'playlist_id' => $playlistSuggestion->playlist_id,
                     'torrent_id'  => $playlistSuggestion->torrent_id,
                 ]);

--- a/app/Http/Controllers/PlaylistTorrentController.php
+++ b/app/Http/Controllers/PlaylistTorrentController.php
@@ -35,11 +35,11 @@ class PlaylistTorrentController extends Controller
      */
     public function store(StorePlaylistTorrentRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $playlist = Playlist::findOrFail($request->integer('playlist_id'));
+        $playlist = Playlist::query()->findOrFail($request->integer('playlist_id'));
 
         abort_unless($request->user()->id === $playlist->user_id, 403);
 
-        $playlistTorrent = PlaylistTorrent::create($request->validated());
+        $playlistTorrent = PlaylistTorrent::query()->create($request->validated());
 
         $playlistTorrent->torrent()->searchable();
 
@@ -52,7 +52,7 @@ class PlaylistTorrentController extends Controller
      */
     public function massUpsert(MassUpsertPlaylistTorrentRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $playlist = Playlist::findOrFail($request->integer('playlist_id'));
+        $playlist = Playlist::query()->findOrFail($request->integer('playlist_id'));
 
         abort_unless($request->user()->id === $playlist->user_id, 403);
 
@@ -69,7 +69,7 @@ class PlaylistTorrentController extends Controller
             '*.torrent_id.exists' => 'The torrent ID/URL ":input" entered was not found on site.'
         ])->validate();
 
-        PlaylistTorrent::upsert($playlistTorrents, ['playlist_id', 'torrent_id', 'tmdb_id']);
+        PlaylistTorrent::query()->upsert($playlistTorrents, ['playlist_id', 'torrent_id', 'tmdb_id']);
 
         $playlist->torrents()->searchable();
 

--- a/app/Http/Controllers/PollController.php
+++ b/app/Http/Controllers/PollController.php
@@ -31,7 +31,7 @@ class PollController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('poll.latest', [
-            'polls' => Poll::latest()->paginate(15),
+            'polls' => Poll::query()->latest()->paginate(15),
         ]);
     }
 
@@ -40,7 +40,7 @@ class PollController extends Controller
      */
     public function show(Request $request, Poll $poll): \Illuminate\Contracts\View\Factory|\Illuminate\View\View|\Illuminate\Http\RedirectResponse
     {
-        if (Voter::whereBelongsTo($poll)->whereBelongsTo($request->user())->exists()) {
+        if (Voter::query()->whereBelongsTo($poll)->whereBelongsTo($request->user())->exists()) {
             return to_route('polls.votes.index', ['poll' => $poll])
                 ->withInfo(trans('poll.already-voted-result'));
         }

--- a/app/Http/Controllers/PollVoteController.php
+++ b/app/Http/Controllers/PollVoteController.php
@@ -39,12 +39,12 @@ class PollVoteController extends Controller
      */
     public function store(StorePollVoteRequest $request, Poll $poll): \Illuminate\Http\RedirectResponse
     {
-        if (Voter::whereBelongsTo($poll)->whereBelongsTo($request->user())->exists()) {
+        if (Voter::query()->whereBelongsTo($poll)->whereBelongsTo($request->user())->exists()) {
             return to_route('polls.votes.index', ['poll' => $poll])
                 ->withErrors(trans('poll.already-voted-error'));
         }
 
-        Option::whereIn('id', $request->validated('options'))->increment('votes');
+        Option::query()->whereIn('id', $request->validated('options'))->increment('votes');
 
         $poll->users()->attach($request->user());
 

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -75,7 +75,7 @@ class PostController extends Controller
 
         $forum = $topic->forum;
 
-        $post = Post::create([
+        $post = Post::query()->create([
             'content'  => $request->input('content'),
             'anon'     => $request->boolean('anon'),
             'user_id'  => $user->id,
@@ -170,7 +170,7 @@ class PostController extends Controller
 
         // User Tagged Notification
         preg_match_all('/@([\w\-]+)/', (string) $post->content, $matches);
-        $users = User::whereIn('username', $matches[1])->where('id', '!=', $user->id)->get();
+        $users = User::query()->whereIn('username', $matches[1])->where('id', '!=', $user->id)->get();
         Notification::send($users, new NewPostTag($post));
 
         return redirect()->to($realUrl)
@@ -184,8 +184,8 @@ class PostController extends Controller
     {
         $user = $request->user();
 
-        $post = Post::find($id);
-        $topic = Topic::whereKey($post->topic_id)->authorized(canReadTopic: true, canReplyTopic: true)->sole();
+        $post = Post::query()->find($id);
+        $topic = Topic::query()->whereKey($post->topic_id)->authorized(canReadTopic: true, canReplyTopic: true)->sole();
 
         abort_unless($user->group->is_modo || $user->id === $post->user_id, 403);
 
@@ -211,7 +211,7 @@ class PostController extends Controller
 
         $user = $request->user();
 
-        $post = Post::findOrFail($id);
+        $post = Post::query()->findOrFail($id);
         $postUrl = \sprintf('forums/topics/%s/posts/%s', $post->topic->id, $id);
 
         abort_unless($user->group->is_modo || $user->id === $post->user_id, 403);
@@ -234,11 +234,11 @@ class PostController extends Controller
     public function destroy(Request $request, int $id): \Illuminate\Http\RedirectResponse
     {
         $user = $request->user();
-        $post = Post::with('topic')->findOrFail($id);
+        $post = Post::query()->with('topic')->findOrFail($id);
 
         abort_unless($user->group->is_modo || $user->id === $post->user_id, 403);
 
-        $topic = Topic::whereKey($post->topic_id)->authorized(canReplyTopic: true)->sole();
+        $topic = Topic::query()->whereKey($post->topic_id)->authorized(canReplyTopic: true)->sole();
 
         $post->delete();
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -32,7 +32,7 @@ class ReportController extends Controller
      */
     public function request(Request $request, int $id): \Illuminate\Http\RedirectResponse
     {
-        $torrentRequest = TorrentRequest::findOrFail($id);
+        $torrentRequest = TorrentRequest::query()->findOrFail($id);
         $reportedBy = $request->user();
         $reportedUser = $torrentRequest->user;
 
@@ -43,7 +43,7 @@ class ReportController extends Controller
             ],
         ]);
 
-        Report::create([
+        Report::query()->create([
             'type'                => 'Request',
             'reported_request_id' => $torrentRequest->id,
             'reported_torrent_id' => null,
@@ -62,7 +62,7 @@ class ReportController extends Controller
      */
     public function torrent(Request $request, int $id): \Illuminate\Http\RedirectResponse
     {
-        $torrent = Torrent::findOrFail($id);
+        $torrent = Torrent::query()->findOrFail($id);
         $reportedBy = $request->user();
         $reportedUser = $torrent->user;
 
@@ -73,7 +73,7 @@ class ReportController extends Controller
             ],
         ]);
 
-        Report::create([
+        Report::query()->create([
             'type'                => 'Torrent',
             'reported_torrent_id' => $torrent->id,
             'reported_request_id' => null,
@@ -92,7 +92,7 @@ class ReportController extends Controller
      */
     public function user(Request $request, string $username): \Illuminate\Http\RedirectResponse
     {
-        $reportedUser = User::where('username', '=', $username)->sole();
+        $reportedUser = User::query()->where('username', '=', $username)->sole();
         $reportedBy = $request->user();
 
         $request->validate([
@@ -102,7 +102,7 @@ class ReportController extends Controller
             ],
         ]);
 
-        Report::create([
+        Report::query()->create([
             'type'                => 'User',
             'reported_torrent_id' => null,
             'reported_request_id' => null,

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -97,7 +97,7 @@ class RequestController extends Controller
     public function create(Request $request): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('requests.create', [
-            'categories' => Category::orderBy('position')
+            'categories' => Category::query()->orderBy('position')
                 ->get()
                 ->mapWithKeys(fn ($category) => [$category->id => [
                     'name' => $category->name,
@@ -111,10 +111,10 @@ class RequestController extends Controller
                     },
                 ]])
                 ->toArray(),
-            'types'       => Type::orderBy('position')->get(),
-            'resolutions' => Resolution::orderBy('position')->get(),
+            'types'       => Type::query()->orderBy('position')->get(),
+            'resolutions' => Resolution::query()->orderBy('position')->get(),
             'user'        => $request->user(),
-            'category_id' => $request->category_id ?? Category::first('id')->id,
+            'category_id' => $request->category_id ?? Category::query()->first('id')->id,
             'title'       => urldecode((string) $request->title),
             'imdb'        => $request->imdb,
             'movieId'     => $request->tmdb_movie_id,
@@ -134,9 +134,9 @@ class RequestController extends Controller
 
         $user->decrement('seedbonus', $request->bounty);
 
-        $torrentRequest = TorrentRequest::create(['user_id' => $request->user()->id] + $request->validated());
+        $torrentRequest = TorrentRequest::query()->create(['user_id' => $request->user()->id] + $request->validated());
 
-        TorrentRequestBounty::create([
+        TorrentRequestBounty::query()->create([
             'user_id'     => $user->id,
             'seedbonus'   => $request->bounty,
             'requests_id' => $torrentRequest->id,
@@ -187,8 +187,8 @@ class RequestController extends Controller
                         },
                     ]
                 ]),
-            'types'          => Type::orderBy('position')->get(),
-            'resolutions'    => Resolution::orderBy('position')->get(),
+            'types'          => Type::query()->orderBy('position')->get(),
+            'resolutions'    => Resolution::query()->orderBy('position')->get(),
             'user'           => $request->user(),
             'torrentRequest' => $torrentRequest,
         ]);

--- a/app/Http/Controllers/RequestFillController.php
+++ b/app/Http/Controllers/RequestFillController.php
@@ -34,7 +34,7 @@ class RequestFillController extends Controller
      */
     public function store(StoreRequestFillRequest $request, TorrentRequest $torrentRequest): \Illuminate\Http\RedirectResponse
     {
-        $torrent = Torrent::find(basename((string) $request->torrent_id));
+        $torrent = Torrent::query()->find(basename((string) $request->torrent_id));
 
         if ($torrent === null) {
             return to_route('requests.show', ['torrentRequest' => $torrentRequest])

--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -40,8 +40,8 @@ class RssController extends Controller
     {
         return view('rss.index', [
             'hash'        => $hash,
-            'public_rss'  => Rss::where('is_private', '=', false)->oldest('position')->get(),
-            'private_rss' => Rss::where('is_private', '=', true)->where('user_id', '=', $request->user()->id)->latest()->get(),
+            'public_rss'  => Rss::query()->where('is_private', '=', false)->oldest('position')->get(),
+            'private_rss' => Rss::query()->where('is_private', '=', true)->where('user_id', '=', $request->user()->id)->latest()->get(),
             'user'        => $request->user(),
         ]);
     }
@@ -52,10 +52,10 @@ class RssController extends Controller
     public function create(Request $request): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('rss.create', [
-            'categories'  => Category::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'types'       => Type::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'resolutions' => Resolution::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'genres'      => TmdbGenre::orderBy('name')->get(),
+            'categories'  => Category::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'types'       => Type::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'resolutions' => Resolution::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'genres'      => TmdbGenre::query()->orderBy('name')->get(),
             'user'        => $request->user(),
         ]);
     }
@@ -133,7 +133,7 @@ class RssController extends Controller
         $user = $request->user();
 
         // Redis returns ints as numeric strings!
-        $disabledGroupId = (int) cache()->rememberForever('group:disabled:id', fn () => Group::where('slug', '=', 'disabled')->soleValue('id'));
+        $disabledGroupId = (int) cache()->rememberForever('group:disabled:id', fn () => Group::query()->where('slug', '=', 'disabled')->soleValue('id'));
 
         abort_if($user->group_id === $disabledGroupId, 404);
 
@@ -211,15 +211,15 @@ class RssController extends Controller
     public function edit(Request $request, int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         $user = $request->user();
-        $rss = Rss::where('is_private', '=', true)->findOrFail($id);
+        $rss = Rss::query()->where('is_private', '=', true)->findOrFail($id);
 
         abort_unless($user->group->is_modo || $user->id === $rss->user_id, 403);
 
         return view('rss.edit', [
-            'categories'  => Category::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'types'       => Type::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'resolutions' => Resolution::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'genres'      => TmdbGenre::orderBy('name')->get(),
+            'categories'  => Category::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'types'       => Type::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'resolutions' => Resolution::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'genres'      => TmdbGenre::query()->orderBy('name')->get(),
             'user'        => $user,
             'rss'         => $rss,
         ]);
@@ -231,7 +231,7 @@ class RssController extends Controller
     public function update(Request $request, int $id): \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response
     {
         $user = $request->user();
-        $rss = Rss::where('is_private', '=', true)->findOrFail($id);
+        $rss = Rss::query()->where('is_private', '=', true)->findOrFail($id);
 
         abort_unless($user->group->is_modo || $user->id === $rss->user_id, 403);
 
@@ -297,7 +297,7 @@ class RssController extends Controller
     public function destroy(Request $request, int $id): \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response
     {
         $user = $request->user();
-        $rss = Rss::where('is_private', '=', true)->findOrFail($id);
+        $rss = Rss::query()->where('is_private', '=', true)->findOrFail($id);
 
         abort_unless($user->group->is_modo || $user->id === $rss->user_id, 403);
 

--- a/app/Http/Controllers/SimilarTorrentController.php
+++ b/app/Http/Controllers/SimilarTorrentController.php
@@ -41,12 +41,13 @@ class SimilarTorrentController extends Controller
 
                 abort_unless($hasTorrents, 404, 'No Similar Torrents Found');
 
-                $meta = TmdbMovie::with([
-                    'genres',
-                    'credits' => ['person', 'occupation'],
-                    'companies',
-                    'collections.movies',
-                ])
+                $meta = TmdbMovie::query()
+                    ->with([
+                        'genres',
+                        'credits' => ['person', 'occupation'],
+                        'companies',
+                        'collections.movies',
+                    ])
                     ->findOrFail($tmdbId);
                 $tmdb = $tmdbId;
 
@@ -56,12 +57,13 @@ class SimilarTorrentController extends Controller
 
                 abort_unless($hasTorrents, 404, 'No Similar Torrents Found');
 
-                $meta = TmdbTv::with([
-                    'genres',
-                    'credits' => ['person', 'occupation'],
-                    'companies',
-                    'networks'
-                ])
+                $meta = TmdbTv::query()
+                    ->with([
+                        'genres',
+                        'credits' => ['person', 'occupation'],
+                        'companies',
+                        'networks'
+                    ])
                     ->findOrFail($tmdbId);
                 $tmdb = $tmdbId;
 
@@ -71,11 +73,12 @@ class SimilarTorrentController extends Controller
 
                 abort_unless($hasTorrents, 404, 'No Similar Torrents Found');
 
-                $meta = IgdbGame::with([
-                    'genres',
-                    'companies',
-                    'platforms',
-                ])
+                $meta = IgdbGame::query()
+                    ->with([
+                        'genres',
+                        'companies',
+                        'platforms',
+                    ])
                     ->findOrFail($tmdbId);
 
                 $igdb = $tmdbId;
@@ -107,18 +110,18 @@ class SimilarTorrentController extends Controller
             $metaId === 0
             || (
                 $category->movie_meta
-                && Torrent::where('category_id', '=', $category->id)->where('tmdb_movie_id', '=', $metaId)->doesntExist()
-                && TorrentRequest::where('category_id', '=', $category->id)->where('tmdb_movie_id', '=', $metaId)->doesntExist()
+                && Torrent::query()->where('category_id', '=', $category->id)->where('tmdb_movie_id', '=', $metaId)->doesntExist()
+                && TorrentRequest::query()->where('category_id', '=', $category->id)->where('tmdb_movie_id', '=', $metaId)->doesntExist()
             )
             || (
                 $category->tv_meta
-                && Torrent::where('category_id', '=', $category->id)->where('tmdb_tv_id', '=', $metaId)->doesntExist()
-                && TorrentRequest::where('category_id', '=', $category->id)->where('tmdb_tv_id', '=', $metaId)->doesntExist()
+                && Torrent::query()->where('category_id', '=', $category->id)->where('tmdb_tv_id', '=', $metaId)->doesntExist()
+                && TorrentRequest::query()->where('category_id', '=', $category->id)->where('tmdb_tv_id', '=', $metaId)->doesntExist()
             )
             || (
                 $category->game_meta
-                && Torrent::where('category_id', '=', $category->id)->where('igdb', '=', $metaId)->doesntExist()
-                && TorrentRequest::where('category_id', '=', $category->id)->where('igdb', '=', $metaId)->doesntExist()
+                && Torrent::query()->where('category_id', '=', $category->id)->where('igdb', '=', $metaId)->doesntExist()
+                && TorrentRequest::query()->where('category_id', '=', $category->id)->where('igdb', '=', $metaId)->doesntExist()
             )
         ) {
             return to_route('torrents.similar', ['category_id' => $category->id, 'tmdb' => $metaId])

--- a/app/Http/Controllers/Staff/ApplicationController.php
+++ b/app/Http/Controllers/Staff/ApplicationController.php
@@ -48,7 +48,7 @@ class ApplicationController extends Controller
     public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.application.show', [
-            'application' => Application::withoutGlobalScope(ApprovedScope::class)->with(['user', 'moderated', 'imageProofs', 'urlProofs'])->findOrFail($id)
+            'application' => Application::query()->withoutGlobalScope(ApprovedScope::class)->with(['user', 'moderated', 'imageProofs', 'urlProofs'])->findOrFail($id)
         ]);
     }
 
@@ -59,14 +59,14 @@ class ApplicationController extends Controller
      */
     public function approve(ApproveApplicationRequest $request, int $id): \Illuminate\Http\RedirectResponse
     {
-        $application = Application::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $application = Application::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         $application->status = ModerationStatus::APPROVED;
         $application->moderated_at = now();
         $application->moderated_by = $request->user()->id;
         $application->save();
 
-        $invite = Invite::create([
+        $invite = Invite::query()->create([
             'user_id'    => $request->user()->id,
             'email'      => $application->email,
             'code'       => Uuid::uuid4()->toString(),
@@ -85,7 +85,7 @@ class ApplicationController extends Controller
      */
     public function reject(RejectApplicationRequest $request, int $id): \Illuminate\Http\RedirectResponse
     {
-        $application = Application::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $application = Application::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $application->update([
             'status'       => ModerationStatus::REJECTED,
             'moderated_at' => now(),

--- a/app/Http/Controllers/Staff/ArticleController.php
+++ b/app/Http/Controllers/Staff/ArticleController.php
@@ -37,7 +37,8 @@ class ArticleController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.article.index', [
-            'articles' => Article::latest()
+            'articles' => Article::query()
+                ->latest()
                 ->with('user:id,username')
                 ->withCount('comments')
                 ->paginate(25),
@@ -67,7 +68,7 @@ class ArticleController extends Controller
             Image::make($image->getRealPath())->fit(75, 75)->encode('png', 100)->save($path);
         }
 
-        $article = Article::create(['user_id' => $request->user()->id, 'image' => $filename ?? null] + $request->validated());
+        $article = Article::query()->create(['user_id' => $request->user()->id, 'image' => $filename ?? null] + $request->validated());
 
         UnreadArticle::query()->insertUsing(
             ['article_id', 'user_id'],

--- a/app/Http/Controllers/Staff/AutomaticTorrentFreeleechController.php
+++ b/app/Http/Controllers/Staff/AutomaticTorrentFreeleechController.php
@@ -29,22 +29,22 @@ class AutomaticTorrentFreeleechController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.automatic-torrent-freeleech.index', [
-            'automaticTorrentFreeleeches' => AutomaticTorrentFreeleech::orderby('position')->get(),
+            'automaticTorrentFreeleeches' => AutomaticTorrentFreeleech::query()->orderby('position')->get(),
         ]);
     }
 
     public function create(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.automatic-torrent-freeleech.create', [
-            'categories'  => Category::orderBy('position')->get(),
-            'resolutions' => Resolution::orderBy('position')->get(),
-            'types'       => Type::orderBy('position')->get(),
+            'categories'  => Category::query()->orderBy('position')->get(),
+            'resolutions' => Resolution::query()->orderBy('position')->get(),
+            'types'       => Type::query()->orderBy('position')->get(),
         ]);
     }
 
     public function store(StoreAutomaticTorrentFreeleechRequest $request): \Illuminate\Http\RedirectResponse
     {
-        AutomaticTorrentFreeleech::create($request->validated());
+        AutomaticTorrentFreeleech::query()->create($request->validated());
 
         return to_route('staff.automatic_torrent_freeleeches.index')
             ->with('success', 'Resolution successfully added');
@@ -54,9 +54,9 @@ class AutomaticTorrentFreeleechController extends Controller
     {
         return view('Staff.automatic-torrent-freeleech.edit', [
             'automaticTorrentFreeleech' => $automaticTorrentFreeleech,
-            'categories'                => Category::orderBy('position')->get(),
-            'resolutions'               => Resolution::orderBy('position')->get(),
-            'types'                     => Type::orderBy('position')->get(),
+            'categories'                => Category::query()->orderBy('position')->get(),
+            'resolutions'               => Resolution::query()->orderBy('position')->get(),
+            'types'                     => Type::query()->orderBy('position')->get(),
         ]);
     }
 

--- a/app/Http/Controllers/Staff/BanController.php
+++ b/app/Http/Controllers/Staff/BanController.php
@@ -36,7 +36,7 @@ class BanController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.ban.index', [
-            'bans' => Ban::latest()->with('user.group', 'staff.group')->paginate(25),
+            'bans' => Ban::query()->latest()->with('user.group', 'staff.group')->paginate(25),
         ]);
     }
 
@@ -47,17 +47,17 @@ class BanController extends Controller
      */
     public function store(StoreBanRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $user = User::findOrFail($request->string('owned_by'));
+        $user = User::query()->findOrFail($request->string('owned_by'));
         $staff = $request->user();
 
         abort_if($user->group->is_modo || $staff->is($user), 403);
 
         $user->update([
-            'group_id'     => Group::where('slug', '=', 'banned')->soleValue('id'),
+            'group_id'     => Group::query()->where('slug', '=', 'banned')->soleValue('id'),
             'can_download' => 0,
         ]);
 
-        $ban = Ban::create(['created_by' => $staff->id] + $request->validated());
+        $ban = Ban::query()->create(['created_by' => $staff->id] + $request->validated());
 
         cache()->forget('user:'.$user->passkey);
 

--- a/app/Http/Controllers/Staff/BlacklistClientController.php
+++ b/app/Http/Controllers/Staff/BlacklistClientController.php
@@ -33,7 +33,7 @@ class BlacklistClientController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.blacklist.clients.index', [
-            'clients' => BlacklistClient::latest()->get(),
+            'clients' => BlacklistClient::query()->latest()->get(),
         ]);
     }
 
@@ -80,7 +80,7 @@ class BlacklistClientController extends Controller
      */
     public function store(StoreBlacklistClientRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $client = BlacklistClient::create([
+        $client = BlacklistClient::query()->create([
             // Overriding is necessary to cast empty strings (converted to null by middleware) back into strings
             'peer_id_prefix' => $request->string('peer_id_prefix'),
         ] + $request->validated());

--- a/app/Http/Controllers/Staff/BonEarningController.php
+++ b/app/Http/Controllers/Staff/BonEarningController.php
@@ -31,7 +31,7 @@ class BonEarningController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.bon-earning.index', [
-            'bonEarnings' => BonEarning::with('conditions')->orderBy('position')->get(),
+            'bonEarnings' => BonEarning::query()->with('conditions')->orderBy('position')->get(),
         ]);
     }
 
@@ -48,7 +48,7 @@ class BonEarningController extends Controller
      */
     public function store(StoreBonEarningRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $bonEarning = BonEarning::create($request->validated('bon_earning'));
+        $bonEarning = BonEarning::query()->create($request->validated('bon_earning'));
 
         $bonEarning->conditions()->upsert($request->validated('conditions', []), ['id']);
 

--- a/app/Http/Controllers/Staff/BonExchangeController.php
+++ b/app/Http/Controllers/Staff/BonExchangeController.php
@@ -47,7 +47,7 @@ class BonExchangeController extends Controller
      */
     public function store(StoreBonExchangeRequest $request): \Illuminate\Http\RedirectResponse
     {
-        BonExchange::create([
+        BonExchange::query()->create([
             'upload'             => $request->type === 'upload',
             'download'           => $request->type === 'download',
             'personal_freeleech' => $request->type === 'personal_freeleech',
@@ -65,7 +65,7 @@ class BonExchangeController extends Controller
     public function edit(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.bon-exchange.edit', [
-            'bonExchange' => BonExchange::findOrFail($id),
+            'bonExchange' => BonExchange::query()->findOrFail($id),
         ]);
     }
 
@@ -74,7 +74,7 @@ class BonExchangeController extends Controller
      */
     public function update(UpdateBonExchangeRequest $request, int $id): \Illuminate\Http\RedirectResponse
     {
-        BonExchange::findOrFail($id)->update([
+        BonExchange::query()->findOrFail($id)->update([
             'upload'             => $request->type === 'upload',
             'download'           => $request->type === 'download',
             'personal_freeleech' => $request->type === 'personal_freeleech',
@@ -93,7 +93,7 @@ class BonExchangeController extends Controller
      */
     public function destroy(int $id): \Illuminate\Http\RedirectResponse
     {
-        BonExchange::findOrFail($id)->delete();
+        BonExchange::query()->findOrFail($id)->delete();
 
         return to_route('staff.bon_exchanges.index')
             ->with('success', 'Bon exchange successfully deleted');

--- a/app/Http/Controllers/Staff/CategoryController.php
+++ b/app/Http/Controllers/Staff/CategoryController.php
@@ -35,7 +35,7 @@ class CategoryController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.category.index', [
-            'categories' => Category::orderBy('position')->get(),
+            'categories' => Category::query()->orderBy('position')->get(),
         ]);
     }
 
@@ -62,7 +62,7 @@ class CategoryController extends Controller
             Image::make($image->getRealPath())->fit(50, 50)->encode('png', 100)->save($path);
         }
 
-        Category::create([
+        Category::query()->create([
             'image'      => $filename ?? null,
             'no_meta'    => $request->meta === 'no',
             'music_meta' => $request->meta === 'music',

--- a/app/Http/Controllers/Staff/ChatBotController.php
+++ b/app/Http/Controllers/Staff/ChatBotController.php
@@ -33,7 +33,7 @@ class ChatBotController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
         return view('Staff.chat.bot.index', [
-            'bots' => Bot::oldest('position')->get(),
+            'bots' => Bot::query()->oldest('position')->get(),
         ]);
     }
 

--- a/app/Http/Controllers/Staff/ChatRoomController.php
+++ b/app/Http/Controllers/Staff/ChatRoomController.php
@@ -51,7 +51,7 @@ class ChatRoomController extends Controller
      */
     public function store(StoreChatRoomRequest $request): \Illuminate\Http\RedirectResponse
     {
-        Chatroom::create($request->validated());
+        Chatroom::query()->create($request->validated());
 
         return to_route('staff.chatrooms.index')
             ->with('success', 'Chatroom successfully added');
@@ -93,7 +93,7 @@ class ChatRoomController extends Controller
             )
             ->soleValue('id');
 
-        User::whereBelongsTo($chatroom)->update(['chatroom_id' => $default]);
+        User::query()->whereBelongsTo($chatroom)->update(['chatroom_id' => $default]);
 
         $chatroom->delete();
 

--- a/app/Http/Controllers/Staff/ChatStatusController.php
+++ b/app/Http/Controllers/Staff/ChatStatusController.php
@@ -50,7 +50,7 @@ class ChatStatusController extends Controller
      */
     public function store(StoreChatStatusRequest $request): \Illuminate\Http\RedirectResponse
     {
-        ChatStatus::create($request->validated());
+        ChatStatus::query()->create($request->validated());
 
         return to_route('staff.statuses.index')
             ->with('success', 'Chat status successfully added');

--- a/app/Http/Controllers/Staff/DistributorController.php
+++ b/app/Http/Controllers/Staff/DistributorController.php
@@ -31,7 +31,7 @@ class DistributorController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.distributor.index', [
-            'distributors' => Distributor::orderBy('name')->get(),
+            'distributors' => Distributor::query()->orderBy('name')->get(),
         ]);
     }
 
@@ -48,7 +48,7 @@ class DistributorController extends Controller
      */
     public function store(StoreDistributorRequest $request): \Illuminate\Http\RedirectResponse
     {
-        Distributor::create($request->validated());
+        Distributor::query()->create($request->validated());
 
         return to_route('staff.distributors.index')
             ->with('success', 'Distributor successfully added');
@@ -81,7 +81,7 @@ class DistributorController extends Controller
     public function delete(Distributor $distributor): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.distributor.delete', [
-            'distributors' => Distributor::orderBy('name')->get(),
+            'distributors' => Distributor::query()->orderBy('name')->get(),
             'distributor'  => $distributor,
         ]);
     }

--- a/app/Http/Controllers/Staff/DonationController.php
+++ b/app/Http/Controllers/Staff/DonationController.php
@@ -34,18 +34,20 @@ class DonationController extends Controller
     {
         abort_unless($request->user()->group->is_owner, 403);
 
-        $donations = Donation::with(['package' => function ($query): void {
+        $donations = Donation::query()->with(['package' => function ($query): void {
             $query->withTrashed();
         }])->latest()->paginate(25);
 
-        $dailyDonations = Donation::selectRaw('DATE(donations.created_at) as date, SUM(donation_packages.cost) as total')
+        $dailyDonations = Donation::query()
+            ->selectRaw('DATE(donations.created_at) as date, SUM(donation_packages.cost) as total')
             ->join('donation_packages', 'donations.package_id', '=', 'donation_packages.id')
             ->where('donations.status', '=', ModerationStatus::APPROVED)
             ->groupBy('date')
             ->orderBy('date')
             ->get();
 
-        $monthlyDonations = Donation::selectRaw('EXTRACT(YEAR FROM donations.created_at) as year, EXTRACT(MONTH FROM donations.created_at) as month, SUM(donation_packages.cost) as total')
+        $monthlyDonations = Donation::query()
+            ->selectRaw('EXTRACT(YEAR FROM donations.created_at) as year, EXTRACT(MONTH FROM donations.created_at) as month, SUM(donation_packages.cost) as total')
             ->join('donation_packages', 'donations.package_id', '=', 'donation_packages.id')
             ->where('donations.status', '=', ModerationStatus::APPROVED)
             ->groupBy('year', 'month')
@@ -69,7 +71,7 @@ class DonationController extends Controller
 
         $now = now();
 
-        $donation = Donation::with(['user', 'package'])->findOrFail($id);
+        $donation = Donation::query()->with(['user', 'package'])->findOrFail($id);
         $donation->status = ModerationStatus::APPROVED;
         $donation->starts_at = $now;
 
@@ -86,10 +88,10 @@ class DonationController extends Controller
         $donation->user->seedbonus += $donation->package->bonus_value ?? 0;
         $donation->user->save();
 
-        $conversation = Conversation::create(['subject' => 'Your donation from '.$donation->created_at.', has been approved by '.$request->user()->username]);
+        $conversation = Conversation::query()->create(['subject' => 'Your donation from '.$donation->created_at.', has been approved by '.$request->user()->username]);
         $conversation->users()->sync([$request->user()->id => ['read' => true], $donation->user_id]);
 
-        PrivateMessage::create([
+        PrivateMessage::query()->create([
             'conversation_id' => $conversation->id,
             'sender_id'       => $request->user()->id,
             'message'         => '[b]Thank you for supporting '.config('app.name').'[/b]'."\n"
@@ -113,13 +115,13 @@ class DonationController extends Controller
     {
         abort_unless($request->user()->group->is_owner, 403);
 
-        $donation = Donation::findOrFail($id);
+        $donation = Donation::query()->findOrFail($id);
         $donation->status = ModerationStatus::REJECTED;
 
-        $conversation = Conversation::create(['subject' => 'Your donation from '.$donation->created_at.', has been rejected by '.$request->user()->username]);
+        $conversation = Conversation::query()->create(['subject' => 'Your donation from '.$donation->created_at.', has been rejected by '.$request->user()->username]);
         $conversation->users()->sync([$request->user()->id => ['read' => true], $donation->user_id]);
 
-        PrivateMessage::create([
+        PrivateMessage::query()->create([
             'conversation_id' => $conversation->id,
             'sender_id'       => $request->user()->id,
             'message'         => 'Your donation could not be approved at this time. Please contact us for more information by replying to this private message.',

--- a/app/Http/Controllers/Staff/DonationGatewayController.php
+++ b/app/Http/Controllers/Staff/DonationGatewayController.php
@@ -31,7 +31,7 @@ class DonationGatewayController extends Controller
     {
         abort_unless($request->user()->group->is_owner, 403);
 
-        return view('Staff.donation-gateway.index', ['gateways' => DonationGateway::orderBy('position')->paginate(25)]);
+        return view('Staff.donation-gateway.index', ['gateways' => DonationGateway::query()->orderBy('position')->paginate(25)]);
     }
 
     /**
@@ -51,7 +51,7 @@ class DonationGatewayController extends Controller
     {
         abort_unless($request->user()->group->is_owner, 403);
 
-        DonationGateway::create($request->validated());
+        DonationGateway::query()->create($request->validated());
 
         return redirect()->route('staff.gateways.index')
             ->with('success', 'Donation gateway added successfully!');

--- a/app/Http/Controllers/Staff/DonationPackageController.php
+++ b/app/Http/Controllers/Staff/DonationPackageController.php
@@ -29,7 +29,7 @@ class DonationPackageController extends Controller
      */
     public function index(): \Illuminate\Contracts\View\View|\Illuminate\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\Foundation\Application
     {
-        return view('Staff.donation-package.index', ['packages' => DonationPackage::orderBy('position')->paginate(25)]);
+        return view('Staff.donation-package.index', ['packages' => DonationPackage::query()->orderBy('position')->paginate(25)]);
     }
 
     /**
@@ -45,7 +45,7 @@ class DonationPackageController extends Controller
      */
     public function store(StoreDonationPackageRequest $request): \Illuminate\Http\RedirectResponse
     {
-        DonationPackage::create($request->validated());
+        DonationPackage::query()->create($request->validated());
 
         return redirect()->route('staff.packages.index')
             ->with('success', 'Donation package added successfully!');

--- a/app/Http/Controllers/Staff/FlushController.php
+++ b/app/Http/Controllers/Staff/FlushController.php
@@ -50,7 +50,7 @@ class FlushController extends Controller
         }
 
         $carbon = new Carbon();
-        $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2))->get();
+        $peers = Peer::query()->select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2))->get();
 
         foreach ($peers as $peer) {
             History::query()

--- a/app/Http/Controllers/Staff/ForumCategoryController.php
+++ b/app/Http/Controllers/Staff/ForumCategoryController.php
@@ -40,7 +40,7 @@ class ForumCategoryController extends Controller
 
     public function store(StoreForumCategoryRequest $request): \Illuminate\Http\RedirectResponse
     {
-        ForumCategory::create($request->validated());
+        ForumCategory::query()->create($request->validated());
 
         return to_route('staff.forum_categories.index')
             ->with('success', 'Forum has been created successfully');

--- a/app/Http/Controllers/Staff/ForumController.php
+++ b/app/Http/Controllers/Staff/ForumController.php
@@ -37,8 +37,8 @@ class ForumController extends Controller
     {
         return view('Staff.forum.create', [
             'forumCategoryId' => $request->integer('forumCategoryId'),
-            'categories'      => ForumCategory::orderBy('position')->get(),
-            'groups'          => Group::orderBy('position')->get(),
+            'categories'      => ForumCategory::query()->orderBy('position')->get(),
+            'groups'          => Group::query()->orderBy('position')->get(),
         ]);
     }
 
@@ -47,7 +47,7 @@ class ForumController extends Controller
      */
     public function store(StoreForumRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $forum = Forum::create($request->validated('forum'));
+        $forum = Forum::query()->create($request->validated('forum'));
 
         $forum->permissions()->upsert($request->validated('permissions'), ['forum_id', 'group_id']);
 
@@ -61,8 +61,8 @@ class ForumController extends Controller
     public function edit(Forum $forum): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.forum.edit', [
-            'categories' => ForumCategory::orderBy('position')->get(),
-            'groups'     => Group::orderBy('position')->get(),
+            'categories' => ForumCategory::query()->orderBy('position')->get(),
+            'groups'     => Group::query()->orderBy('position')->get(),
             'forum'      => $forum->load(['permissions', 'category']),
         ]);
     }

--- a/app/Http/Controllers/Staff/GroupController.php
+++ b/app/Http/Controllers/Staff/GroupController.php
@@ -36,7 +36,7 @@ class GroupController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.group.index', [
-            'groups' => Group::orderBy('position')->get(),
+            'groups' => Group::query()->orderBy('position')->get(),
         ]);
     }
 
@@ -60,7 +60,7 @@ class GroupController extends Controller
      */
     public function store(StoreGroupRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $group = Group::create(['slug' => Str::slug($request->validated('group.name'))] + $request->validated('group'));
+        $group = Group::query()->create(['slug' => Str::slug($request->validated('group.name'))] + $request->validated('group'));
 
         $group->permissions()->upsert($request->validated('permissions'), ['forum_id', 'group_id']);
 

--- a/app/Http/Controllers/Staff/HomeController.php
+++ b/app/Http/Controllers/Staff/HomeController.php
@@ -51,8 +51,8 @@ class HomeController extends Controller
         return view('Staff.dashboard.index', [
             'users' => cache()->flexible('dashboard_users', [60 * 5, 60 * 10], fn () => DB::table('users')
                 ->selectRaw('COUNT(*) AS total')
-                ->selectRaw('SUM(group_id = ?) AS banned', [Group::where('slug', '=', 'banned')->soleValue('id')])
-                ->selectRaw('SUM(group_id = ?) AS validating', [Group::where('slug', '=', 'validating')->soleValue('id')])
+                ->selectRaw('SUM(group_id = ?) AS banned', [Group::query()->where('slug', '=', 'banned')->soleValue('id')])
+                ->selectRaw('SUM(group_id = ?) AS validating', [Group::query()->where('slug', '=', 'validating')->soleValue('id')])
                 ->first()),
             'torrents' => cache()->flexible('dashboard_torrents', [60 * 5, 60 * 10], fn () => DB::table('torrents')
                 ->whereNull('deleted_at')

--- a/app/Http/Controllers/Staff/InternalController.php
+++ b/app/Http/Controllers/Staff/InternalController.php
@@ -33,8 +33,8 @@ class InternalController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.internals.index', [
-            'internalGroups' => Internal::orderBy('name')->get(),
-            'internalUsers'  => User::with(['group', 'internals'])
+            'internalGroups' => Internal::query()->orderBy('name')->get(),
+            'internalUsers'  => User::query()->with(['group', 'internals'])
                 ->withCount('torrents as total_uploads')
                 ->whereRelation('group', 'is_internal', '=', true)
                 ->orWhereHas('internals')
@@ -100,7 +100,7 @@ class InternalController extends Controller
      */
     public function store(StoreInternalRequest $request): \Illuminate\Http\RedirectResponse
     {
-        Internal::create($request->validated());
+        Internal::query()->create($request->validated());
 
         return to_route('staff.internals.index')
             ->with('success', 'New internal group added!');

--- a/app/Http/Controllers/Staff/InternalUserController.php
+++ b/app/Http/Controllers/Staff/InternalUserController.php
@@ -26,8 +26,8 @@ class InternalUserController extends Controller
 {
     public function store(StoreInternalUserRequest $request): \Illuminate\Http\RedirectResponse
     {
-        InternalUser::create([
-            'user_id'     => User::where('username', '=', $request->string('username'))->value('id'),
+        InternalUser::query()->create([
+            'user_id'     => User::query()->where('username', '=', $request->string('username'))->value('id'),
             'internal_id' => $request->integer('internal_id'),
             'position'    => $request->integer('position'),
         ]);

--- a/app/Http/Controllers/Staff/MassActionController.php
+++ b/app/Http/Controllers/Staff/MassActionController.php
@@ -34,10 +34,10 @@ class MassActionController extends Controller
      */
     public function update(): \Illuminate\Http\RedirectResponse
     {
-        $validatingGroupId = Group::where('slug', '=', 'validating')->soleValue('id');
-        $memberGroupId = Group::where('slug', '=', 'user')->soleValue('id');
+        $validatingGroupId = Group::query()->where('slug', '=', 'validating')->soleValue('id');
+        $memberGroupId = Group::query()->where('slug', '=', 'user')->soleValue('id');
 
-        foreach (User::where('group_id', '=', $validatingGroupId)->get() as $user) {
+        foreach (User::query()->where('group_id', '=', $validatingGroupId)->get() as $user) {
             $user->update([
                 'group_id'          => $memberGroupId,
                 'can_download'      => 1,

--- a/app/Http/Controllers/Staff/MassEmailController.php
+++ b/app/Http/Controllers/Staff/MassEmailController.php
@@ -26,14 +26,14 @@ class MassEmailController extends Controller
 {
     public function create(): \Illuminate\Contracts\View\View|\Illuminate\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\Foundation\Application
     {
-        return view('Staff.mass-email.create', ['groups' => Group::orderBy('position')->get()]);
+        return view('Staff.mass-email.create', ['groups' => Group::query()->orderBy('position')->get()]);
     }
 
     public function store(MassEmailRequest $request): \Illuminate\Http\RedirectResponse
     {
         $request->validated();
 
-        $users = User::whereIntegerInRaw('group_id', $request->groups)->get();
+        $users = User::query()->whereIntegerInRaw('group_id', $request->groups)->get();
 
         foreach ($users as $user) {
             dispatch(new SendMassEmail($user, $request->subject, $request->message));

--- a/app/Http/Controllers/Staff/MassPrivateMessageController.php
+++ b/app/Http/Controllers/Staff/MassPrivateMessageController.php
@@ -27,7 +27,7 @@ class MassPrivateMessageController extends Controller
     public function create(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.mass-private-message.create', [
-            'groups' => Group::orderBy('position')->get()
+            'groups' => Group::query()->orderBy('position')->get()
         ]);
     }
 
@@ -35,7 +35,7 @@ class MassPrivateMessageController extends Controller
     {
         $request->validated();
 
-        $userIds = User::whereIntegerInRaw('group_id', $request->group_ids)->pluck('id');
+        $userIds = User::query()->whereIntegerInRaw('group_id', $request->group_ids)->pluck('id');
 
         foreach ($userIds as $userId) {
             dispatch(new ProcessMassPM(User::SYSTEM_USER_ID, $userId, $request->subject, $request->message));

--- a/app/Http/Controllers/Staff/MediaLanguageController.php
+++ b/app/Http/Controllers/Staff/MediaLanguageController.php
@@ -30,7 +30,7 @@ class MediaLanguageController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.media-language.index', [
-            'media_languages' => MediaLanguage::orderBy('name')->get(),
+            'media_languages' => MediaLanguage::query()->orderBy('name')->get(),
         ]);
     }
 
@@ -47,7 +47,7 @@ class MediaLanguageController extends Controller
      */
     public function store(StoreMediaLanguageRequest $request): \Illuminate\Http\RedirectResponse
     {
-        MediaLanguage::create($request->validated());
+        MediaLanguage::query()->create($request->validated());
 
         return to_route('staff.media_languages.index')
             ->with('success', 'Media language successfully added');

--- a/app/Http/Controllers/Staff/ModerationController.php
+++ b/app/Http/Controllers/Staff/ModerationController.php
@@ -48,15 +48,15 @@ class ModerationController extends Controller
 
         return view('Staff.moderation.index', [
             'current' => now(),
-            'pending' => Torrent::withoutGlobalScope(ApprovedScope::class)
+            'pending' => Torrent::query()->withoutGlobalScope(ApprovedScope::class)
                 ->with(['user.group', 'category', 'type', 'resolution'])
                 ->where('status', '=', ModerationStatus::PENDING)
                 ->get(),
-            'postponed' => Torrent::withoutGlobalScope(ApprovedScope::class)
+            'postponed' => Torrent::query()->withoutGlobalScope(ApprovedScope::class)
                 ->with(['user.group', 'moderated.group', 'category', 'type', 'resolution'])
                 ->where('status', '=', ModerationStatus::POSTPONED)
                 ->get(),
-            'rejected' => Torrent::withoutGlobalScope(ApprovedScope::class)
+            'rejected' => Torrent::query()->withoutGlobalScope(ApprovedScope::class)
                 ->with(['user.group', 'moderated.group', 'category', 'type', 'resolution'])
                 ->where('status', '=', ModerationStatus::REJECTED)
                 ->get(),
@@ -70,7 +70,7 @@ class ModerationController extends Controller
     {
         abort_unless(auth()->user()->group->is_torrent_modo, 403);
 
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->with('user')->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->with('user')->findOrFail($id);
 
         if (ModerationStatus::from($request->integer('old_status')) !== $torrent->status) {
             return to_route('torrents.show', ['id' => $id])
@@ -118,11 +118,11 @@ class ModerationController extends Controller
                     'moderated_by' => $staff->id,
                 ]);
 
-                $conversation = Conversation::create(['subject' => 'Your upload, '.$torrent->name.', has been rejected by '.$staff->username]);
+                $conversation = Conversation::query()->create(['subject' => 'Your upload, '.$torrent->name.', has been rejected by '.$staff->username]);
 
                 $conversation->users()->sync([$staff->id => ['read' => true], $torrent->user_id]);
 
-                PrivateMessage::create([
+                PrivateMessage::query()->create([
                     'conversation_id' => $conversation->id,
                     'sender_id'       => $staff->id,
                     'message'         => "Greetings, \n\nYour upload, [url=/torrents/".$id.']'.$torrent->name."[/url], has been rejected. Please see below the message from the staff member.\n\n[quote=".$staff->username.']'.$request->message.'[/quote]',
@@ -142,11 +142,11 @@ class ModerationController extends Controller
                     'moderated_by' => $staff->id,
                 ]);
 
-                $conversation = Conversation::create(['subject' => 'Your upload, '.$torrent->name.', has been postponed by '.$staff->username]);
+                $conversation = Conversation::query()->create(['subject' => 'Your upload, '.$torrent->name.', has been postponed by '.$staff->username]);
 
                 $conversation->users()->sync([$staff->id => ['read' => true], $torrent->user_id]);
 
-                PrivateMessage::create([
+                PrivateMessage::query()->create([
                     'conversation_id' => $conversation->id,
                     'sender_id'       => $staff->id,
                     'message'         => "Greetings, \n\nYour upload, [url=/torrents/".$id.']'.$torrent->name."[/url], has been postponed. Please see below the message from the staff member.\n\n[quote=".$staff->username.']'.$request->message.'[/quote]',

--- a/app/Http/Controllers/Staff/PageController.php
+++ b/app/Http/Controllers/Staff/PageController.php
@@ -50,7 +50,7 @@ class PageController extends Controller
      */
     public function store(StorePageRequest $request): \Illuminate\Http\RedirectResponse
     {
-        Page::create($request->validated());
+        Page::query()->create($request->validated());
 
         return to_route('staff.pages.index')
             ->with('success', 'Page has been created successfully');

--- a/app/Http/Controllers/Staff/PlaylistCategoryController.php
+++ b/app/Http/Controllers/Staff/PlaylistCategoryController.php
@@ -48,7 +48,7 @@ class PlaylistCategoryController extends Controller
      */
     public function store(StorePlaylistCategoryRequest $request): \Illuminate\Http\RedirectResponse
     {
-        PlaylistCategory::create($request->validated());
+        PlaylistCategory::query()->create($request->validated());
 
         return to_route('staff.playlist_categories.index');
     }

--- a/app/Http/Controllers/Staff/PollController.php
+++ b/app/Http/Controllers/Staff/PollController.php
@@ -42,7 +42,7 @@ class PollController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.poll.index', [
-            'polls' => Poll::latest()->paginate(25),
+            'polls' => Poll::query()->latest()->paginate(25),
         ]);
     }
 
@@ -69,7 +69,7 @@ class PollController extends Controller
      */
     public function store(StorePoll $request): \Illuminate\Http\RedirectResponse
     {
-        $poll = Poll::create(['user_id' => $request->user()->id] + $request->safe()->only(['title', 'expires_at', 'multiple_choice']));
+        $poll = Poll::query()->create(['user_id' => $request->user()->id] + $request->safe()->only(['title', 'expires_at', 'multiple_choice']));
 
         $poll->options()->upsert($request->validated('options'), ['id'], []);
 

--- a/app/Http/Controllers/Staff/RegionController.php
+++ b/app/Http/Controllers/Staff/RegionController.php
@@ -31,7 +31,7 @@ class RegionController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.region.index', [
-            'regions' => Region::orderBy('position')->get(),
+            'regions' => Region::query()->orderBy('position')->get(),
         ]);
     }
 
@@ -48,7 +48,7 @@ class RegionController extends Controller
      */
     public function store(StoreRegionRequest $request): \Illuminate\Http\RedirectResponse
     {
-        Region::create($request->validated());
+        Region::query()->create($request->validated());
 
         return to_route('staff.regions.index')
             ->with('success', 'Region successfully added');

--- a/app/Http/Controllers/Staff/ReportAssigneeController.php
+++ b/app/Http/Controllers/Staff/ReportAssigneeController.php
@@ -29,7 +29,7 @@ class ReportAssigneeController extends Controller
     {
         $report->update($request->validated());
 
-        $assignedStaff = User::findOrFail($request->integer('assigned_to'));
+        $assignedStaff = User::query()->findOrFail($request->integer('assigned_to'));
 
         $assignedStaff->notify(new NewReportAssigned($report));
 

--- a/app/Http/Controllers/Staff/ReportController.php
+++ b/app/Http/Controllers/Staff/ReportController.php
@@ -48,7 +48,7 @@ class ReportController extends Controller
         return view('Staff.report.show', [
             'report' => $report,
             'urls'   => $match[0],
-            'staff'  => User::whereIn('group_id', Group::where('is_modo', '=', 1)->whereNot('slug', '=', 'bot')->select('id'))->get(),
+            'staff'  => User::query()->whereIn('group_id', Group::query()->where('is_modo', '=', 1)->whereNot('slug', '=', 'bot')->select('id'))->get(),
         ]);
     }
 
@@ -69,11 +69,11 @@ class ReportController extends Controller
             'solved_at' => now(),
         ] + $request->validated());
 
-        $conversation = Conversation::create(['subject' => 'Your Report Has A New Verdict']);
+        $conversation = Conversation::query()->create(['subject' => 'Your Report Has A New Verdict']);
 
         $conversation->users()->sync([$staff->id => ['read' => true], $report->reporter_id]);
 
-        PrivateMessage::create([
+        PrivateMessage::query()->create([
             'conversation_id' => $conversation->id,
             'sender_id'       => $staff->id,
             'message'         => '[b]REPORT TITLE:[/b] '.$report->title."\n\n[b]ORIGINAL MESSAGE:[/b] ".$report->message."\n\n[b]VERDICT:[/b] ".$report->verdict,

--- a/app/Http/Controllers/Staff/ResolutionController.php
+++ b/app/Http/Controllers/Staff/ResolutionController.php
@@ -30,7 +30,7 @@ class ResolutionController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.resolution.index', [
-            'resolutions' => Resolution::orderBy('position')->get(),
+            'resolutions' => Resolution::query()->orderBy('position')->get(),
         ]);
     }
 
@@ -47,7 +47,7 @@ class ResolutionController extends Controller
      */
     public function store(StoreResolutionRequest $request): \Illuminate\Http\RedirectResponse
     {
-        Resolution::create($request->validated());
+        Resolution::query()->create($request->validated());
 
         return to_route('staff.resolutions.index')
             ->with('success', 'Resolution successfully added');

--- a/app/Http/Controllers/Staff/RssController.php
+++ b/app/Http/Controllers/Staff/RssController.php
@@ -38,7 +38,7 @@ class RssController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
         return view('Staff.rss.index', [
-            'public_rss' => Rss::where('is_private', '=', false)->oldest('position')->get(),
+            'public_rss' => Rss::query()->where('is_private', '=', false)->oldest('position')->get(),
         ]);
     }
 
@@ -48,10 +48,10 @@ class RssController extends Controller
     public function create(Request $request): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.rss.create', [
-            'categories'  => Category::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'types'       => Type::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'resolutions' => Resolution::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'genres'      => TmdbGenre::orderBy('name')->get(),
+            'categories'  => Category::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'types'       => Type::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'resolutions' => Resolution::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'genres'      => TmdbGenre::query()->orderBy('name')->get(),
             'user'        => $request->user(),
         ]);
     }
@@ -81,10 +81,10 @@ class RssController extends Controller
         abort_if($rss->is_private, 403);
 
         return view('Staff.rss.edit', [
-            'categories'  => Category::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'types'       => Type::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'resolutions' => Resolution::select(['id', 'name', 'position'])->orderBy('position')->get(),
-            'genres'      => TmdbGenre::orderBy('name')->get(),
+            'categories'  => Category::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'types'       => Type::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'resolutions' => Resolution::query()->select(['id', 'name', 'position'])->orderBy('position')->get(),
+            'genres'      => TmdbGenre::query()->orderBy('name')->get(),
             'user'        => $request->user(),
             'rss'         => $rss,
         ]);

--- a/app/Http/Controllers/Staff/SeedboxController.php
+++ b/app/Http/Controllers/Staff/SeedboxController.php
@@ -31,7 +31,7 @@ class SeedboxController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.seedbox.index', [
-            'seedboxes' => Seedbox::with('user.group')->latest()->paginate(50),
+            'seedboxes' => Seedbox::query()->with('user.group')->latest()->paginate(50),
         ]);
     }
 

--- a/app/Http/Controllers/Staff/TicketCategoryController.php
+++ b/app/Http/Controllers/Staff/TicketCategoryController.php
@@ -33,7 +33,7 @@ class TicketCategoryController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.ticket-category.index', [
-            'ticketCategories' => TicketCategory::orderBy('position')->get(),
+            'ticketCategories' => TicketCategory::query()->orderBy('position')->get(),
         ]);
     }
 
@@ -50,7 +50,7 @@ class TicketCategoryController extends Controller
      */
     public function store(StoreTicketCategoryRequest $request): \Illuminate\Http\RedirectResponse
     {
-        TicketCategory::create($request->validated());
+        TicketCategory::query()->create($request->validated());
 
         return to_route('staff.ticket_categories.index')
             ->with('success', 'Ticket category successfully added');

--- a/app/Http/Controllers/Staff/TicketPriorityController.php
+++ b/app/Http/Controllers/Staff/TicketPriorityController.php
@@ -33,7 +33,7 @@ class TicketPriorityController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.ticket-priority.index', [
-            'ticketPriorities' => TicketPriority::orderBy('position')->get(),
+            'ticketPriorities' => TicketPriority::query()->orderBy('position')->get(),
         ]);
     }
 
@@ -50,7 +50,7 @@ class TicketPriorityController extends Controller
      */
     public function store(StoreTicketPriorityRequest $request): \Illuminate\Http\RedirectResponse
     {
-        TicketPriority::create($request->validated());
+        TicketPriority::query()->create($request->validated());
 
         return to_route('staff.ticket_priorities.index')
             ->with('success', 'Ticket priority successfully added');

--- a/app/Http/Controllers/Staff/TypeController.php
+++ b/app/Http/Controllers/Staff/TypeController.php
@@ -33,7 +33,7 @@ class TypeController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.type.index', [
-            'types' => Type::orderBy('position')->get(),
+            'types' => Type::query()->orderBy('position')->get(),
         ]);
     }
 
@@ -50,7 +50,7 @@ class TypeController extends Controller
      */
     public function store(StoreTypeRequest $request): \Illuminate\Http\RedirectResponse
     {
-        Type::create($request->validated());
+        Type::query()->create($request->validated());
 
         return to_route('staff.types.index')
             ->with('success', 'Type successfully added');

--- a/app/Http/Controllers/Staff/UnbanController.php
+++ b/app/Http/Controllers/Staff/UnbanController.php
@@ -34,7 +34,7 @@ class UnbanController extends Controller
      */
     public function store(StoreUnbanRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $user = User::findOrFail($request->integer('owned_by'));
+        $user = User::query()->findOrFail($request->integer('owned_by'));
         $staff = $request->user();
 
         abort_if($user->group->is_modo || $request->user()->is($user), 403);
@@ -44,7 +44,7 @@ class UnbanController extends Controller
             'can_download' => 1,
         ]);
 
-        Ban::create([
+        Ban::query()->create([
             'owned_by'     => $user->id,
             'created_by'   => $staff->id,
             'unban_reason' => $request->unban_reason,

--- a/app/Http/Controllers/Staff/UploadContestController.php
+++ b/app/Http/Controllers/Staff/UploadContestController.php
@@ -46,7 +46,7 @@ class UploadContestController extends Controller
      */
     public function store(StoreUploadContestRequest $request): \Illuminate\Http\RedirectResponse
     {
-        UploadContest::create([
+        UploadContest::query()->create([
             'active'  => 0,
             'awarded' => 0,
         ] + $request->validated());

--- a/app/Http/Controllers/Staff/UploaderController.php
+++ b/app/Http/Controllers/Staff/UploaderController.php
@@ -27,7 +27,8 @@ class UploaderController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.uploader.index', [
-            'uploaders' => User::with(['group'])
+            'uploaders' => User::query()
+                ->with(['group'])
                 ->withCount('torrents as total_uploads')
                 ->whereRelation('group', 'is_uploader', '=', true)
                 // Count recent uploads for current user

--- a/app/Http/Controllers/Staff/UserController.php
+++ b/app/Http/Controllers/Staff/UserController.php
@@ -61,7 +61,7 @@ class UserController extends Controller
 
         return view('Staff.user.edit', [
             'user'      => $user,
-            'groups'    => Group::when(!$group->is_owner, fn ($query) => $query->where('level', '<=', $group->level))->orderBy('position')->get(),
+            'groups'    => Group::query()->when(!$group->is_owner, fn ($query) => $query->where('level', '<=', $group->level))->orderBy('position')->get(),
             'internals' => Internal::all(),
         ]);
     }
@@ -73,7 +73,7 @@ class UserController extends Controller
     {
         $user->load('group');
         $staff = $request->user();
-        $group = Group::findOrFail($request->group_id);
+        $group = Group::query()->findOrFail($request->group_id);
 
         abort_if(! $staff->group->is_owner && ($staff->group->level <= $user->group->level || $staff->group->level <= $group->level), 403);
 
@@ -123,44 +123,44 @@ class UserController extends Controller
             'deleted_by'   => auth()->id(),
         ]);
 
-        Torrent::withoutGlobalScope(ApprovedScope::class)->where('user_id', '=', $user->id)->update([
+        Torrent::query()->withoutGlobalScope(ApprovedScope::class)->where('user_id', '=', $user->id)->update([
             'user_id' => User::SYSTEM_USER_ID,
         ]);
 
-        Comment::where('user_id', '=', $user->id)->update([
+        Comment::query()->where('user_id', '=', $user->id)->update([
             'user_id' => User::SYSTEM_USER_ID,
         ]);
 
-        Post::where('user_id', '=', $user->id)->update([
+        Post::query()->where('user_id', '=', $user->id)->update([
             'user_id' => User::SYSTEM_USER_ID,
         ]);
 
-        Topic::where('first_post_user_id', '=', $user->id)->update([
+        Topic::query()->where('first_post_user_id', '=', $user->id)->update([
             'first_post_user_id' => User::SYSTEM_USER_ID,
         ]);
 
-        Topic::where('last_post_user_id', '=', $user->id)->update([
+        Topic::query()->where('last_post_user_id', '=', $user->id)->update([
             'last_post_user_id' => User::SYSTEM_USER_ID,
         ]);
 
-        PrivateMessage::where('sender_id', '=', $user->id)->update([
+        PrivateMessage::query()->where('sender_id', '=', $user->id)->update([
             'sender_id' => User::SYSTEM_USER_ID,
         ]);
 
-        Participant::where('user_id', '=', $user->id)->delete();
-        Message::where('user_id', '=', $user->id)->delete();
-        Like::where('user_id', '=', $user->id)->delete();
-        Thank::where('user_id', '=', $user->id)->delete();
-        Peer::where('user_id', '=', $user->id)->delete();
-        History::where('user_id', '=', $user->id)->delete();
-        FailedLoginAttempt::where('user_id', '=', $user->id)->delete();
+        Participant::query()->where('user_id', '=', $user->id)->delete();
+        Message::query()->where('user_id', '=', $user->id)->delete();
+        Like::query()->where('user_id', '=', $user->id)->delete();
+        Thank::query()->where('user_id', '=', $user->id)->delete();
+        Peer::query()->where('user_id', '=', $user->id)->delete();
+        History::query()->where('user_id', '=', $user->id)->delete();
+        FailedLoginAttempt::query()->where('user_id', '=', $user->id)->delete();
 
         // Removes all follows for user
         $user->followers()->detach();
         $user->following()->detach();
 
         // Removes all FL Tokens for user
-        foreach (FreeleechToken::where('user_id', '=', $user->id)->get() as $token) {
+        foreach (FreeleechToken::query()->where('user_id', '=', $user->id)->get() as $token) {
             $token->delete();
             cache()->forget('freeleech_token:'.$user->id.':'.$token->torrent_id);
         }

--- a/app/Http/Controllers/Staff/WatchlistController.php
+++ b/app/Http/Controllers/Staff/WatchlistController.php
@@ -39,7 +39,7 @@ class WatchlistController extends Controller
      */
     final public function store(StoreWatchedUserRequest $request): \Illuminate\Http\RedirectResponse
     {
-        Watchlist::create(['staff_id' => $request->user()->id] + $request->validated());
+        Watchlist::query()->create(['staff_id' => $request->user()->id] + $request->validated());
 
         return back()->with('success', 'User successfully being watched');
     }

--- a/app/Http/Controllers/Staff/WhitelistedImageUrlController.php
+++ b/app/Http/Controllers/Staff/WhitelistedImageUrlController.php
@@ -26,7 +26,7 @@ class WhitelistedImageUrlController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.whitelisted-image-url.index', [
-            'whitelistedImageUrls' => WhitelistedImageUrl::orderBy('pattern')->get(),
+            'whitelistedImageUrls' => WhitelistedImageUrl::query()->orderBy('pattern')->get(),
         ]);
     }
 
@@ -42,7 +42,7 @@ class WhitelistedImageUrlController extends Controller
 
     public function store(StoreWhitelistedImageUrlRequest $request): \Illuminate\Http\RedirectResponse
     {
-        WhitelistedImageUrl::create($request->validated());
+        WhitelistedImageUrl::query()->create($request->validated());
 
         cache()->forget('whitelisted-image-urls');
 

--- a/app/Http/Controllers/Staff/WikiCategoryController.php
+++ b/app/Http/Controllers/Staff/WikiCategoryController.php
@@ -49,7 +49,7 @@ class WikiCategoryController extends Controller
      */
     public function store(StoreWikiCategoryRequest $request): \Illuminate\Http\RedirectResponse
     {
-        WikiCategory::create($request->validated());
+        WikiCategory::query()->create($request->validated());
 
         return to_route('staff.wiki_categories.index')
             ->with('success', 'Wiki category successfully added');

--- a/app/Http/Controllers/Staff/WikiController.php
+++ b/app/Http/Controllers/Staff/WikiController.php
@@ -41,7 +41,7 @@ class WikiController extends Controller
      */
     public function store(StoreWikiRequest $request): \Illuminate\Http\RedirectResponse
     {
-        Wiki::create($request->validated());
+        Wiki::query()->create($request->validated());
 
         return to_route('staff.wiki_categories.index')
             ->with('success', 'Wiki has been created successfully');

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -91,7 +91,8 @@ class StatsController extends Controller
     public function seeders(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('stats.users.seeders', [
-            'seeders' => Peer::with('user.group')
+            'seeders' => Peer::query()
+                ->with('user.group')
                 ->select(DB::raw('user_id, count(distinct torrent_id) as value'))
                 ->where('seeder', '=', 1)
                 ->where('active', '=', 1)
@@ -205,7 +206,7 @@ class StatsController extends Controller
     public function seeded(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('stats.torrents.seeded', [
-            'seeded' => Torrent::orderByDesc('seeders')->take(100)->get(),
+            'seeded' => Torrent::query()->orderByDesc('seeders')->take(100)->get(),
         ]);
     }
 
@@ -215,7 +216,7 @@ class StatsController extends Controller
     public function leeched(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('stats.torrents.leeched', [
-            'leeched' => Torrent::orderByDesc('leechers')->take(100)->get(),
+            'leeched' => Torrent::query()->orderByDesc('leechers')->take(100)->get(),
         ]);
     }
 
@@ -225,7 +226,7 @@ class StatsController extends Controller
     public function completed(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('stats.torrents.completed', [
-            'completed' => Torrent::orderByDesc('times_completed')->take(100)->get(),
+            'completed' => Torrent::query()->orderByDesc('times_completed')->take(100)->get(),
         ]);
     }
 
@@ -235,7 +236,8 @@ class StatsController extends Controller
     public function dying(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('stats.torrents.dying', [
-            'dying' => Torrent::where('seeders', '=', 1)
+            'dying' => Torrent::query()
+                ->where('seeders', '=', 1)
                 ->where('times_completed', '>=', 1)
                 ->orderByDesc('leechers')
                 ->take(100)
@@ -249,7 +251,8 @@ class StatsController extends Controller
     public function dead(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('stats.torrents.dead', [
-            'dead' => Torrent::where('seeders', '=', 0)
+            'dead' => Torrent::query()
+                ->where('seeders', '=', 0)
                 ->orderByDesc('leechers')
                 ->take(100)
                 ->get(),
@@ -262,7 +265,7 @@ class StatsController extends Controller
     public function bountied(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('stats.requests.bountied', [
-            'bountied' => TorrentRequest::orderByDesc('bounty')->take(100)->get(),
+            'bountied' => TorrentRequest::query()->orderByDesc('bounty')->take(100)->get(),
         ]);
     }
 
@@ -272,7 +275,7 @@ class StatsController extends Controller
     public function groups(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('stats.groups.groups', [
-            'groups' => Group::orderBy('position')->withCount(['users' => fn ($query) => $query->withTrashed()])->get(),
+            'groups' => Group::query()->orderBy('position')->withCount(['users' => fn ($query) => $query->withTrashed()])->get(),
         ]);
     }
 
@@ -290,7 +293,7 @@ class StatsController extends Controller
             'user_account_age'  => (int) Carbon::now()->diffInSeconds($user->created_at, true),
             'user_seed_size'    => $user->seedingTorrents()->sum('size'),
             'user_uploads'      => $user->torrents()->count(),
-            'groups'            => Group::orderBy('position')->where('is_modo', '=', 0)->get(),
+            'groups'            => Group::query()->orderBy('position')->where('is_modo', '=', 0)->get(),
         ]);
     }
 
@@ -436,12 +439,14 @@ class StatsController extends Controller
                 ->groupBy('total_style')
                 ->orderByDesc('value')
                 ->get(),
-            'customThemes' => UserSetting::where('custom_css', '!=', '')
+            'customThemes' => UserSetting::query()
+                ->where('custom_css', '!=', '')
                 ->select(DB::raw('custom_css, count(*) as value'))
                 ->groupBy('custom_css')
                 ->orderByDesc('value')
                 ->get(),
-            'standaloneThemes' => UserSetting::whereNotNull('standalone_css')
+            'standaloneThemes' => UserSetting::query()
+                ->whereNotNull('standalone_css')
                 ->select(DB::raw('standalone_css, count(*) as value'))
                 ->groupBy('standalone_css')
                 ->orderByDesc('value')

--- a/app/Http/Controllers/SubtitleController.php
+++ b/app/Http/Controllers/SubtitleController.php
@@ -65,8 +65,8 @@ class SubtitleController extends Controller
     public function create(Request $request): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('subtitle.create', [
-            'torrent'         => Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($request->integer('torrent_id')),
-            'media_languages' => MediaLanguage::orderBy('name')->get(),
+            'torrent'         => Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($request->integer('torrent_id')),
+            'media_languages' => MediaLanguage::query()->orderBy('name')->get(),
         ]);
     }
 
@@ -82,9 +82,9 @@ class SubtitleController extends Controller
 
         $filename = uniqid('', true).'.'.$subtitleFile->getClientOriginalExtension();
 
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($request->integer('torrent_id'));
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($request->integer('torrent_id'));
 
-        $subtitle = Subtitle::create([
+        $subtitle = Subtitle::query()->create([
             'title'        => $torrent->name,
             'file_name'    => $filename,
             'file_size'    => $subtitleFile->getSize(),

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -38,8 +38,8 @@ class TicketController extends Controller
     final public function create(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
         return view('ticket.create', [
-            'categories' => TicketCategory::orderBy('position')->get(),
-            'priorities' => TicketPriority::orderBy('position')->get(),
+            'categories' => TicketCategory::query()->orderBy('position')->get(),
+            'priorities' => TicketPriority::query()->orderBy('position')->get(),
         ]);
     }
 
@@ -48,7 +48,7 @@ class TicketController extends Controller
      */
     final public function store(StoreTicketRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $ticket = Ticket::create(['user_id' => $request->user()->id] + $request->validated());
+        $ticket = Ticket::query()->create(['user_id' => $request->user()->id] + $request->validated());
 
         if ($request->hasFile('attachments')) {
             TicketAttachmentController::storeTicketAttachments($request, $ticket, $request->user());

--- a/app/Http/Controllers/TicketNoteController.php
+++ b/app/Http/Controllers/TicketNoteController.php
@@ -31,7 +31,7 @@ class TicketNoteController extends Controller
         $user = $request->user();
         abort_unless($user->group->is_modo, 403);
 
-        TicketNote::create(['ticket_id' => $ticket->id, 'user_id' => $user->id] + $request->validated());
+        TicketNote::query()->create(['ticket_id' => $ticket->id, 'user_id' => $user->id] + $request->validated());
 
         return to_route('tickets.show', ['ticket' => $ticket])
             ->with('success', trans('ticket.note-create-success'));

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -66,9 +66,9 @@ class TopicController extends Controller
     {
         $user = $request->user();
 
-        $topic = Topic::with('user', 'forum.category')->authorized(canReadTopic: true)->findOrFail($id);
+        $topic = Topic::query()->with('user', 'forum.category')->authorized(canReadTopic: true)->findOrFail($id);
 
-        $subscription = Subscription::where('user_id', '=', $user->id)->where('topic_id', '=', $id)->first();
+        $subscription = Subscription::query()->where('user_id', '=', $user->id)->where('topic_id', '=', $id)->first();
 
         $topic->views++;
         $topic->save();
@@ -90,7 +90,7 @@ class TopicController extends Controller
     {
         $user = $request->user();
 
-        $forum = Forum::with('category')->authorized(canStartTopic: true)->findOrFail($id);
+        $forum = Forum::query()->with('category')->authorized(canStartTopic: true)->findOrFail($id);
 
         return view('forum.forum-topic.create', [
             'forum' => $forum,
@@ -111,7 +111,7 @@ class TopicController extends Controller
         $user = $request->user();
         $forum = Forum::authorized(canStartTopic: true)->findOrFail($id);
 
-        $topic = Topic::create([
+        $topic = Topic::query()->create([
             'name'               => $request->title,
             'state'              => 'open',
             'first_post_user_id' => $user->id,
@@ -122,7 +122,7 @@ class TopicController extends Controller
             'num_post'           => 1,
         ]);
 
-        $post = Post::create([
+        $post = Post::query()->create([
             'content'  => $request->input('content'),
             'anon'     => $request->boolean('anon'),
             'user_id'  => $user->id,
@@ -215,11 +215,11 @@ class TopicController extends Controller
     {
         $user = $request->user();
 
-        $topic = Topic::with('forum.category')->authorized(canReadTopic: true, canReplyTopic: true)->findOrFail($id);
+        $topic = Topic::query()->with('forum.category')->authorized(canReadTopic: true, canReplyTopic: true)->findOrFail($id);
 
         abort_unless($user->group->is_modo || $user->id === $topic->first_post_user_id, 403);
 
-        $categories = Forum::with('category:id,name')
+        $categories = Forum::query()->with('category:id,name')
             ->authorized(canReadTopic: true, canStartTopic: true)
             ->get()
             ->groupBy('category.name');
@@ -303,7 +303,7 @@ class TopicController extends Controller
      */
     public function destroy(int $id): \Illuminate\Http\RedirectResponse
     {
-        $topic = Topic::findOrFail($id);
+        $topic = Topic::query()->findOrFail($id);
 
         $topic->posts()->delete();
         $topic->delete();
@@ -331,7 +331,7 @@ class TopicController extends Controller
      */
     public function close(int $id): \Illuminate\Http\RedirectResponse
     {
-        $topic = Topic::findOrFail($id);
+        $topic = Topic::query()->findOrFail($id);
         $topic->state = 'close';
         $topic->save();
 
@@ -344,7 +344,7 @@ class TopicController extends Controller
      */
     public function open(int $id): \Illuminate\Http\RedirectResponse
     {
-        $topic = Topic::findOrFail($id);
+        $topic = Topic::query()->findOrFail($id);
         $topic->state = 'open';
         $topic->save();
 
@@ -357,7 +357,7 @@ class TopicController extends Controller
      */
     public function pin(Request $request, int $id): \Illuminate\Http\RedirectResponse
     {
-        $topic = Topic::findOrFail($id);
+        $topic = Topic::query()->findOrFail($id);
         $topic->priority = $request->integer('priority');
         $topic->save();
 
@@ -370,7 +370,7 @@ class TopicController extends Controller
      */
     public function unpin(int $id): \Illuminate\Http\RedirectResponse
     {
-        $topic = Topic::findOrFail($id);
+        $topic = Topic::query()->findOrFail($id);
         $topic->priority = 0;
         $topic->save();
 
@@ -383,7 +383,7 @@ class TopicController extends Controller
      */
     public function permalink(int $topicId, int $postId): \Illuminate\Http\RedirectResponse
     {
-        $index = Post::where('topic_id', '=', $topicId)->where('id', '<', $postId)->count();
+        $index = Post::query()->where('topic_id', '=', $topicId)->where('id', '<', $postId)->count();
 
         return to_route('topics.show', [
             'id'   => $topicId,

--- a/app/Http/Controllers/TorrentBuffController.php
+++ b/app/Http/Controllers/TorrentBuffController.php
@@ -46,7 +46,7 @@ class TorrentBuffController extends Controller
         $user = $request->user();
 
         abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrent->bumped_at = Carbon::now();
         $torrent->save();
 
@@ -79,7 +79,7 @@ class TorrentBuffController extends Controller
         $user = $request->user();
 
         abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrent->sticky = !$torrent->sticky;
         $torrent->save();
 
@@ -95,7 +95,7 @@ class TorrentBuffController extends Controller
         $user = $request->user();
 
         abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrentUrl = href_torrent($torrent);
 
         $request->validate([
@@ -139,7 +139,7 @@ class TorrentBuffController extends Controller
         $user = $request->user();
 
         abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         if ($torrent->featured()->doesntExist()) {
             Unit3dAnnounce::addFeaturedTorrent($torrent->id);
@@ -174,9 +174,9 @@ class TorrentBuffController extends Controller
 
         abort_unless($user->group->is_modo, 403);
 
-        $featured_torrent = FeaturedTorrent::where('torrent_id', '=', $id)->sole();
+        $featured_torrent = FeaturedTorrent::query()->where('torrent_id', '=', $id)->sole();
 
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         Unit3dAnnounce::removeFeaturedTorrent($torrent->id);
 
@@ -202,7 +202,7 @@ class TorrentBuffController extends Controller
         $user = $request->user();
 
         abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrentUrl = href_torrent($torrent);
 
         if (!$torrent->doubleup) {
@@ -242,7 +242,7 @@ class TorrentBuffController extends Controller
     public function freeleechToken(Request $request, int $id): \Illuminate\Http\RedirectResponse
     {
         $user = $request->user();
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         $activeToken = cache()->get('freeleech_token:'.$user->id.':'.$torrent->id);
 
@@ -277,7 +277,7 @@ class TorrentBuffController extends Controller
         $user = $request->user();
         abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
 
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrent_url = href_torrent($torrent);
 
         if (!$torrent->refundable) {

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -319,7 +319,7 @@ class TorrentController extends Controller
     public function edit(Request $request, int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         $user = $request->user();
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         abort_unless($user->group->is_editor || $user->group->is_modo || $user->id === $torrent->user_id, 403);
 
@@ -340,11 +340,11 @@ class TorrentController extends Controller
                         },
                     ]
                 ]),
-            'types'        => Type::orderBy('position')->get()->mapWithKeys(fn ($type) => [$type['id'] => ['name' => $type['name']]]),
-            'resolutions'  => Resolution::orderBy('position')->get(),
-            'regions'      => Region::orderBy('position')->get(),
-            'distributors' => Distributor::orderBy('name')->get(),
-            'keywords'     => Keyword::where('torrent_id', '=', $torrent->id)->pluck('name'),
+            'types'        => Type::query()->orderBy('position')->get()->mapWithKeys(fn ($type) => [$type['id'] => ['name' => $type['name']]]),
+            'resolutions'  => Resolution::query()->orderBy('position')->get(),
+            'regions'      => Region::query()->orderBy('position')->get(),
+            'distributors' => Distributor::query()->orderBy('name')->get(),
+            'keywords'     => Keyword::query()->where('torrent_id', '=', $torrent->id)->pluck('name'),
             'torrent'      => $torrent,
             'user'         => $user,
         ]);
@@ -356,7 +356,7 @@ class TorrentController extends Controller
     public function update(UpdateTorrentRequest $request, int $id): \Illuminate\Http\RedirectResponse
     {
         $user = $request->user();
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         abort_unless(
             $user->group->is_editor
@@ -396,7 +396,7 @@ class TorrentController extends Controller
         }
 
         // Torrent Keywords System
-        Keyword::where('torrent_id', '=', $torrent->id)->delete();
+        Keyword::query()->where('torrent_id', '=', $torrent->id)->delete();
 
         $keywords = [];
 
@@ -405,7 +405,7 @@ class TorrentController extends Controller
         }
 
         foreach (collect($keywords)->chunk(65_000 / 2) as $keywords) {
-            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name']);
+            Keyword::query()->upsert($keywords->toArray(), ['torrent_id', 'name']);
         }
 
         // Meta
@@ -436,7 +436,7 @@ class TorrentController extends Controller
         ]);
 
         $user = $request->user();
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         abort_unless($user->group->is_modo || ($user->id === $torrent->user_id && Carbon::now()->lt($torrent->created_at->addDay())), 403);
 
@@ -491,7 +491,7 @@ class TorrentController extends Controller
         abort_unless($user->can_upload ?? $user->group->can_upload, 403, __('torrent.cant-upload').' '.__('torrent.cant-upload-desc'));
 
         return view('torrent.create', [
-            'categories' => Category::orderBy('position')
+            'categories' => Category::query()->orderBy('position')
                 ->get()
                 ->mapWithKeys(fn ($category) => [$category->id => [
                     'name' => $category->name,
@@ -505,10 +505,10 @@ class TorrentController extends Controller
                     },
                 ]])
                 ->toArray(),
-            'types'        => Type::orderBy('position')->get(),
-            'resolutions'  => Resolution::orderBy('position')->get(),
-            'regions'      => Region::orderBy('position')->get(),
-            'distributors' => Distributor::orderBy('name')->get(),
+            'types'        => Type::query()->orderBy('position')->get(),
+            'resolutions'  => Resolution::query()->orderBy('position')->get(),
+            'regions'      => Region::query()->orderBy('position')->get(),
+            'distributors' => Distributor::query()->orderBy('name')->get(),
             'user'         => $request->user(),
             'category_id'  => $request->category_id ?? Category::query()->first()->id,
             'title'        => urldecode((string) $request->title),
@@ -540,7 +540,7 @@ class TorrentController extends Controller
         $fileName = uniqid('', true).'.torrent'; // Generate a unique name
         Storage::disk('torrent-files')->put($fileName, Bencode::bencode($decodedTorrent));
 
-        $torrent = Torrent::create([
+        $torrent = Torrent::query()->create([
             'mediainfo'    => TorrentTools::anonymizeMediainfo($request->filled('mediainfo') ? $request->string('mediainfo') : null),
             'info_hash'    => Bencode::get_infohash($decodedTorrent),
             'file_name'    => $fileName,
@@ -556,7 +556,7 @@ class TorrentController extends Controller
         // Populate the status/seeders/leechers/times_completed fields for the external tracker
         $torrent->refresh();
 
-        $category = Category::findOrFail($request->integer('category_id'));
+        $category = Category::query()->findOrFail($request->integer('category_id'));
 
         // Backup the files contained in the torrent
         $files = TorrentTools::getTorrentFiles($decodedTorrent);
@@ -568,7 +568,7 @@ class TorrentController extends Controller
         // Can't insert them all at once since some torrents have more files than mysql supports placeholders.
         // Divide by 3 since we're inserting 3 fields: name, size and torrent_id
         foreach (collect($files)->chunk(intdiv(65_000, 3)) as $files) {
-            TorrentFile::insert($files->toArray());
+            TorrentFile::query()->insert($files->toArray());
         }
 
         // Cover Image for No-Meta Torrents
@@ -615,7 +615,7 @@ class TorrentController extends Controller
         }
 
         foreach (collect($keywords)->chunk(intdiv(65_000, 2)) as $keywords) {
-            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name']);
+            Keyword::query()->upsert($keywords->toArray(), ['torrent_id', 'name']);
         }
 
         // check for trusted user and update torrent

--- a/app/Http/Controllers/TorrentDownloadController.php
+++ b/app/Http/Controllers/TorrentDownloadController.php
@@ -33,7 +33,7 @@ class TorrentDownloadController extends Controller
     public function show(Request $request, int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('torrent.download-check', [
-            'torrent' => Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id),
+            'torrent' => Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id),
             'user'    => $request->user(),
         ]);
     }
@@ -46,9 +46,9 @@ class TorrentDownloadController extends Controller
         $user = $request->user();
 
         if (!$user && $rsskey) {
-            $user = User::where('rsskey', '=', $rsskey)->sole();
+            $user = User::query()->where('rsskey', '=', $rsskey)->sole();
         }
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $hasHistory = $user->history()->where([['torrent_id', '=', $torrent->id], ['seeder', '=', 1]])->exists();
 
         // User's ratio is too low

--- a/app/Http/Controllers/TorrentHistoryController.php
+++ b/app/Http/Controllers/TorrentHistoryController.php
@@ -29,7 +29,7 @@ class TorrentHistoryController extends Controller
     public function index(int $id, Request $request): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('torrent.history', [
-            'torrent'   => Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id),
+            'torrent'   => Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id),
             'histories' => History::query()
                 ->with(['user.group'])
                 ->where('torrent_id', '=', $id)

--- a/app/Http/Controllers/TorrentPeerController.php
+++ b/app/Http/Controllers/TorrentPeerController.php
@@ -28,7 +28,7 @@ class TorrentPeerController extends Controller
      */
     public function index(int $id, Request $request): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         return view('torrent.peers', [
             'torrent' => $torrent,

--- a/app/Http/Controllers/TorrentPendingController.php
+++ b/app/Http/Controllers/TorrentPendingController.php
@@ -25,7 +25,7 @@ class TorrentPendingController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('torrent.pending', [
-            'torrents' => Torrent::withoutGlobalScope(ApprovedScope::class)
+            'torrents' => Torrent::query()->withoutGlobalScope(ApprovedScope::class)
                 ->with(['category', 'type', 'resolution'])
                 ->where('status', '=', ModerationStatus::PENDING)
                 ->orWhere('status', '=', ModerationStatus::POSTPONED)

--- a/app/Http/Controllers/TorrentReseedController.php
+++ b/app/Http/Controllers/TorrentReseedController.php
@@ -46,11 +46,12 @@ class TorrentReseedController extends Controller
      */
     public function store(Request $request, int $id): \Illuminate\Http\RedirectResponse
     {
-        $torrent = Torrent::findOrFail($id);
+        $torrent = Torrent::query()->findOrFail($id);
         $userId = $request->user()->id;
 
         // Check if this user has already made a reseed request for this torrent
-        $existingUserReseed = TorrentReseed::where('torrent_id', '=', $torrent->id)
+        $existingUserReseed = TorrentReseed::query()
+            ->where('torrent_id', '=', $torrent->id)
             ->where('user_id', '=', $userId)
             ->first();
 
@@ -60,7 +61,7 @@ class TorrentReseedController extends Controller
         }
 
         // Check seeders condition and if a request already exists for this torrent
-        $existingReseed = TorrentReseed::where('torrent_id', '=', $torrent->id)->first();
+        $existingReseed = TorrentReseed::query()->where('torrent_id', '=', $torrent->id)->first();
 
         if ($torrent->seeders <= 2) {
             if ($existingReseed) {
@@ -70,17 +71,17 @@ class TorrentReseedController extends Controller
                 return to_route('torrents.show', ['id' => $torrent->id])
                     ->with('success', 'A reseed request already exists. Your request has been counted.');
             }
-            TorrentReseed::create([
+            TorrentReseed::query()->create([
                 'torrent_id'     => $torrent->id,
                 'user_id'        => $userId,
                 'requests_count' => 1,
             ]);
 
             // Send notifications
-            $potentialReseeds = History::where('torrent_id', '=', $torrent->id)->where('active', '=', 0)->get();
+            $potentialReseeds = History::query()->where('torrent_id', '=', $torrent->id)->where('active', '=', 0)->get();
 
             foreach ($potentialReseeds as $potentialReseed) {
-                User::find($potentialReseed->user_id)->notify(new NewReseedRequest($torrent));
+                User::query()->find($potentialReseed->user_id)->notify(new NewReseedRequest($torrent));
             }
 
             $torrentUrl = href_torrent($torrent);

--- a/app/Http/Controllers/User/ConversationController.php
+++ b/app/Http/Controllers/User/ConversationController.php
@@ -79,13 +79,13 @@ class ConversationController extends Controller
     {
         abort_unless($request->user()->is($user), 403);
 
-        $recipient = User::where('username', '=', $request->validated('receiver_username'))->sole();
+        $recipient = User::query()->where('username', '=', $request->validated('receiver_username'))->sole();
 
         abort_if($recipient->id === User::SYSTEM_USER_ID, 403);
 
-        $conversation = Conversation::create($request->validated('conversation'));
+        $conversation = Conversation::query()->create($request->validated('conversation'));
 
-        PrivateMessage::create([
+        PrivateMessage::query()->create([
             'conversation_id' => $conversation->id,
             'message'         => $request->validated('message'),
             'sender_id'       => $user->id,
@@ -106,7 +106,7 @@ class ConversationController extends Controller
 
         abort_if($conversation->participants()->withTrashed()->where('user_id', '=', User::SYSTEM_USER_ID)->exists(), 403, 'You cannot reply to the system');
 
-        PrivateMessage::create([
+        PrivateMessage::query()->create([
             'sender_id'       => $user->id,
             'conversation_id' => $conversation->id,
             'message'         => $request->validated('message'),

--- a/app/Http/Controllers/User/GiftController.php
+++ b/app/Http/Controllers/User/GiftController.php
@@ -43,10 +43,11 @@ class GiftController extends Controller
 
         return view('user.gift.index', [
             'user'  => $user,
-            'gifts' => Gift::with([
-                'sender.group',
-                'recipient.group',
-            ])
+            'gifts' => Gift::query()
+                ->with([
+                    'sender.group',
+                    'recipient.group',
+                ])
                 ->where('sender_id', '=', $user->id)
                 ->orWhere('recipient_id', '=', $user->id)
                 ->latest()
@@ -76,13 +77,13 @@ class GiftController extends Controller
     public function store(StoreGiftRequest $request): \Illuminate\Http\RedirectResponse
     {
         $sender = $request->user();
-        $receiver = User::where('username', '=', $request->recipient_username)->sole();
+        $receiver = User::query()->where('username', '=', $request->recipient_username)->sole();
 
         DB::transaction(function () use ($sender, $receiver, $request): void {
             $sender->decrement('seedbonus', $request->bon);
             $receiver->increment('seedbonus', $request->bon);
 
-            $gift = Gift::create([
+            $gift = Gift::query()->create([
                 'bon'          => $request->bon,
                 'sender_id'    => $sender->id,
                 'recipient_id' => $receiver->id,

--- a/app/Http/Controllers/User/InviteController.php
+++ b/app/Http/Controllers/User/InviteController.php
@@ -121,7 +121,7 @@ class InviteController extends Controller
 
         $user->decrement('invites');
 
-        $invite = Invite::create([
+        $invite = Invite::query()->create([
             'user_id'       => $user->id,
             'email'         => $request->input('email'),
             'code'          => Uuid::uuid4()->toString(),

--- a/app/Http/Controllers/User/NotificationSettingController.php
+++ b/app/Http/Controllers/User/NotificationSettingController.php
@@ -35,7 +35,7 @@ class NotificationSettingController extends Controller
 
         // Can't use upsert here because upsert doesn't serialize the custom
         // array cast to a string before upserting
-        UserNotification::updateOrCreate(['user_id' => $user->id], $request->validated());
+        UserNotification::query()->updateOrCreate(['user_id' => $user->id], $request->validated());
 
         cache()->forget('user-notification:by-user-id:'.$user->id);
 

--- a/app/Http/Controllers/User/PostTipController.php
+++ b/app/Http/Controllers/User/PostTipController.php
@@ -38,11 +38,12 @@ class PostTipController extends Controller
 
         return view('user.post-tip.index', [
             'user' => $user,
-            'tips' => PostTip::with([
-                'sender.group',
-                'recipient.group',
-                'post.topic'
-            ])
+            'tips' => PostTip::query()
+                ->with([
+                    'sender.group',
+                    'recipient.group',
+                    'post.topic'
+                ])
                 ->where('sender_id', '=', $user->id)
                 ->orWhere('recipient_id', '=', $user->id)
                 ->latest()
@@ -63,10 +64,10 @@ class PostTipController extends Controller
         abort_unless($request->user()->is($user), 403);
 
         DB::transaction(static function () use ($request): void {
-            $tip = PostTip::create($request->validated());
+            $tip = PostTip::query()->create($request->validated());
 
-            User::whereKey($tip->sender_id)->decrement('seedbonus', (float) $tip->bon);
-            User::whereKey($tip->recipient_id)->increment('seedbonus', (float) $tip->bon);
+            User::query()->whereKey($tip->sender_id)->decrement('seedbonus', (float) $tip->bon);
+            User::query()->whereKey($tip->recipient_id)->increment('seedbonus', (float) $tip->bon);
 
             $tip->recipient->notify((new NewPostTip($tip))->afterCommit());
         });

--- a/app/Http/Controllers/User/PrivacySettingController.php
+++ b/app/Http/Controllers/User/PrivacySettingController.php
@@ -35,7 +35,7 @@ class PrivacySettingController extends Controller
 
         // Can't use upsert here because upsert doesn't serialize the custom
         // array cast to a string before upserting
-        UserPrivacy::updateOrCreate(['user_id' => $user->id], $request->validated());
+        UserPrivacy::query()->updateOrCreate(['user_id' => $user->id], $request->validated());
 
         cache()->forget('user-privacy:by-user-id:'.$user->id);
 

--- a/app/Http/Controllers/User/ResurrectionController.php
+++ b/app/Http/Controllers/User/ResurrectionController.php
@@ -42,7 +42,7 @@ class ResurrectionController extends Controller
     {
         abort_unless($request->user()->is($user), 403);
 
-        $torrent = Torrent::findOrFail($request->integer('torrent_id'));
+        $torrent = Torrent::query()->findOrFail($request->integer('torrent_id'));
 
         if ($user->id === $torrent->user_id) {
             return to_route('torrents.show', ['id' => $torrent->id])
@@ -59,16 +59,16 @@ class ResurrectionController extends Controller
                 ->withErrors('This torrent is not older than 30 days.');
         }
 
-        $isPending = Resurrection::whereBelongsTo($torrent)->where('rewarded', '=', 0)->exists();
+        $isPending = Resurrection::query()->whereBelongsTo($torrent)->where('rewarded', '=', 0)->exists();
 
         if ($isPending) {
             return to_route('torrents.show', ['id' => $torrent->id])
                 ->withErrors(trans('graveyard.resurrect-failed-pending'));
         }
 
-        $history = History::whereBelongsTo($torrent)->whereBelongsTo($user)->first();
+        $history = History::query()->whereBelongsTo($torrent)->whereBelongsTo($user)->first();
 
-        Resurrection::create([
+        Resurrection::query()->create([
             'user_id'    => $user->id,
             'torrent_id' => $torrent->id,
             'seedtime'   => config('graveyard.time') + ($history?->seedtime ?? 0),

--- a/app/Http/Controllers/User/SeedboxController.php
+++ b/app/Http/Controllers/User/SeedboxController.php
@@ -49,7 +49,7 @@ class SeedboxController extends Controller
         abort_unless($request->user()->is($user), 403);
 
         // The user's seedbox IPs are encrypted, so they have to be decrypted first to check that the new IP inputted is unique
-        $userSeedboxes = Seedbox::where('user_id', '=', $user->id)->get(['ip', 'name']);
+        $userSeedboxes = Seedbox::query()->where('user_id', '=', $user->id)->get(['ip', 'name']);
         $seedboxIps = $userSeedboxes->pluck('ip')->filter(fn ($ip) => filter_var($ip, FILTER_VALIDATE_IP) !== false);
         $seedboxNames = $userSeedboxes->pluck('name');
 
@@ -73,7 +73,7 @@ class SeedboxController extends Controller
             ]
         );
 
-        Seedbox::create([
+        Seedbox::query()->create([
             'user_id' => $user->id,
             'name'    => $request->name,
             'ip'      => $request->ip,

--- a/app/Http/Controllers/User/TorrentTipController.php
+++ b/app/Http/Controllers/User/TorrentTipController.php
@@ -38,11 +38,12 @@ class TorrentTipController extends Controller
 
         return view('user.torrent-tip.index', [
             'user' => $user,
-            'tips' => TorrentTip::with([
-                'sender.group',
-                'recipient.group',
-                'torrent'
-            ])
+            'tips' => TorrentTip::query()
+                ->with([
+                    'sender.group',
+                    'recipient.group',
+                    'torrent'
+                ])
                 ->where('sender_id', '=', $user->id)
                 ->orWhere('recipient_id', '=', $user->id)
                 ->latest()
@@ -63,10 +64,10 @@ class TorrentTipController extends Controller
         abort_unless($request->user()->is($user), 403);
 
         DB::transaction(static function () use ($request, $user): void {
-            $tip = TorrentTip::create($request->validated());
+            $tip = TorrentTip::query()->create($request->validated());
 
-            User::whereKey($tip->sender_id)->decrement('seedbonus', (float) $tip->bon);
-            User::whereKey($tip->recipient_id)->increment('seedbonus', (float) $tip->bon);
+            User::query()->whereKey($tip->sender_id)->decrement('seedbonus', (float) $tip->bon);
+            User::query()->whereKey($tip->recipient_id)->increment('seedbonus', (float) $tip->bon);
 
             $recipient = $tip->recipient;
 

--- a/app/Http/Controllers/User/TransactionController.php
+++ b/app/Http/Controllers/User/TransactionController.php
@@ -63,7 +63,7 @@ class TransactionController extends Controller
 
         return DB::transaction(function () use ($request, $user) {
             $user->refresh();
-            $bonExchange = BonExchange::findOrFail($request->integer('exchange'));
+            $bonExchange = BonExchange::query()->findOrFail($request->integer('exchange'));
 
             if ($bonExchange->cost > $user->seedbonus) {
                 return back()->withErrors('Not enough BON.');
@@ -91,7 +91,7 @@ class TransactionController extends Controller
                         return back()->withErrors('Your previous personal freeleech is still active.');
                     }
 
-                    PersonalFreeleech::create(['user_id' => $user->id]);
+                    PersonalFreeleech::query()->create(['user_id' => $user->id]);
 
                     cache()->put('personal_freeleech:'.$user->id, true);
 
@@ -114,7 +114,7 @@ class TransactionController extends Controller
                     break;
             }
 
-            BonTransactions::create([
+            BonTransactions::query()->create([
                 'bon_exchange_id' => $bonExchange->id,
                 'name'            => $bonExchange->description,
                 'cost'            => $bonExchange->value,

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -92,9 +92,9 @@ class UserController extends Controller
                 ->with(['torrent', 'user'])
                 ->latest('created_at')
                 ->paginate(10, ['*'], 'deletedWarningsPage'),
-            'boughtUpload' => BonTransactions::where('sender_id', '=', $user->id)->where([['name', 'like', '%Upload%']])->sum('cost'),
-            // 'boughtDownload'        => BonTransactions::where('sender_id', '=', $user->id)->where([['name', 'like', '%Download%']])->sum('cost'),
-            'invitedBy' => Invite::where('accepted_by', '=', $user->id)->first(),
+            'boughtUpload' => BonTransactions::query()->where('sender_id', '=', $user->id)->where([['name', 'like', '%Upload%']])->sum('cost'),
+            // 'boughtDownload'        => BonTransactions::query()->where('sender_id', '=', $user->id)->where([['name', 'like', '%Download%']])->sum('cost'),
+            'invitedBy' => Invite::query()->where('accepted_by', '=', $user->id)->first(),
             'clients'   => $user->peers()
                 ->join('torrents', 'torrents.id', '=', 'peers.torrent_id')
                 ->select('agent', 'port')
@@ -107,7 +107,8 @@ class UserController extends Controller
                 ->groupBy(['ip', 'port', 'agent'])
                 ->where('active', '=', true)
                 ->get(),
-            'achievements' => AchievementProgress::with('details')
+            'achievements' => AchievementProgress::query()
+                ->with('details')
                 ->where('achiever_id', '=', $user->id)
                 ->whereNotNull('unlocked_at')
                 ->get(),
@@ -119,7 +120,7 @@ class UserController extends Controller
                 ->first(),
             'watch'        => $user->watchlist,
             'externalUser' => ! $user->trashed() && $request->user()->group->is_modo ? Unit3dAnnounce::getUser($user->id) : false,
-            'donation'     => Donation::where('status', '=', ModerationStatus::APPROVED)->where('user_id', '=', $user->id)->latest()->first(),
+            'donation'     => Donation::query()->where('status', '=', ModerationStatus::APPROVED)->where('user_id', '=', $user->id)->latest()->first(),
         ]);
     }
 

--- a/app/Http/Controllers/User/WarningController.php
+++ b/app/Http/Controllers/User/WarningController.php
@@ -38,7 +38,7 @@ class WarningController extends Controller
     {
         abort_unless($request->user()->group->is_modo, 403);
 
-        Warning::create([
+        Warning::query()->create([
             'user_id'    => $user->id,
             'warned_by'  => $request->user()->id,
             'torrent'    => null,

--- a/app/Http/Controllers/User/WishController.php
+++ b/app/Http/Controllers/User/WishController.php
@@ -44,8 +44,8 @@ class WishController extends Controller
                 ->withCount(['movieTorrents', 'tvTorrents'])
                 ->latest()
                 ->paginate(25),
-            'movieCategoryIds' => Category::where('movie_meta', '=', 1)->pluck('id')->toArray(),
-            'tvCategoryIds'    => Category::where('tv_meta', '=', 1)->pluck('id')->toArray(),
+            'movieCategoryIds' => Category::query()->where('movie_meta', '=', 1)->pluck('id')->toArray(),
+            'tvCategoryIds'    => Category::query()->where('tv_meta', '=', 1)->pluck('id')->toArray(),
             'route'            => 'wish',
         ]);
     }
@@ -70,7 +70,7 @@ class WishController extends Controller
 
                 $title = $meta['title'].' ('.$meta['release_date'].')';
 
-                Wish::create([
+                Wish::query()->create([
                     'user_id'       => $user->id,
                     'title'         => $title,
                     'tmdb_movie_id' => $request->tmdb_movie_id,
@@ -87,7 +87,7 @@ class WishController extends Controller
 
                 $title = $meta['name'].' ('.$meta['first_air_date'].')';
 
-                Wish::create([
+                Wish::query()->create([
                     'user_id'    => $user->id,
                     'title'      => $title,
                     'tmdb_tv_id' => $request->tmdb_tv_id,

--- a/app/Http/Controllers/YearlyOverviewController.php
+++ b/app/Http/Controllers/YearlyOverviewController.php
@@ -53,7 +53,8 @@ class YearlyOverviewController extends Controller
         return view('stats.yearly-overviews.show', [
             'topMovies' => cache()->rememberForever(
                 'yearly-overview:'.$year.':top-movies',
-                fn () => Torrent::with('movie')
+                fn () => Torrent::query()
+                    ->with('movie')
                     ->select([
                         'tmdb_movie_id',
                         DB::raw('COUNT(h.user_id) as download_count'),
@@ -77,7 +78,8 @@ class YearlyOverviewController extends Controller
             ),
             'topTv' => cache()->rememberForever(
                 'yearly-overview:'.$year.':top-tv',
-                fn () => Torrent::with('tv')
+                fn () => Torrent::query()
+                    ->with('tv')
                     ->select([
                         'tmdb_tv_id',
                         DB::raw('COUNT(h.user_id) as download_count'),
@@ -102,7 +104,8 @@ class YearlyOverviewController extends Controller
             'uploaders' => cache()->remember(
                 'yearly-overview:'.$year.':uploaders',
                 3600,
-                fn () => Torrent::with('user.group')
+                fn () => Torrent::query()
+                    ->with('user.group')
                     ->where('created_at', '>=', $year.'-01-01 00:00:00')
                     ->where('created_at', '<=', $year.'-12-31 23:59:59')
                     ->where('anon', '=', false)
@@ -115,7 +118,8 @@ class YearlyOverviewController extends Controller
             'posters' => $posters = cache()->remember(
                 'yearly-overview:'.$year.':posts',
                 3600,
-                fn () => Post::with('user.group')
+                fn () => Post::query()
+                    ->with('user.group')
                     ->where('created_at', '>=', $year.'-01-01 00:00:00')
                     ->where('created_at', '<=', $year.'-12-31 23:59:59')
                     ->select(DB::raw('user_id, COUNT(*) as value'))
@@ -127,7 +131,8 @@ class YearlyOverviewController extends Controller
             'requesters' => cache()->remember(
                 'yearly-overview:'.$year.':requesters',
                 3600,
-                fn () => TorrentRequest::with(['user.group'])
+                fn () => TorrentRequest::query()
+                    ->with(['user.group'])
                     ->where('created_at', '>=', $year.'-01-01 00:00:00')
                     ->where('created_at', '<=', $year.'-12-31 23:59:59')
                     ->where('user_id', '!=', 1)
@@ -141,7 +146,8 @@ class YearlyOverviewController extends Controller
             'fillers' => cache()->remember(
                 'yearly-overview:'.$year.':fillers',
                 3600,
-                fn () => TorrentRequest::with('filler.group')
+                fn () => TorrentRequest::query()
+                    ->with('filler.group')
                     ->where('filled_when', '>=', $year.'-01-01 00:00:00')
                     ->where('filled_when', '<=', $year.'-12-31 23:59:59')
                     ->where('filled_by', '!=', 1)
@@ -155,7 +161,8 @@ class YearlyOverviewController extends Controller
             'commenters' => cache()->remember(
                 'yearly-overview:'.$year.':commenters',
                 3600,
-                fn () => Comment::with('user.group')
+                fn () => Comment::query()
+                    ->with('user.group')
                     ->where('created_at', '>=', $year.'-01-01 00:00:00')
                     ->where('created_at', '<=', $year.'-12-31 23:59:59')
                     ->where('user_id', '!=', 1)
@@ -169,7 +176,8 @@ class YearlyOverviewController extends Controller
             'thankers' => cache()->remember(
                 'yearly-overview:'.$year.':thankers',
                 3600,
-                fn () => Thank::with('user.group')
+                fn () => Thank::query()
+                    ->with('user.group')
                     ->where('created_at', '>=', $year.'-01-01 00:00:00')
                     ->where('created_at', '<=', $year.'-12-31 23:59:59')
                     ->where('user_id', '!=', 1)

--- a/app/Http/Livewire/ApikeySearch.php
+++ b/app/Http/Livewire/ApikeySearch.php
@@ -53,7 +53,7 @@ class ApikeySearch extends Component
             ->with([
                 'user' => fn ($query) => $query->withTrashed()->with('group'),
             ])
-            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
+            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::query()->withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
             ->when($this->apikey, fn ($query) => $query->where('content', 'LIKE', '%'.$this->apikey.'%'))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);

--- a/app/Http/Livewire/ApplicationSearch.php
+++ b/app/Http/Livewire/ApplicationSearch.php
@@ -69,7 +69,7 @@ class ApplicationSearch extends Component
     {
         abort_unless(auth()->user()->group->is_modo, 403);
 
-        $application = Application::withoutGlobalScopes()->findOrFail($id);
+        $application = Application::query()->withoutGlobalScopes()->findOrFail($id);
         $application->urlProofs()->delete();
         $application->imageProofs()->delete();
         $application->delete();

--- a/app/Http/Livewire/AttachmentUpload.php
+++ b/app/Http/Livewire/AttachmentUpload.php
@@ -46,7 +46,7 @@ class AttachmentUpload extends Component
     {
         $this->validate();
 
-        $ticket = Ticket::find($this->ticket);
+        $ticket = Ticket::query()->find($this->ticket);
 
         abort_unless($ticket->user_id === $this->user->id || $this->user->group->is_modo, 403);
 
@@ -70,7 +70,7 @@ class AttachmentUpload extends Component
      */
     protected \Illuminate\Database\Eloquent\Collection $attachments {
         get {
-            $ticket = Ticket::find($this->ticket);
+            $ticket = Ticket::query()->find($this->ticket);
 
             abort_unless($ticket->user_id === $this->user->id || $this->user->group->is_modo, 403);
 

--- a/app/Http/Livewire/BlockIpAddress.php
+++ b/app/Http/Livewire/BlockIpAddress.php
@@ -49,7 +49,7 @@ class BlockIpAddress extends Component
 
         $this->validate();
 
-        BlockedIp::create([
+        BlockedIp::query()->create([
             'ip_address' => $this->ipAddress,
             'reason'     => $this->reason,
             'user_id'    => auth()->user()->id,

--- a/app/Http/Livewire/Comment.php
+++ b/app/Http/Livewire/Comment.php
@@ -157,17 +157,17 @@ class Comment extends Component
                 $ticket = $this->model;
 
                 if ($this->user->id !== $ticket->staff_id && $ticket->staff_id !== null) {
-                    User::find($ticket->staff_id)->notify(new NewComment($this->model, $reply));
+                    User::query()->find($ticket->staff_id)->notify(new NewComment($this->model, $reply));
                     $this->model->update(['staff_read' => false]);
                 }
 
                 if ($this->user->id !== $ticket->user_id) {
-                    User::find($ticket->user_id)->notify(new NewComment($this->model, $reply));
+                    User::query()->find($ticket->user_id)->notify(new NewComment($this->model, $reply));
                     $this->model->update(['user_read' => false]);
                 }
 
                 if (!\in_array($this->comment->user_id, [$ticket->staff_id, $ticket->user_id, $this->user->id])) {
-                    User::find($this->comment->user_id)->notify(new NewComment($this->model, $reply));
+                    User::query()->find($this->comment->user_id)->notify(new NewComment($this->model, $reply));
                 }
 
                 break;
@@ -176,18 +176,18 @@ class Comment extends Component
             case TorrentRequest::class:
             case Torrent::class:
                 if ($this->user->id !== $this->model->user_id) {
-                    User::find($this->model->user_id)?->notify(new NewComment($this->model, $reply));
+                    User::query()->find($this->model->user_id)?->notify(new NewComment($this->model, $reply));
                 }
 
                 if ($this->user->id !== $this->comment->user_id && $this->comment->user_id !== $this->model->user_id) {
-                    User::find($this->comment->user_id)?->notify(new NewComment($this->model, $reply));
+                    User::query()->find($this->comment->user_id)?->notify(new NewComment($this->model, $reply));
                 }
 
                 break;
         }
 
         // User Tagged Notification
-        $users = User::whereIn('username', $this->taggedUsers())->get();
+        $users = User::query()->whereIn('username', $this->taggedUsers())->get();
         Notification::sendNow($users, new NewCommentTag($this->model, $reply));
 
         if (!$this->model instanceof Ticket) {

--- a/app/Http/Livewire/Comments.php
+++ b/app/Http/Livewire/Comments.php
@@ -129,23 +129,23 @@ class Comments extends Component
         switch ($this->model::class) {
             case Ticket::class:
                 // Notify assigned staff if needed
-                User::find($this->model->staff_id)?->notify(new NewComment($this->model, $comment));
+                User::query()->find($this->model->staff_id)?->notify(new NewComment($this->model, $comment));
 
                 // Notify ticket creator if needed
-                User::find($this->model->user_id)?->notify(new NewComment($this->model, $comment));
+                User::query()->find($this->model->user_id)?->notify(new NewComment($this->model, $comment));
 
                 break;
             case Article::class:
             case Playlist::class:
             case TorrentRequest::class:
             case Torrent::class:
-                User::find($this->model->user_id)?->notify(new NewComment($this->model, $comment));
+                User::query()->find($this->model->user_id)?->notify(new NewComment($this->model, $comment));
 
                 break;
         }
 
         // User Tagged Notification
-        $users = User::whereIn('username', $this->taggedUsers())->get();
+        $users = User::query()->whereIn('username', $this->taggedUsers())->get();
         Notification::sendNow($users, new NewCommentTag($this->model, $comment));
 
         if (!$this->model instanceof Ticket) {

--- a/app/Http/Livewire/EmailUpdateSearch.php
+++ b/app/Http/Livewire/EmailUpdateSearch.php
@@ -50,7 +50,7 @@ class EmailUpdateSearch extends Component
             ->with([
                 'user' => fn ($query) => $query->withTrashed()->with('group'),
             ])
-            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
+            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::query()->withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);
     }

--- a/app/Http/Livewire/ForumTopicSearch.php
+++ b/app/Http/Livewire/ForumTopicSearch.php
@@ -60,7 +60,7 @@ class ForumTopicSearch extends Component
     final public function mount(Forum $forum): void
     {
         $this->forum = $forum;
-        $this->subscription = Subscription::where('user_id', '=', auth()->id())->where('forum_id', '=', $forum->id)->first();
+        $this->subscription = Subscription::query()->where('user_id', '=', auth()->id())->where('forum_id', '=', $forum->id)->first();
         $this->state = $this->forum->default_topic_state_filter ?: '';
         $this->permission = ForumPermission::query()
             ->where('group_id', '=', auth()->user()->group_id)

--- a/app/Http/Livewire/InviteLogSearch.php
+++ b/app/Http/Livewire/InviteLogSearch.php
@@ -89,7 +89,8 @@ class InviteLogSearch extends Component
      * @var \Illuminate\Pagination\LengthAwarePaginator<int, Invite>
      */
     final protected \Illuminate\Pagination\LengthAwarePaginator $invites {
-        get => Invite::withTrashed()
+        get => Invite::query()
+            ->withTrashed()
             ->with([
                 'sender'   => fn ($query) => $query->withTrashed()->with('group'),
                 'receiver' => fn ($query) => $query->withTrashed()->with('group'),

--- a/app/Http/Livewire/NotificationSearch.php
+++ b/app/Http/Livewire/NotificationSearch.php
@@ -141,7 +141,7 @@ class NotificationSearch extends Component
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application
     {
         return view('livewire.notification-search', [
-            'user'          => User::with(['group'])->findOrFail(auth()->id()),
+            'user'          => User::query()->with(['group'])->findOrFail(auth()->id()),
             'notifications' => $this->notifications,
         ]);
     }

--- a/app/Http/Livewire/PasskeySearch.php
+++ b/app/Http/Livewire/PasskeySearch.php
@@ -53,7 +53,7 @@ class PasskeySearch extends Component
             ->with([
                 'user' => fn ($query) => $query->withTrashed()->with('group'),
             ])
-            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::withTrashed()->select('id')->where('username', '=', $this->username)))
+            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::query()->withTrashed()->select('id')->where('username', '=', $this->username)))
             ->when($this->passkey, fn ($query) => $query->where('content', 'LIKE', '%'.$this->passkey.'%'))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);

--- a/app/Http/Livewire/PasswordResetHistorySearch.php
+++ b/app/Http/Livewire/PasswordResetHistorySearch.php
@@ -50,7 +50,7 @@ class PasswordResetHistorySearch extends Component
             ->with([
                 'user' => fn ($query) => $query->withTrashed()->with('group'),
             ])
-            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
+            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::query()->withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);
     }

--- a/app/Http/Livewire/PeerSearch.php
+++ b/app/Http/Livewire/PeerSearch.php
@@ -192,7 +192,7 @@ class PeerSearch extends Component
                         'peers.ip',
                         Peer::query()
                             ->select('ip')
-                            ->fromSub(Peer::select('ip', 'user_id')->distinct(), 'distinct_ips')
+                            ->fromSub(Peer::query()->select('ip', 'user_id')->distinct(), 'distinct_ips')
                             ->groupBy('ip')
                             ->havingRaw('COUNT(*) > 1')
                     )
@@ -204,7 +204,7 @@ class PeerSearch extends Component
                         DB::raw('(peers.ip, peers.port)'),
                         Peer::query()
                             ->select('ip', 'port')
-                            ->fromSub(Peer::select('ip', 'port', 'user_id')->distinct(), 'distinct_sockets')
+                            ->fromSub(Peer::query()->select('ip', 'port', 'user_id')->distinct(), 'distinct_sockets')
                             ->groupBy('ip', 'port')
                             ->havingRaw('COUNT(*) > 1')
                     )

--- a/app/Http/Livewire/RsskeySearch.php
+++ b/app/Http/Livewire/RsskeySearch.php
@@ -53,7 +53,7 @@ class RsskeySearch extends Component
             ->with([
                 'user' => fn ($query) => $query->withTrashed()->with('group'),
             ])
-            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
+            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::query()->withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
             ->when($this->rsskey, fn ($query) => $query->where('content', 'LIKE', '%'.$this->rsskey.'%'))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);

--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -348,7 +348,8 @@ class SimilarTorrent extends Component
      * @var \Illuminate\Database\Eloquent\Collection<int, TorrentRequest>
      */
     final protected \Illuminate\Database\Eloquent\Collection $torrentRequests {
-        get => TorrentRequest::with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
+        get => TorrentRequest::query()
+            ->with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
             ->withCount(['comments'])
             ->withExists('claim')
             ->when($this->category->movie_meta, fn ($query) => $query->where('tmdb_movie_id', '=', $this->tmdbId))
@@ -405,7 +406,7 @@ class SimilarTorrent extends Component
             return;
         }
 
-        $torrents = Torrent::whereKey($this->checked)->pluck('name')->toArray();
+        $torrents = Torrent::query()->whereKey($this->checked)->pluck('name')->toArray();
         $names = $torrents;
         $this->dispatch(
             'swal:confirm',
@@ -424,17 +425,17 @@ class SimilarTorrent extends Component
             return;
         }
 
-        $torrents = Torrent::whereKey($this->checked)->get();
+        $torrents = Torrent::query()->whereKey($this->checked)->get();
         $users = [];
         $title = match (true) {
-            $this->category->movie_meta => ($movie = TmdbMovie::find($this->tmdbId))->title.($movie->release_date === null ? '' : ' ('.$movie->release_date->format('Y').')'),
-            $this->category->tv_meta    => ($tv = TmdbTv::find($this->tmdbId))->name.($tv->first_air_date === null ? '' : ' ('.$tv->first_air_date->format('Y').')'),
-            $this->category->game_meta  => ($game = IgdbGame::find($this->igdbId))->name.($game->first_release_date === null ? '' : ' ('.$game->first_release_date->format('Y').')'),
+            $this->category->movie_meta => ($movie = TmdbMovie::query()->find($this->tmdbId))->title.($movie->release_date === null ? '' : ' ('.$movie->release_date->format('Y').')'),
+            $this->category->tv_meta    => ($tv = TmdbTv::query()->find($this->tmdbId))->name.($tv->first_air_date === null ? '' : ' ('.$tv->first_air_date->format('Y').')'),
+            $this->category->game_meta  => ($game = IgdbGame::query()->find($this->igdbId))->name.($game->first_release_date === null ? '' : ' ('.$game->first_release_date->format('Y').')'),
             default                     => $torrents->pluck('name')->join(', '),
         };
 
         foreach ($torrents as $torrent) {
-            foreach (History::where('torrent_id', '=', $torrent->id)->get() as $pm) {
+            foreach (History::query()->where('torrent_id', '=', $torrent->id)->get() as $pm) {
                 if (!\in_array($pm->user_id, $users)) {
                     $users[] = $pm->user_id;
                 }

--- a/app/Http/Livewire/ThankButton.php
+++ b/app/Http/Livewire/ThankButton.php
@@ -47,7 +47,7 @@ class ThankButton extends Component
             return;
         }
 
-        $thank = Thank::create([
+        $thank = Thank::query()->create([
             'user_id'    => $this->user->id,
             'torrent_id' => $this->torrent->id,
         ]);

--- a/app/Http/Livewire/TmdbCollectionSearch.php
+++ b/app/Http/Livewire/TmdbCollectionSearch.php
@@ -39,7 +39,8 @@ class TmdbCollectionSearch extends Component
      * @var \Illuminate\Pagination\LengthAwarePaginator<int, TmdbCollection>
      */
     final protected \Illuminate\Pagination\LengthAwarePaginator $collections {
-        get => TmdbCollection::withCount('movies')
+        get => TmdbCollection::query()
+            ->withCount('movies')
             ->with([
                 'movies' => fn ($query) => $query->withMin('torrents', 'category_id'),
             ])

--- a/app/Http/Livewire/TmdbPersonCredit.php
+++ b/app/Http/Livewire/TmdbPersonCredit.php
@@ -239,7 +239,7 @@ class TmdbPersonCredit extends Component
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application
     {
         return view('livewire.tmdb-person-credit', [
-            'user'                    => User::with(['group'])->findOrFail(auth()->user()->id),
+            'user'                    => User::query()->with(['group'])->findOrFail(auth()->user()->id),
             'personalFreeleech'       => $this->personalFreeleech,
             'medias'                  => $this->medias,
             'directedCount'           => $this->directedCount,

--- a/app/Http/Livewire/TopicPostSearch.php
+++ b/app/Http/Livewire/TopicPostSearch.php
@@ -61,7 +61,7 @@ class TopicPostSearch extends Component
                 ->paginate(25);
 
             if ($lastPost = $posts->getCollection()->last()) {
-                TopicRead::upsert([[
+                TopicRead::query()->upsert([[
                     'topic_id'          => $this->topic->id,
                     'user_id'           => auth()->id(),
                     'last_read_post_id' => $lastPost->id,

--- a/app/Http/Livewire/TorrentRequestSearch.php
+++ b/app/Http/Livewire/TorrentRequestSearch.php
@@ -213,7 +213,7 @@ class TorrentRequestSearch extends Component
                 && $field[-1] === '/'
                 && @preg_match($field, 'Validate regex') !== false;
 
-            return TorrentRequest::with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
+            return TorrentRequest::query()->with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
                 ->withCount(['comments', 'bounties'])
                 ->withExists('claim')
                 ->when(

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -667,8 +667,8 @@ class TorrentSearch extends Component
             $movieIds = $groups->getCollection()->where('meta', '=', 'movie')->pluck('tmdb_movie_id');
             $tvIds = $groups->getCollection()->where('meta', '=', 'tv')->pluck('tmdb_tv_id');
 
-            $movies = TmdbMovie::with('genres', 'directors')->whereIntegerInRaw('id', $movieIds)->get()->keyBy('id');
-            $tv = TmdbTv::with('genres', 'creators')->whereIntegerInRaw('id', $tvIds)->get()->keyBy('id');
+            $movies = TmdbMovie::query()->with('genres', 'directors')->whereIntegerInRaw('id', $movieIds)->get()->keyBy('id');
+            $tv = TmdbTv::query()->with('genres', 'creators')->whereIntegerInRaw('id', $tvIds)->get()->keyBy('id');
 
             if ($isSqlAllowed) {
                 $torrents = Torrent::query()
@@ -789,8 +789,8 @@ class TorrentSearch extends Component
             $movieIds = $groups->getCollection()->where('meta', '=', 'movie')->pluck('tmdb_movie_id');
             $tvIds = $groups->getCollection()->where('meta', '=', 'tv')->pluck('tmdb_tv_id');
 
-            $movies = TmdbMovie::with('genres', 'directors')->whereIntegerInRaw('id', $movieIds)->get()->keyBy('id');
-            $tv = TmdbTv::with('genres', 'creators')->whereIntegerInRaw('id', $tvIds)->get()->keyBy('id');
+            $movies = TmdbMovie::query()->with('genres', 'directors')->whereIntegerInRaw('id', $movieIds)->get()->keyBy('id');
+            $tv = TmdbTv::query()->with('genres', 'creators')->whereIntegerInRaw('id', $tvIds)->get()->keyBy('id');
 
             $groups = $groups->through(function ($group) use ($movies, $tv) {
                 switch ($group->meta) {

--- a/app/Http/Livewire/Trending.php
+++ b/app/Http/Livewire/Trending.php
@@ -265,11 +265,11 @@ class Trending extends Component
         get {
             $metaTypes = [];
 
-            if (Category::where('movie_meta', '=', true)->exists()) {
+            if (Category::query()->where('movie_meta', '=', true)->exists()) {
                 $metaTypes[(string) __('mediahub.movie')] = 'movie_meta';
             }
 
-            if (Category::where('tv_meta', '=', true)->exists()) {
+            if (Category::query()->where('tv_meta', '=', true)->exists()) {
                 $metaTypes[(string) __('mediahub.show')] = 'tv_meta';
             }
 

--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -68,7 +68,7 @@ class UserActive extends Component
 
     final public function mount(int $userId): void
     {
-        $this->user = User::find($userId);
+        $this->user = User::query()->find($userId);
     }
 
     final public function updatingSearch(): void

--- a/app/Http/Livewire/UserBookmarks.php
+++ b/app/Http/Livewire/UserBookmarks.php
@@ -41,7 +41,7 @@ class UserBookmarks extends Component
 
     final public function mount(int $userId): void
     {
-        $this->user = User::find($userId);
+        $this->user = User::query()->find($userId);
     }
 
     /**

--- a/app/Http/Livewire/UserEarnings.php
+++ b/app/Http/Livewire/UserEarnings.php
@@ -51,7 +51,7 @@ class UserEarnings extends Component
 
     final public function mount(int $userId): void
     {
-        $this->user = User::find($userId);
+        $this->user = User::query()->find($userId);
     }
 
     final public function updatingSearch(): void
@@ -76,7 +76,7 @@ class UserEarnings extends Component
                 ->where('torrents.name', 'LIKE', '%'.str_replace(' ', '%', $this->torrentName).'%')
                 ->groupBy('peers.torrent_id');
 
-            foreach (BonEarning::with('conditions')->orderBy('position')->get() as $bonEarning) {
+            foreach (BonEarning::query()->with('conditions')->orderBy('position')->get() as $bonEarning) {
                 // Raw bindings are fine since all database values are either enums or numeric
                 $conditionQuery = '1=1';
 
@@ -118,7 +118,7 @@ class UserEarnings extends Component
      */
     final protected \Illuminate\Database\Query\Builder $query {
         get {
-            $bonEarnings = BonEarning::with('conditions')->orderBy('position')->get();
+            $bonEarnings = BonEarning::query()->with('conditions')->orderBy('position')->get();
 
             $earningsQuery = str_repeat('(', $bonEarnings->count()).'0';
 

--- a/app/Http/Livewire/UserNotes.php
+++ b/app/Http/Livewire/UserNotes.php
@@ -65,7 +65,7 @@ class UserNotes extends Component
 
     final public function mount(): void
     {
-        $this->messages = Note::where('user_id', '=', $this->user->id)->pluck('message', 'id')->toArray();
+        $this->messages = Note::query()->where('user_id', '=', $this->user->id)->pluck('message', 'id')->toArray();
     }
 
     /**
@@ -94,7 +94,7 @@ class UserNotes extends Component
 
         $this->validateOnly('message');
 
-        Note::create([
+        Note::query()->create([
             'user_id'  => $this->user->id,
             'staff_id' => auth()->id(),
             'message'  => $this->message,
@@ -115,7 +115,7 @@ class UserNotes extends Component
         $this->validateOnly('messages');
         $this->validateOnly('messages.*');
 
-        Note::whereKey($id)->update([
+        Note::query()->whereKey($id)->update([
             'staff_id'   => auth()->id(),
             'message'    => $this->messages[$id],
             'updated_at' => now(),
@@ -128,7 +128,7 @@ class UserNotes extends Component
     {
         abort_unless(auth()->user()->group->is_modo, 403);
 
-        Note::findOrFail($id)->delete();
+        Note::query()->findOrFail($id)->delete();
 
         $this->dispatch('success', type: 'success', message: 'Note has successfully been deleted!');
     }

--- a/app/Http/Livewire/UserResurrections.php
+++ b/app/Http/Livewire/UserResurrections.php
@@ -50,7 +50,7 @@ class UserResurrections extends Component
 
     final public function mount(int $userId): void
     {
-        $this->user = User::find($userId);
+        $this->user = User::query()->find($userId);
     }
 
     final public function updatingSearch(): void

--- a/app/Http/Livewire/UserSearch.php
+++ b/app/Http/Livewire/UserSearch.php
@@ -106,7 +106,7 @@ class UserSearch extends Component
      * @var \Illuminate\Support\Collection<int, Group>
      */
     final protected $groups {
-        get => Group::orderBy('position')->get();
+        get => Group::query()->orderBy('position')->get();
     }
 
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application

--- a/app/Http/Livewire/UserTorrents.php
+++ b/app/Http/Livewire/UserTorrents.php
@@ -80,7 +80,7 @@ class UserTorrents extends Component
 
     final public function mount(int $userId): void
     {
-        $this->user = User::find($userId);
+        $this->user = User::query()->find($userId);
     }
 
     final public function updatingSearch(): void

--- a/app/Http/Livewire/UserUnregisteredInfoHashSearch.php
+++ b/app/Http/Livewire/UserUnregisteredInfoHashSearch.php
@@ -45,7 +45,7 @@ class UserUnregisteredInfoHashSearch extends Component
 
     final public function mount(int $userId): void
     {
-        $this->user = User::find($userId);
+        $this->user = User::query()->find($userId);
     }
 
     final public function updatingSearch(): void

--- a/app/Http/Livewire/UserUploads.php
+++ b/app/Http/Livewire/UserUploads.php
@@ -59,7 +59,7 @@ class UserUploads extends Component
 
     final public function mount(int $userId): void
     {
-        $this->user = User::find($userId);
+        $this->user = User::query()->find($userId);
     }
 
     final public function updatingSearch(): void

--- a/app/Http/Livewire/UserWarnings.php
+++ b/app/Http/Livewire/UserWarnings.php
@@ -99,7 +99,7 @@ class UserWarnings extends Component
 
         $this->validate();
 
-        Warning::create([
+        Warning::query()->create([
             'user_id'    => $this->user->id,
             'warned_by'  => auth()->user()->id,
             'torrent_id' => null,
@@ -222,7 +222,7 @@ class UserWarnings extends Component
     {
         abort_unless(auth()->user()->group->is_modo, 403);
 
-        Warning::withTrashed()->findOrFail($id)->restore();
+        Warning::query()->withTrashed()->findOrFail($id)->restore();
 
         $this->dispatch('success', type: 'success', message: 'Warning was successfully restored');
     }

--- a/app/Http/Middleware/CheckIfBanned.php
+++ b/app/Http/Middleware/CheckIfBanned.php
@@ -31,7 +31,7 @@ class CheckIfBanned
     {
         $user = $request->user();
         // Redis returns ints as numeric strings!
-        $bannedGroupId = (int) cache()->rememberForever('group:banned:id', fn () => Group::where('slug', '=', 'banned')->soleValue('id'));
+        $bannedGroupId = (int) cache()->rememberForever('group:banned:id', fn () => Group::query()->where('slug', '=', 'banned')->soleValue('id'));
 
         if ($user && $user->group_id === $bannedGroupId) {
             if ($request->is('api/*')) {

--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -61,7 +61,7 @@ class StoreTorrentRequest extends FormRequest
     public function rules(Request $request): array
     {
         $user = $request->user()->loadExists('internals');
-        $category = Category::findOrFail($request->integer('category_id'));
+        $category = Category::query()->findOrFail($request->integer('category_id'));
 
         $mustBeNull = function (string $attribute, mixed $value, callable $fail): void {
             if ($value !== null) {
@@ -98,7 +98,7 @@ class StoreTorrentRequest extends FormRequest
                         }
                     }
 
-                    $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->where('info_hash', '=', Bencode::get_infohash($decodedTorrent))->first();
+                    $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->where('info_hash', '=', Bencode::get_infohash($decodedTorrent))->first();
 
                     if ($torrent !== null) {
                         match ($torrent->status) {

--- a/app/Http/Requests/StoreTorrentRequestRequest.php
+++ b/app/Http/Requests/StoreTorrentRequestRequest.php
@@ -53,7 +53,7 @@ class StoreTorrentRequestRequest extends FormRequest
      */
     public function rules(Request $request): array
     {
-        $category = Category::findOrFail($request->integer('category_id'));
+        $category = Category::query()->findOrFail($request->integer('category_id'));
 
         $mustBeNull = function (string $attribute, mixed $value, callable $fail): void {
             if ($value !== null) {

--- a/app/Http/Requests/UpdateTorrentRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequest.php
@@ -55,12 +55,12 @@ class UpdateTorrentRequest extends FormRequest
      */
     public function rules(Request $request): array
     {
-        $category = Category::findOrFail($request->integer('category_id'));
+        $category = Category::query()->findOrFail($request->integer('category_id'));
 
         /** @var string $torrentId */
         $torrentId = $request->route('id');
 
-        $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->find($torrentId);
+        $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->find($torrentId);
         $user = $request->user()->load('group')->loadExists('internals');
 
         $mustBeNull = function (string $attribute, mixed $value, callable $fail): void {

--- a/app/Http/Requests/UpdateTorrentRequestRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequestRequest.php
@@ -53,7 +53,7 @@ class UpdateTorrentRequestRequest extends FormRequest
      */
     public function rules(Request $request): array
     {
-        $category = Category::findOrFail($request->integer('category_id'));
+        $category = Category::query()->findOrFail($request->integer('category_id'));
 
         $mustBeNull = function (string $attribute, mixed $value, callable $fail): void {
             if ($value !== null) {

--- a/app/Http/Requests/User/StorePostTipRequest.php
+++ b/app/Http/Requests/User/StorePostTipRequest.php
@@ -38,7 +38,7 @@ class StorePostTipRequest extends FormRequest
                 'required',
                 function ($attribute, $value, $fail): void {
                     if (
-                        Post::whereKey($value)->whereNotIn(
+                        Post::query()->whereKey($value)->whereNotIn(
                             'topic_id',
                             Topic::query()
                                 ->whereRelation(
@@ -94,7 +94,8 @@ class StorePostTipRequest extends FormRequest
     {
         $this->merge([
             'sender_id'    => auth()->id(),
-            'recipient_id' => Post::whereKey($this->post_id)
+            'recipient_id' => Post::query()
+                ->whereKey($this->post_id)
                 ->whereNotIn(
                     'topic_id',
                     Topic::query()

--- a/app/Http/Requests/User/StoreTorrentTipRequest.php
+++ b/app/Http/Requests/User/StoreTorrentTipRequest.php
@@ -76,7 +76,7 @@ class StoreTorrentTipRequest extends FormRequest
     {
         $this->merge([
             'sender_id'    => auth()->id(),
-            'recipient_id' => Torrent::whereKey($this->torrent_id)->value('user_id'),
+            'recipient_id' => Torrent::query()->whereKey($this->torrent_id)->value('user_id'),
         ]);
     }
 }

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -113,7 +113,7 @@ class ProcessAnnounce implements ShouldQueue
             $this->torrent->id,
             cache()->rememberForever(
                 'featured-torrent-ids',
-                fn () => FeaturedTorrent::select('torrent_id')->pluck('torrent_id')->toArray(),
+                fn () => FeaturedTorrent::query()->select('torrent_id')->pluck('torrent_id')->toArray(),
             ),
             true
         );

--- a/app/Jobs/ProcessMassPM.php
+++ b/app/Jobs/ProcessMassPM.php
@@ -43,11 +43,11 @@ class ProcessMassPM implements ShouldQueue
      */
     public function handle(): void
     {
-        $conversation = Conversation::create(['subject' => $this->subject]);
+        $conversation = Conversation::query()->create(['subject' => $this->subject]);
 
         $conversation->users()->sync([$this->senderId => ['read' => true], $this->receiverId]);
 
-        PrivateMessage::create([
+        PrivateMessage::query()->create([
             'conversation_id' => $conversation->id,
             'sender_id'       => $this->senderId,
             'message'         => $this->message

--- a/app/Jobs/ProcessMovieJob.php
+++ b/app/Jobs/ProcessMovieJob.php
@@ -81,11 +81,11 @@ class ProcessMovieJob implements ShouldQueue
             return;
         }
 
-        $movie = TmdbMovie::updateOrCreate(['id' => $this->id], $movieScraper->getMovie());
+        $movie = TmdbMovie::query()->updateOrCreate(['id' => $this->id], $movieScraper->getMovie());
 
         // Genres
 
-        TmdbGenre::upsert($movieScraper->getGenres(), 'id');
+        TmdbGenre::query()->upsert($movieScraper->getGenres(), 'id');
         $movie->genres()->sync(array_unique(array_column($movieScraper->getGenres(), 'id')));
 
         // Companies
@@ -96,7 +96,7 @@ class ProcessMovieJob implements ShouldQueue
             $companies[] = (new Client\Company($company['id']))->getCompany();
         }
 
-        TmdbCompany::upsert($companies, 'id');
+        TmdbCompany::query()->upsert($companies, 'id');
         $movie->companies()->sync(array_unique(array_column($companies, 'id')));
 
         // Collection
@@ -104,7 +104,7 @@ class ProcessMovieJob implements ShouldQueue
         if ($movieScraper->data['belongs_to_collection'] !== null) {
             $collection = (new Client\Collection($movieScraper->data['belongs_to_collection']['id']))->getCollection();
 
-            TmdbCollection::upsert($collection, 'id');
+            TmdbCollection::query()->upsert($collection, 'id');
             $movie->collections()->sync([$collection['id']]);
         }
 
@@ -128,14 +128,14 @@ class ProcessMovieJob implements ShouldQueue
             $cache[$cacheKey] = now();
         }
 
-        TmdbPerson::upsert($people, 'id');
+        TmdbPerson::query()->upsert($people, 'id');
 
         if ($cache !== []) {
             cache()->put($cache, 8 * 3600);
         }
 
-        TmdbCredit::where('tmdb_movie_id', '=', $this->id)->delete();
-        TmdbCredit::upsert($credits, ['tmdb_person_id', 'tmdb_movie_id', 'tmdb_tv_id', 'occupation_id', 'character']);
+        TmdbCredit::query()->where('tmdb_movie_id', '=', $this->id)->delete();
+        TmdbCredit::query()->upsert($credits, ['tmdb_person_id', 'tmdb_movie_id', 'tmdb_tv_id', 'occupation_id', 'character']);
 
         // Recommendations
 

--- a/app/Jobs/ProcessTvJob.php
+++ b/app/Jobs/ProcessTvJob.php
@@ -97,7 +97,7 @@ class ProcessTvJob implements ShouldQueue
             return;
         }
 
-        $tv = TmdbTv::updateOrCreate(['id' => $this->id], $tvScraper->getTv());
+        $tv = TmdbTv::query()->updateOrCreate(['id' => $this->id], $tvScraper->getTv());
 
         // Companies
 
@@ -107,7 +107,7 @@ class ProcessTvJob implements ShouldQueue
             $companies[] = (new Client\Company($company['id']))->getCompany();
         }
 
-        TmdbCompany::upsert($companies, 'id');
+        TmdbCompany::query()->upsert($companies, 'id');
         $tv->companies()->sync(array_unique(array_column($companies, 'id')));
 
         // Networks
@@ -118,12 +118,12 @@ class ProcessTvJob implements ShouldQueue
             $networks[] = (new Client\Network($network['id']))->getNetwork();
         }
 
-        TmdbNetwork::upsert($networks, 'id');
+        TmdbNetwork::query()->upsert($networks, 'id');
         $tv->networks()->sync(array_unique(array_column($networks, 'id')));
 
         // Genres
 
-        TmdbGenre::upsert($tvScraper->getGenres(), 'id');
+        TmdbGenre::query()->upsert($tvScraper->getGenres(), 'id');
         $tv->genres()->sync(array_unique(array_column($tvScraper->getGenres(), 'id')));
 
         // People
@@ -147,15 +147,15 @@ class ProcessTvJob implements ShouldQueue
         }
 
         foreach (collect($people)->chunk(intdiv(65_000, 13)) as $people) {
-            TmdbPerson::upsert($people->toArray(), 'id');
+            TmdbPerson::query()->upsert($people->toArray(), 'id');
         }
 
         if ($cache !== []) {
             cache()->put($cache, 8 * 3600);
         }
 
-        TmdbCredit::where('tmdb_tv_id', '=', $this->id)->delete();
-        TmdbCredit::upsert($credits, ['tmdb_person_id', 'tmdb_movie_id', 'tmdb_tv_id', 'occupation_id', 'character']);
+        TmdbCredit::query()->where('tmdb_tv_id', '=', $this->id)->delete();
+        TmdbCredit::query()->upsert($credits, ['tmdb_person_id', 'tmdb_movie_id', 'tmdb_tv_id', 'occupation_id', 'character']);
 
         // Recommendations
 

--- a/app/Listeners/AchievementUnlocked.php
+++ b/app/Listeners/AchievementUnlocked.php
@@ -36,7 +36,7 @@ class AchievementUnlocked
     public function handle(Unlocked $unlocked): void
     {
         // There's an AchievementProgress instance located on $event->progress
-        $user = User::findOrFail($unlocked->progress->achiever_id);
+        $user = User::query()->findOrFail($unlocked->progress->achiever_id);
 
         if (auth()->id() === $user->id) {
             Session::flash('achievement', $unlocked->progress->details->name);

--- a/app/Notifications/Channels/SystemNotificationChannel.php
+++ b/app/Notifications/Channels/SystemNotificationChannel.php
@@ -30,11 +30,11 @@ class SystemNotificationChannel
     {
         $data = $notification->toSystemNotification($notifiable);
 
-        $conversation = Conversation::create(['subject' => $data['subject']]);
+        $conversation = Conversation::query()->create(['subject' => $data['subject']]);
 
         $conversation->users()->sync([User::SYSTEM_USER_ID => ['read' => true], $notifiable->id]);
 
-        PrivateMessage::create([
+        PrivateMessage::query()->create([
             'conversation_id' => $conversation->id,
             'sender_id'       => User::SYSTEM_USER_ID,
             'message'         => $data['message'],

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -178,7 +178,7 @@ class FortifyServiceProvider extends ServiceProvider
                 defer(function () use ($user, $request): void {
                     $ip = $request->ip();
 
-                    FailedLoginAttempt::create([
+                    FailedLoginAttempt::query()->create([
                         'user_id'    => $user->id,
                         'username'   => $request->username,
                         'ip_address' => $ip,
@@ -208,7 +208,7 @@ class FortifyServiceProvider extends ServiceProvider
                         ->count();
 
                     if ($ipAttemptCount >= config('other.auth.brute-force.max-attempts')) {
-                        BlockedIp::upsert([[
+                        BlockedIp::query()->upsert([[
                             'ip_address' => $ip,
                             'user_id'    => User::SYSTEM_USER_ID,
                             'reason'     => 'Brute-force attempt: 6 failed attempts in last '.config('other.auth.brute-force.interval').' s',

--- a/app/Repositories/ChatRepository.php
+++ b/app/Repositories/ChatRepository.php
@@ -28,7 +28,7 @@ class ChatRepository
 {
     public function message(int $userId, int $roomId, string $message, ?int $receiver = null, ?int $bot = null): Message
     {
-        $message = Message::create([
+        $message = Message::query()->create([
             'user_id'     => $userId,
             'chatroom_id' => $roomId,
             'message'     => $message,
@@ -45,7 +45,7 @@ class ChatRepository
 
     public function botMessage(int $botId, int $roomId, string $message, ?int $receiver = null): void
     {
-        $save = Message::create([
+        $save = Message::query()->create([
             'bot_id'      => $botId,
             'user_id'     => 1,
             'chatroom_id' => 0,
@@ -53,7 +53,7 @@ class ChatRepository
             'receiver_id' => $receiver,
         ]);
 
-        $message = Message::with([
+        $message = Message::query()->with([
             'bot',
             'user'     => ['group', 'chatStatus'],
             'receiver' => ['group', 'chatStatus'],
@@ -66,7 +66,7 @@ class ChatRepository
 
     public function privateMessage(int $userId, int $roomId, string $message, ?int $receiver = null, ?int $bot = null, ?bool $ignore = null): Message
     {
-        $save = Message::create([
+        $save = Message::query()->create([
             'user_id'     => $userId,
             'chatroom_id' => 0,
             'message'     => $message,
@@ -191,7 +191,7 @@ class ChatRepository
                 $message = $messages->last();
                 echo $message['id']."\n";
 
-                $message = Message::find($message->id);
+                $message = Message::query()->find($message->id);
 
                 if ($message->receiver_id === null) {
                     $message->delete();
@@ -205,7 +205,7 @@ class ChatRepository
         if ($bot) {
             $this->message(User::SYSTEM_USER_ID, $this->systemChatroom(), $message, null, $bot);
         } else {
-            $systemBotId = Bot::where('command', 'systembot')->first()->id;
+            $systemBotId = Bot::query()->where('command', 'systembot')->first()->id;
 
             $this->message(User::SYSTEM_USER_ID, $this->systemChatroom(), $message, null, $systemBotId);
         }
@@ -221,12 +221,12 @@ class ChatRepository
             if ($room instanceof Chatroom) {
                 $room = $room->id;
             } elseif (\is_int($room)) {
-                $room = Chatroom::findOrFail($room)->id;
+                $room = Chatroom::query()->findOrFail($room)->id;
             } else {
                 $room = Chatroom::query()->where('name', '=', $room)->first()->id;
             }
         } elseif (\is_int($config)) {
-            $room = Chatroom::findOrFail($config)->id;
+            $room = Chatroom::query()->findOrFail($config)->id;
         } else {
             $room = Chatroom::query()->where('name', '=', $config)->first()->id;
         }

--- a/app/View/Composers/FooterComposer.php
+++ b/app/View/Composers/FooterComposer.php
@@ -15,7 +15,7 @@ class FooterComposer
     public function compose(View $view): void
     {
         $view->with([
-            'pages' => cache()->flexible('cached-pages', [3600, 3600 * 2], fn () => Page::select(['id', 'name', 'created_at'])->take(6)->get())
+            'pages' => cache()->flexible('cached-pages', [3600, 3600 * 2], fn () => Page::query()->select(['id', 'name', 'created_at'])->take(6)->get())
         ]);
     }
 }

--- a/app/View/Composers/TopNavComposer.php
+++ b/app/View/Composers/TopNavComposer.php
@@ -28,7 +28,7 @@ class TopNavComposer
             'pages' => cache()->flexible(
                 'cached-pages',
                 [3600, 3600 * 2],
-                fn () => Page::select(['id', 'name', 'created_at'])->take(6)->get()
+                fn () => Page::query()->select(['id', 'name', 'created_at'])->take(6)->get()
             ),
             'hasUnreadTicket' => Ticket::query()
                 ->when(

--- a/database/migrations/2023_06_14_102346_delete_user_activations.php
+++ b/database/migrations/2023_06_14_102346_delete_user_activations.php
@@ -32,7 +32,7 @@ return new class () extends Migration {
             $table->timestamp('email_verified_at')->nullable();
         });
 
-        $users = User::where('group_id', '!=', UserGroup::VALIDATING->value)->get();
+        $users = User::query()->where('group_id', '!=', UserGroup::VALIDATING->value)->get();
 
         foreach ($users as $user) {
             $user->markEmailAsVerified();

--- a/database/seeders/AchievementDetailSeeder.php
+++ b/database/seeders/AchievementDetailSeeder.php
@@ -24,7 +24,7 @@ class AchievementDetailSeeder extends Seeder
 {
     public function run(): void
     {
-        AchievementDetail::upsert([
+        AchievementDetail::query()->upsert([
             [
                 'id'          => 2,
                 'name'        => 'FirstComment',

--- a/database/seeders/ArticleSeeder.php
+++ b/database/seeders/ArticleSeeder.php
@@ -24,7 +24,7 @@ class ArticleSeeder extends Seeder
 {
     public function run(): void
     {
-        Article::upsert([
+        Article::query()->upsert([
             [
                 'id'         => 1,
                 'title'      => 'Welcome To '.config('other.title').' .',

--- a/database/seeders/BonEarningConditionSeeder.php
+++ b/database/seeders/BonEarningConditionSeeder.php
@@ -23,7 +23,7 @@ class BonEarningConditionSeeder extends Seeder
 {
     public function run(): void
     {
-        BonEarningCondition::upsert([
+        BonEarningCondition::query()->upsert([
             [
                 'id'             => 1,
                 'bon_earning_id' => 1,

--- a/database/seeders/BonEarningSeeder.php
+++ b/database/seeders/BonEarningSeeder.php
@@ -23,7 +23,7 @@ class BonEarningSeeder extends Seeder
 {
     public function run(): void
     {
-        BonEarning::upsert([
+        BonEarning::query()->upsert([
             [
                 'id'          => 1,
                 'position'    => 1,

--- a/database/seeders/BonExchangeSeeder.php
+++ b/database/seeders/BonExchangeSeeder.php
@@ -24,7 +24,7 @@ class BonExchangeSeeder extends Seeder
 {
     public function run(ByteUnits $byteUnits): void
     {
-        BonExchange::upsert([
+        BonExchange::query()->upsert([
             [
                 'id'                 => 1,
                 'description'        => '2 GiB Upload',

--- a/database/seeders/BotSeeder.php
+++ b/database/seeders/BotSeeder.php
@@ -24,7 +24,7 @@ class BotSeeder extends Seeder
 {
     public function run(): void
     {
-        Bot::upsert([
+        Bot::query()->upsert([
             [
                 'name'     => 'SystemBot',
                 'emoji'    => '1f916',

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -23,7 +23,7 @@ class CategorySeeder extends Seeder
 {
     public function run(): void
     {
-        Category::upsert([
+        Category::query()->upsert([
             [
                 'id'         => 1,
                 'name'       => 'Movies',

--- a/database/seeders/ChatStatusSeeder.php
+++ b/database/seeders/ChatStatusSeeder.php
@@ -24,7 +24,7 @@ class ChatStatusSeeder extends Seeder
 {
     public function run(): void
     {
-        ChatStatus::upsert([
+        ChatStatus::query()->upsert([
             [
                 'name'  => 'Online',
                 'color' => '#2ECC40',

--- a/database/seeders/ChatroomSeeder.php
+++ b/database/seeders/ChatroomSeeder.php
@@ -24,7 +24,7 @@ class ChatroomSeeder extends Seeder
 {
     public function run(): void
     {
-        Chatroom::upsert([
+        Chatroom::query()->upsert([
             [
                 'name' => 'General',
             ],

--- a/database/seeders/DistributorSeeder.php
+++ b/database/seeders/DistributorSeeder.php
@@ -23,7 +23,7 @@ class DistributorSeeder extends Seeder
 {
     public function run(): void
     {
-        Distributor::upsert([
+        Distributor::query()->upsert([
             [
                 'id'   => 1,
                 'name' => '01 Distribution',

--- a/database/seeders/ForumPermissionSeeder.php
+++ b/database/seeders/ForumPermissionSeeder.php
@@ -23,7 +23,7 @@ class ForumPermissionSeeder extends Seeder
 {
     public function run(): void
     {
-        ForumPermission::upsert([
+        ForumPermission::query()->upsert([
             [
                 'id'          => 1,
                 'forum_id'    => 1,

--- a/database/seeders/ForumSeeder.php
+++ b/database/seeders/ForumSeeder.php
@@ -25,7 +25,7 @@ class ForumSeeder extends Seeder
 {
     public function run(): void
     {
-        ForumCategory::upsert([
+        ForumCategory::query()->upsert([
             [
                 'id'          => 1,
                 'position'    => 1,
@@ -37,7 +37,7 @@ class ForumSeeder extends Seeder
             ],
         ], ['id'], []);
 
-        Forum::upsert([
+        Forum::query()->upsert([
             [
                 'id'                   => 1,
                 'position'             => 2,

--- a/database/seeders/GroupSeeder.php
+++ b/database/seeders/GroupSeeder.php
@@ -23,7 +23,7 @@ class GroupSeeder extends Seeder
 {
     public function run(): void
     {
-        Group::upsert([
+        Group::query()->upsert([
             [
                 'name'             => 'Validating',
                 'slug'             => 'validating',

--- a/database/seeders/MediaLanguageSeeder.php
+++ b/database/seeders/MediaLanguageSeeder.php
@@ -24,7 +24,7 @@ class MediaLanguageSeeder extends Seeder
 {
     public function run(): void
     {
-        MediaLanguage::upsert([
+        MediaLanguage::query()->upsert([
             [
                 'code' => 'aa',
                 'name' => 'Afar',

--- a/database/seeders/OccupationSeeder.php
+++ b/database/seeders/OccupationSeeder.php
@@ -23,7 +23,7 @@ class OccupationSeeder extends Seeder
 {
     public function run(): void
     {
-        Occupation::upsert([
+        Occupation::query()->upsert([
             [
                 'id'       => 1,
                 'position' => 1,

--- a/database/seeders/PageSeeder.php
+++ b/database/seeders/PageSeeder.php
@@ -26,7 +26,7 @@ class PageSeeder extends Seeder
 {
     public function run(): void
     {
-        Page::upsert([
+        Page::query()->upsert([
             [
                 'id'      => 1,
                 'name'    => 'Rules',

--- a/database/seeders/RegionSeeder.php
+++ b/database/seeders/RegionSeeder.php
@@ -23,7 +23,7 @@ class RegionSeeder extends Seeder
 {
     public function run(): void
     {
-        Region::upsert([
+        Region::query()->upsert([
             [
                 'id'       => 1,
                 'name'     => 'AFG',

--- a/database/seeders/ResolutionSeeder.php
+++ b/database/seeders/ResolutionSeeder.php
@@ -23,7 +23,7 @@ class ResolutionSeeder extends Seeder
 {
     public function run(): void
     {
-        Resolution::upsert([
+        Resolution::query()->upsert([
             [
                 'id'       => 1,
                 'name'     => '4320p',

--- a/database/seeders/TicketCategorySeeder.php
+++ b/database/seeders/TicketCategorySeeder.php
@@ -24,7 +24,7 @@ class TicketCategorySeeder extends Seeder
 {
     final public function run(): void
     {
-        TicketCategory::upsert([
+        TicketCategory::query()->upsert([
             [
                 'name'     => 'Accounts',
                 'position' => 0,

--- a/database/seeders/TicketPrioritySeeder.php
+++ b/database/seeders/TicketPrioritySeeder.php
@@ -24,7 +24,7 @@ class TicketPrioritySeeder extends Seeder
 {
     final public function run(): void
     {
-        TicketPriority::upsert([
+        TicketPriority::query()->upsert([
             [
                 'name'     => 'Low',
                 'position' => 0,

--- a/database/seeders/TypeSeeder.php
+++ b/database/seeders/TypeSeeder.php
@@ -23,7 +23,7 @@ class TypeSeeder extends Seeder
 {
     public function run(): void
     {
-        Type::upsert([
+        Type::query()->upsert([
             [
                 'id'       => 1,
                 'name'     => 'Full Disc',

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -26,7 +26,7 @@ class UserSeeder extends Seeder
 {
     public function run(): void
     {
-        User::upsert([
+        User::query()->upsert([
             [
                 'id'                => User::SYSTEM_USER_ID,
                 'username'          => 'System',

--- a/resources/views/Staff/bon-earning/index.blade.php
+++ b/resources/views/Staff/bon-earning/index.blade.php
@@ -125,7 +125,7 @@
                                                     'age' => \App\Helpers\StringHelper::timeElapsed($condition->operand2),
                                                     'size' => \App\Helpers\StringHelper::formatBytes($condition->operand2),
                                                     'seedtime' => \App\Helpers\StringHelper::timeElapsed($condition->operand2),
-                                                    'type_id' => \App\Models\Type::find($condition->operand2)?->name ?? __('common.unknown'),
+                                                    'type_id' => \App\Models\Type::query()->find($condition->operand2)?->name ?? __('common.unknown'),
                                                     default => preg_replace('/(\.\d+?)0+$/', '$1', $condition->operand2),
                                                 }
                                             }}

--- a/resources/views/blocks/chat.blade.php
+++ b/resources/views/blocks/chat.blade.php
@@ -1,5 +1,7 @@
 @php
-    $user = App\Models\User::with(['chatroom', 'group', 'settings'])->find(auth()->id());
+    $user = App\Models\User::query()
+    ->with(['chatroom', 'group', 'settings'])
+    ->find(auth()->id());
 @endphp
 
 <section

--- a/resources/views/livewire/subtitle-search.blade.php
+++ b/resources/views/livewire/subtitle-search.blade.php
@@ -131,7 +131,7 @@
                             x-bind:class="language === '' ? 'form__select--default' : ''"
                         >
                             <option hidden disabled selected value=""></option>
-                            @foreach (App\Models\MediaLanguage::orderBy('name')->get() as $media_language)
+                            @foreach (App\Models\MediaLanguage::query()->orderBy('name')->get() as $media_language)
                                 <option class="form__option" value="{{ $media_language->id }}">
                                     {{ $media_language->name }} ({{ $media_language->code }})
                                 </option>
@@ -145,7 +145,7 @@
                         <fieldset class="form__fieldset">
                             <legend class="form__legend">{{ __('common.category') }}</legend>
                             <div class="form__fieldset-checkbox-container--shrink">
-                                @foreach (App\Models\Category::orderBy('position')->get() as $category)
+                                @foreach (App\Models\Category::query()->orderBy('position')->get() as $category)
                                     <p class="form__group">
                                         <label class="form__label">
                                             <input

--- a/resources/views/livewire/tmdb-person-search.blade.php
+++ b/resources/views/livewire/tmdb-person-search.blade.php
@@ -78,7 +78,7 @@
                         <fieldset class="form__fieldset">
                             <legend class="form__legend">{{ __('torrent.category') }}</legend>
                             <div class="form__fieldset-checkbox-container">
-                                @foreach (App\Models\Occupation::select(['id', 'name'])->orderBy('position')->get() as $occupation)
+                                @foreach (App\Models\Occupation::query()->select(['id', 'name'])->orderBy('position')->get() as $occupation)
                                     <p class="form__group">
                                         <label class="form__label">
                                             <input

--- a/resources/views/livewire/user-earnings.blade.php
+++ b/resources/views/livewire/user-earnings.blade.php
@@ -187,7 +187,7 @@
                         @foreach ($torrents as $torrent)
                             <tr>
                                 <td class="user-earnings__type">
-                                    {{ $types[$torrent->type_id] ??= \App\Models\Type::find($torrent->type_id)?->name ?? __('common.unknown') }}
+                                    {{ $types[$torrent->type_id] ??= \App\Models\Type::query()->find($torrent->type_id)?->name ?? __('common.unknown') }}
                                 </td>
                                 <td>
                                     <a

--- a/resources/views/livewire/user-resurrections.blade.php
+++ b/resources/views/livewire/user-resurrections.blade.php
@@ -184,7 +184,8 @@
                             </td>
                             <td class="user-resurrections__current-seedtime">
                                 @php
-                                    $history = App\Models\History::select(['seedtime'])
+                                    $history = App\Models\History::query()
+                                        ->select(['seedtime'])
                                         ->where('user_id', '=', $user->id)
                                         ->where('torrent_id', '=', $resurrection->torrent_id)
                                         ->first();

--- a/resources/views/stats/languages/languages.blade.php
+++ b/resources/views/stats/languages/languages.blade.php
@@ -27,7 +27,7 @@
                         <td>{{ $name }}</td>
                         <td>
                             Used by
-                            {{ App\Models\UserSetting::where('locale', '=', $code)->count() }}
+                            {{ App\Models\UserSetting::query()->where('locale', '=', $code)->count() }}
                             Users
                         </td>
                     </tr>

--- a/resources/views/ticket/show.blade.php
+++ b/resources/views/ticket/show.blade.php
@@ -198,7 +198,7 @@
                             x-on:change="$root.submit()"
                         >
                             <option hidden disabled selected value=""></option>
-                            @foreach (App\Models\User::select(['id', 'username'])->whereIn('group_id', App\Models\Group::where('is_modo', 1)->whereNotIn('id', [9])->pluck('id')->toArray())->get() as $user)
+                            @foreach (App\Models\User::query()->select(['id', 'username'])->whereIn('group_id', App\Models\Group::query()->where('is_modo', 1)->whereNotIn('id', [9])->pluck('id')->toArray())->get() as $user)
                                 <option
                                     value="{{ $user->id }}"
                                     @selected($user->id === $ticket->staff_id)

--- a/resources/views/torrent/external-tracker.blade.php
+++ b/resources/views/torrent/external-tracker.blade.php
@@ -89,7 +89,7 @@
                         @foreach ($externalTorrent['peers'] ?? [] as $peerId => $peer)
                             <tr>
                                 <td>
-                                    @if (null !== ($user = \App\Models\User::find($peer['user_id'])))
+                                    @if (null !== ($user = \App\Models\User::query()->find($peer['user_id'])))
                                         @if ($torrent === null)
                                             <x-user-tag :user="$user" :anon="true" />
                                         @else

--- a/resources/views/torrent/partials/subtitles.blade.php
+++ b/resources/views/torrent/partials/subtitles.blade.php
@@ -102,7 +102,7 @@
                                                                 {{ $subtitle->language->name }}
                                                                 ({{ __('torrent.current') }})
                                                             </option>
-                                                            @foreach (App\Models\MediaLanguage::orderBy('name')->get() as $media_language)
+                                                            @foreach (App\Models\MediaLanguage::query()->orderBy('name')->get() as $media_language)
                                                                 <option
                                                                     value="{{ $media_language->id }}"
                                                                 >

--- a/resources/views/user/profile/partials/bans.blade.php
+++ b/resources/views/user/profile/partials/bans.blade.php
@@ -36,7 +36,7 @@
                                     <option value="{{ $user->group->id }}">
                                         {{ $user->group->name }} (Default)
                                     </option>
-                                    @foreach (App\Models\Group::orderByDesc('position')->get() as $group)
+                                    @foreach (App\Models\Group::query()->orderByDesc('position')->get() as $group)
                                         <option value="{{ $group->id }}">
                                             {{ $group->name }}
                                         </option>

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -905,7 +905,7 @@
                         <div class="key-value__group">
                             <dt>{{ __('common.group') }}</dt>
                             <dd>
-                                @if (null !== ($group = \App\Models\Group::find($externalUser['group_id'])))
+                                @if (null !== ($group = \App\Models\Group::query()->find($externalUser['group_id'])))
                                     <span class="user-tag">
                                         <span
                                             class="user-tag__link {{ $group->icon }}"

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -28,17 +28,18 @@ use Illuminate\Support\Facades\Broadcast;
  * |
  */
 
-Broadcast::channel('chatroom.{id}', fn ($user, $id) => User::select([
-    'id',
-    'username',
-    'group_id',
-    'image',
-    'chatroom_id',
-    'chat_status_id',
-    'is_lifetime',
-    'is_donor',
-    'icon'
-])
+Broadcast::channel('chatroom.{id}', fn ($user, $id) => User::query()
+    ->select([
+        'id',
+        'username',
+        'group_id',
+        'image',
+        'chatroom_id',
+        'chat_status_id',
+        'is_lifetime',
+        'is_donor',
+        'icon'
+    ])
     ->with(['chatStatus:id,color', 'chatroom:id,name', 'group:id,color,effect,icon'])
     ->find($user->id));
 Broadcast::channel('chatter.{id}', fn ($user, $id) => $user->id == $id);

--- a/tests/Feature/Actions/Fortify/CreateNewUserTest.php
+++ b/tests/Feature/Actions/Fortify/CreateNewUserTest.php
@@ -68,7 +68,7 @@ test('user registration is available when enabled', function (): void {
     Event::assertDispatched(Registered::class);
 
     // Email verification for newly registered user
-    $user = User::where('email', $email)->first();
+    $user = User::query()->where('email', $email)->first();
     $verificationUrl = URL::temporarySignedRoute(
         'verification.verify',
         now()->addMinutes(5),
@@ -117,7 +117,7 @@ test('user can register using invite code', function (): void {
     Event::assertDispatched(Registered::class);
 
     // Email verification for newly registered user
-    $user = User::where('email', $email)->first();
+    $user = User::query()->where('email', $email)->first();
     $verificationUrl = URL::temporarySignedRoute(
         'verification.verify',
         now()->addMinutes(5),
@@ -195,7 +195,7 @@ test('user cannot confirm email using invalid hash', function (): void {
     Event::assertDispatched(Registered::class);
 
     // Email verification for newly registered user with invalid email
-    $user = User::where('email', $email)->first();
+    $user = User::query()->where('email', $email)->first();
     $verificationUrl = URL::temporarySignedRoute(
         'verification.verify',
         now()->addMinutes(5),
@@ -254,7 +254,7 @@ test('user can register using invite code with internal note assigned', function
     Event::assertDispatched(Registered::class);
 
     // Email verification for newly registered user
-    $user = User::where('email', $email)->first();
+    $user = User::query()->where('email', $email)->first();
     $verificationUrl = URL::temporarySignedRoute(
         'verification.verify',
         now()->addMinutes(5),

--- a/tests/Feature/Http/Controllers/Staff/MassActionControllerTest.php
+++ b/tests/Feature/Http/Controllers/Staff/MassActionControllerTest.php
@@ -22,12 +22,12 @@ test('update returns an ok response', function (): void {
     $this->seed(GroupSeeder::class);
     User::factory()->times(3)->create([
         'email_verified_at' => null,
-        'group_id'          => Group::firstWhere('slug', 'validating')
+        'group_id'          => Group::query()->firstWhere('slug', 'validating')
     ]);
 
     $this->get(route('staff.mass-actions.validate'))
         ->assertRedirect(route('staff.dashboard.index'));
 
-    expect(User::where('email_verified_at', '=', null)->count())
+    expect(User::query()->where('email_verified_at', '=', null)->count())
         ->toBe(0, 'All users should be validated');
 });

--- a/tests/Feature/Notifications/NewCommentArticleNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentArticleNotificationTest.php
@@ -73,7 +73,7 @@ test('user comments on article creates a notification for staff', function (): v
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$staff],
@@ -119,7 +119,7 @@ test('staff comments on own article does not create a notification for staff', f
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });
@@ -168,7 +168,7 @@ test('user comments on article does not a notification for staff user when all n
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });

--- a/tests/Feature/Notifications/NewCommentArticleTagNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentArticleTagNotificationTest.php
@@ -72,7 +72,7 @@ test('user tags user on article creates a notification for tagged user', functio
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$user],
@@ -128,7 +128,7 @@ test('staff tags user on article creates a notification for tagged user even whe
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$user],
@@ -183,7 +183,7 @@ test('user tags user on article creates a notification for tagged user when ment
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$user],
@@ -236,7 +236,7 @@ test('user tags user on article does not create a notification for tagged user w
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$user],
@@ -287,7 +287,7 @@ test('user tags user on article does not create a notification for tagged user w
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$user],
@@ -339,7 +339,7 @@ test('user tags user on article does not create a notification for tagged user w
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$user],

--- a/tests/Feature/Notifications/NewCommentPlaylistNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentPlaylistNotificationTest.php
@@ -69,7 +69,7 @@ test('comments on playlist creates a notification for playlist owner', function 
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$owner],
@@ -114,7 +114,7 @@ test('user comments on own playlist does not create a notification for self', fu
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });
@@ -159,7 +159,7 @@ test('comments on playlist does not create a notification for playlist owner whe
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });

--- a/tests/Feature/Notifications/NewCommentRequestNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentRequestNotificationTest.php
@@ -68,7 +68,7 @@ test('comment own request does not create a notification for self', function ():
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });
@@ -117,7 +117,7 @@ test('comment a request creates a notification for the requester', function (): 
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$requester],
@@ -172,7 +172,7 @@ test('comment a request creates a notification for the requester when request co
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$requester],
@@ -225,7 +225,7 @@ test('comment a request creates a notification for the requester when all notifi
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });
@@ -274,7 +274,7 @@ test('comment a request creates a notification for the requester when request co
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });
@@ -324,7 +324,7 @@ test('comment a request creates a notification for the requester when request co
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });

--- a/tests/Feature/Notifications/NewCommentTicketNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentTicketNotificationTest.php
@@ -79,7 +79,7 @@ test('user comments own ticket does not create a notification for self but assig
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$staff],
@@ -134,7 +134,7 @@ test('user comments own ticket does not create a notification for staff when non
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });
@@ -185,7 +185,7 @@ test('staff comments a ticket creates a notification for the user but not staff'
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$user],
@@ -242,7 +242,7 @@ test('staff comments a ticket create a notification for the user even when all n
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$user],

--- a/tests/Feature/Notifications/NewCommentTicketTagNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentTicketTagNotificationTest.php
@@ -75,7 +75,7 @@ test('user tags user on ticket creates a notification for tagged user', function
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$staff],
@@ -131,7 +131,7 @@ test('user tags user on ticket does not create a notification for tagged user wh
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$staff],

--- a/tests/Feature/Notifications/NewCommentTorrentNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentTorrentNotificationTest.php
@@ -68,7 +68,7 @@ test('comment own torrent does not create a notification for self', function ():
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });
@@ -117,7 +117,7 @@ test('comment a torrent creates a notification for the uploader', function (): v
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$uploader],
@@ -172,7 +172,7 @@ test('comment a torrent creates a notification for the requester when request co
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         [$uploader],
@@ -225,7 +225,7 @@ test('comment a torrent creates a notification for the requester when all notifi
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });
@@ -274,7 +274,7 @@ test('comment a torrent creates a notification for the requester when request co
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });
@@ -324,7 +324,7 @@ test('comment a torrent creates a notification for the requester when request co
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertCount(0);
 });

--- a/tests/Feature/Notifications/NewCommentTorrentRequestTagNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentTorrentRequestTagNotificationTest.php
@@ -72,7 +72,7 @@ test('user tags user on request creates a notification for tagged user', functio
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentTo(
         $user,
@@ -126,7 +126,7 @@ test('user tags user on request creates a notification for tagged user when ment
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentToTimes(
         $user,
@@ -178,7 +178,7 @@ test('user tags user on request does not create a notification for tagged user w
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$user],
@@ -229,7 +229,7 @@ test('user tags user on request does not create a notification for tagged user w
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$user],
@@ -281,7 +281,7 @@ test('user tags user on request does not create a notification for tagged user w
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$user],

--- a/tests/Feature/Notifications/NewCommentTorrentTagNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentTorrentTagNotificationTest.php
@@ -72,7 +72,7 @@ test('user tags user on torrent creates a notification for tagged user', functio
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentToTimes(
         $user,
@@ -126,7 +126,7 @@ test('user tags user on torrent creates a notification for tagged user when ment
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertSentToTimes(
         $user,
@@ -178,7 +178,7 @@ test('user tags user on torrent does not create a notification for tagged user w
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$user],
@@ -229,7 +229,7 @@ test('user tags user on torrent does not create a notification for tagged user w
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$user],
@@ -281,7 +281,7 @@ test('user tags user on torrent does not create a notification for tagged user w
         ->set('anon', false)
         ->call('postComment');
 
-    $this->assertEquals(1, Comment::count());
+    $this->assertEquals(1, Comment::query()->count());
 
     Notification::assertNotSentTo(
         [$user],


### PR DESCRIPTION
Significantly improves DX with LSP compatibility. Now it's possible to navigate to the definition of these functions in laravel and get ide autocomplete.