### PR TITLE
(Fix) Mysql strict mode not working

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -58,6 +58,12 @@ return [
             'engine'         => null,
             'modes'          => [
                 'ANSI',
+                'ONLY_FULL_GROUP_BY',
+                'STRICT_TRANS_TABLES',
+                'NO_ZERO_IN_DATE',
+                'NO_ZERO_DATE',
+                'ERROR_FOR_DIVISION_BY_ZERO',
+                'NO_ENGINE_SUBSTITUTION',
             ],
             'options' => \extension_loaded('pdo_mysql') ? array_filter([
                 Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
@@ -87,6 +93,12 @@ return [
             'engine'         => null,
             'modes'          => [
                 'ANSI',
+                'ONLY_FULL_GROUP_BY',
+                'STRICT_TRANS_TABLES',
+                'NO_ZERO_IN_DATE',
+                'NO_ZERO_DATE',
+                'ERROR_FOR_DIVISION_BY_ZERO',
+                'NO_ENGINE_SUBSTITUTION',
             ],
             'options' => \extension_loaded('pdo_mysql') ? array_filter([
                 Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),

--- a/database/factories/PlaylistCategoryFactory.php
+++ b/database/factories/PlaylistCategoryFactory.php
@@ -33,8 +33,9 @@ class PlaylistCategoryFactory extends Factory
     public function definition(): array
     {
         return [
-            'name'     => $this->faker->name(),
-            'position' => $this->faker->randomNumber(),
+            'name'        => $this->faker->name(),
+            'position'    => $this->faker->numberBetween(0, 2 ** 15 - 1),
+            'description' => $this->faker->text(),
         ];
     }
 }

--- a/database/factories/TicketPriorityFactory.php
+++ b/database/factories/TicketPriorityFactory.php
@@ -35,6 +35,8 @@ class TicketPriorityFactory extends Factory
         return [
             'name'     => $this->faker->name(),
             'position' => $this->faker->randomNumber(),
+            'color'    => $this->faker->hexColor(),
+            'icon'     => $this->faker->word(),
         ];
     }
 }

--- a/database/factories/TopicFactory.php
+++ b/database/factories/TopicFactory.php
@@ -36,7 +36,7 @@ class TopicFactory extends Factory
         return [
             'name'                 => $this->faker->name(),
             'state'                => $this->faker->word(),
-            'priority'             => $this->faker->randomNumber(),
+            'priority'             => $this->faker->numberBetween(0, 2 ** 8 - 1),
             'approved'             => $this->faker->boolean(),
             'denied'               => $this->faker->boolean(),
             'solved'               => $this->faker->boolean(),

--- a/database/factories/TorrentRequestFactory.php
+++ b/database/factories/TorrentRequestFactory.php
@@ -45,7 +45,7 @@ class TorrentRequestFactory extends Factory
             'tmdb_movie_id' => $this->faker->randomNumber(),
             'tmdb_tv_id'    => $this->faker->randomNumber(),
             'mal'           => $this->faker->randomNumber(),
-            'igdb'          => $this->faker->word(),
+            'igdb'          => $this->faker->randomNumber(),
             'description'   => $this->faker->text(),
             'user_id'       => User::factory(),
             'bounty'        => $this->faker->randomFloat(),


### PR DESCRIPTION
Somehow, specifying the ANSI mode (#4300) in laravel's config overrode the existing (boolean) strict setting. Add the existing strict modes to the explicit mode configuration to counteract.