### PR TITLE
(Fix) Update TopTorrents newest tab

### DIFF
--- a/app/Http/Livewire/TopTorrents.php
+++ b/app/Http/Livewire/TopTorrents.php
@@ -65,7 +65,7 @@ class TopTorrents extends Component
                     END AS meta
                 SQL)
                 ->withCount(['comments'])
-                ->when($this->tab === 'newest', fn ($query) => $query->orderByDesc('id'))
+                ->when($this->tab === 'newest', fn ($query) => $query->orderByDesc('created_at'))
                 ->when($this->tab === 'seeded', fn ($query) => $query->orderByDesc('seeders'))
                 ->when(
                     $this->tab === 'dying',

--- a/app/Http/Livewire/TopTorrents.php
+++ b/app/Http/Livewire/TopTorrents.php
@@ -65,7 +65,7 @@ class TopTorrents extends Component
                     END AS meta
                 SQL)
                 ->withCount(['comments'])
-                ->when($this->tab === 'newest', fn ($query) => $query->orderByDesc('created_at'))
+                ->when($this->tab === 'newest', fn ($query) => $query->orderByDesc('id'))
                 ->when($this->tab === 'seeded', fn ($query) => $query->orderByDesc('seeders'))
                 ->when(
                     $this->tab === 'dying',


### PR DESCRIPTION
Since this was ordered by torrent_id, if a torrent was uploaded and pending moderation and other trusted torrents were uploaded after it, those would bury the pending moderation torrent once it was approved. Ordering by created_at fixes this.