### PR TITLE
(Update) Remove TorrentSearch and TmdbPersonCredit from phpstan excludePaths

### DIFF
--- a/app/Http/Livewire/TmdbPersonCredit.php
+++ b/app/Http/Livewire/TmdbPersonCredit.php
@@ -56,10 +56,12 @@ class TmdbPersonCredit extends Component
         get => cache()->get('personal_freeleech:'.auth()->user()->id) ?? false;
     }
 
-    /*
+    /**
      * Livewire doesn't support enum properties, so we have to convert it manually.
+     *
+     * @param-out Occupation $value
      */
-    public function updatingOccupation(&$value): void
+    public function updatingOccupation(int|string &$value): void
     {
         $value = Occupation::from($value);
     }
@@ -105,7 +107,7 @@ class TmdbPersonCredit extends Component
     }
 
     /**
-     * @return \Illuminate\Support\Collection<int, Torrent>
+     * @var \Illuminate\Support\Collection<int, Torrent>
      */
     final protected \Illuminate\Support\Collection $medias {
         get {

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -312,7 +312,7 @@ class TorrentSearch extends Component
     }
 
     /**
-     * @var \Illuminate\Database\Eloquent\Collection<int, Resolution>
+     * @var \Illuminate\Database\Eloquent\Collection<int, TmdbGenre>
      */
     final protected \Illuminate\Database\Eloquent\Collection $genres {
         get => cache()->flexible(
@@ -345,7 +345,7 @@ class TorrentSearch extends Component
     }
 
     /**
-     * @var \Illuminate\Support\Collection<int, TmdbMovie>
+     * @var \Illuminate\Support\Collection<int, string|null>
      */
     final protected \Illuminate\Support\Collection $primaryLanguages {
         get => cache()->flexible(
@@ -525,7 +525,7 @@ class TorrentSearch extends Component
     }
 
     /**
-     * @var \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, Torrent>
+     * @var LengthAwarePaginator<int, TmdbMovie|TmdbTv|null>
      */
     final protected $groupedTorrents {
         get {
@@ -754,7 +754,7 @@ class TorrentSearch extends Component
     }
 
     /**
-     * @var \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, Torrent>
+     * @var LengthAwarePaginator<int, Torrent>
      */
     final protected $groupedPosters {
         get {
@@ -795,11 +795,11 @@ class TorrentSearch extends Component
             $groups = $groups->through(function ($group) use ($movies, $tv) {
                 switch ($group->meta) {
                     case 'movie':
-                        $group->movie = $movies[$group->tmdb_movie_id] ?? null;
+                        $group->setAttribute('movie', $movies[$group->tmdb_movie_id] ?? null);
 
                         break;
                     case 'tv':
-                        $group->tv = $tv[$group->tmdb_tv_id] ?? null;
+                        $group->setAttribute('tv', $tv[$group->tmdb_tv_id] ?? null);
 
                         break;
                 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -457,6 +457,36 @@ parameters:
 			path: app/Http/Livewire/TorrentRequestSearch.php
 
 		-
+			message: '#^Access to an undefined property App\\Models\\Torrent\:\:\$meta\.$#'
+			identifier: property.notFound
+			count: 2
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
+			message: '#^Anonymous function should return Illuminate\\Support\\Collection\<int, string\|null\> but returns Illuminate\\Support\\Collection\<int, string\|null\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
+			message: '#^Get hook for property App\\Http\\Livewire\\TorrentSearch\:\:\$groupedTorrents should return Illuminate\\Pagination\\LengthAwarePaginator\<int, App\\Models\\TmdbMovie\|App\\Models\\TmdbTv\|null\> but returns Illuminate\\Pagination\\LengthAwarePaginator\<int, App\\Models\\TmdbMovie\|App\\Models\\TmdbTv\|null\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
+			message: '#^Get hook for property App\\Http\\Livewire\\TorrentSearch\:\:\$primaryLanguages should return Illuminate\\Support\\Collection\<int, string\|null\> but returns Illuminate\\Support\\Collection\<int, string\|null\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
+			message: '#^Parameter \#3 \$callback of method Illuminate\\Cache\\Repository\:\:flexible\(\) expects callable\(\)\: Illuminate\\Support\\Collection\<int, string\|null\>, Closure\(\)\: Illuminate\\Support\\Collection\<int, string\|null\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
 			message: '#^Method App\\Http\\Middleware\\SetLanguage\:\:setSystemLocale\(\) has parameter \$request with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1


### PR DESCRIPTION
There used to be an infinite loop caused by these files that phpstan could not handle. This seems to be fixed now. Fixed the errors I could - the remaining ones are from larastan/phpstan not supporting the co-variant logic as well as not supporting custom sql selects.