### PR TITLE
(Fix) MariaDB user earnings group by

### DIFF
--- a/app/Console/Commands/AutoBonAllocation.php
+++ b/app/Console/Commands/AutoBonAllocation.php
@@ -107,7 +107,20 @@ class AutoBonAllocation extends Command
                                 ->where('peers.seeder', '=', true)
                                 ->where('peers.active', '=', true)
                                 ->where('peers.created_at', '<', now()->subMinutes(30))
-                                ->groupBy(['peers.user_id', 'peers.torrent_id']),
+                                ->groupBy([
+                                    'peers.user_id',
+                                    'peers.torrent_id',
+                                    'torrents.name',
+                                    'torrents.type_id',
+                                    'torrents.created_at',
+                                    'torrents.size',
+                                    'torrents.seeders',
+                                    'torrents.leechers',
+                                    'torrents.times_completed',
+                                    'torrents.internal',
+                                    'torrents.personal_release',
+                                    'history.seedtime',
+                                ]),
                             'earnings_per_user_per_torrent',
                         )
                             ->select([

--- a/app/Http/Livewire/UserEarnings.php
+++ b/app/Http/Livewire/UserEarnings.php
@@ -185,7 +185,20 @@ class UserEarnings extends Component
                 ->where('peers.active', '=', true)
                 ->where('peers.user_id', '=', $this->user->id)
                 ->where('torrents.name', 'LIKE', '%'.str_replace(' ', '%', $this->torrentName).'%')
-                ->groupBy(['peers.torrent_id', 'peers.user_id']);
+                ->groupBy([
+                    'peers.torrent_id',
+                    'peers.user_id',
+                    'torrents.name',
+                    'torrents.type_id',
+                    'torrents.created_at',
+                    'torrents.size',
+                    'torrents.seeders',
+                    'torrents.leechers',
+                    'torrents.times_completed',
+                    'torrents.internal',
+                    'torrents.personal_release',
+                    'history.seedtime',
+                ]);
 
             return $query;
         }


### PR DESCRIPTION
MariaDB doesn't support functional dependency detection, so all columns that are functionality dependent on peer.torrent_id and peers.user_id need to be explicitly included in the group by.

Reference: https://jira.mariadb.org/browse/MDEV-11588