### PR TITLE
(Fix) Report Verdict No Longer Visible

### DIFF
--- a/resources/views/Staff/report/show.blade.php
+++ b/resources/views/Staff/report/show.blade.php
@@ -68,7 +68,7 @@
         </section>
     @endif
 
-    @if ($report->solved)
+    @if ($report->solved_by !== null)
         <section class="panelV2">
             <h2 class="panel__heading">Verdict</h2>
             {{-- format-ignore-start --}}<div class="panel__body" style="white-space: pre-wrap">{{ $report->verdict }}</div>{{-- format-ignore-end --}}


### PR DESCRIPTION
Closes #5174

The 2025_09_25_110038_alter_reports_create_assignee.php migration:
1. Renamed staff_id to solved_by
2. Added solved_at
3. Dropped the solved bool
4. A bunch of other stuff that's not relevant here

"$report->solved_by !== null" is functionally equivalent to the old "$report->solved" as solved_by has a NULL default so we can assume if the report in question has a non-null value, it has been solved and we should show the report verdict instead.