### PR TITLE
(Fix) Code copy button type

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -187,7 +187,7 @@ class Bbcode
                 'openBbcode'  => '/^\[code\]/i',
                 'closeBbcode' => '[/code]',
                 'openHtml'    => '<div class="bbcode-rendered__clipboard" x-data="clipboardButton"><pre><code>',
-                'closeHtml'   => '</code></pre><div class="bbcode-rendered__clipboard-container"><button class="bbcode-rendered__clipboard-button" x-bind="button"><i class="fa fa-clone"></i></button></div></div>',
+                'closeHtml'   => '</code></pre><div class="bbcode-rendered__clipboard-container"><button type="button" class="bbcode-rendered__clipboard-button" x-bind="button"><i class="fa fa-clone"></i></button></div></div>',
                 'block'       => true,
             ],
             'pre' => [


### PR DESCRIPTION
When the bbcode button is inside the torrent edit form, the default type is submit. This in turn copies the code contents to clipboard when submitting the form with the enter key.