### PR TITLE
(Fix) Torrent filename parser dts x.y removes dot

### DIFF
--- a/resources/js/unit3d/helper.js
+++ b/resources/js/unit3d/helper.js
@@ -19,6 +19,7 @@ class uploadExtensionBuilder {
         title = title.replace(/( DTS-?X ?)(\d)( )(\d)/i, ' DTS:X $2.$4');
         title = title.replace(/( DTS-?X)(-?[^ ]*)$/i, ' DTS:X 7.1$2');
         title = title.replace(/( DTS-?H?D? ?HRA? ?)(\d)( )(\d)/i, ' DTS-HD HRA $2.$4');
+        title = title.replace(/( DTS ?)(\d)( )(\d)/i, ' DTS $2.$4');
         title = title.replace(/( FLAC ?)(\d)( )(\d)/i, '$1 $2.$4');
         title = title.replace(/( L?PCM ?)(\d)( )(\d)/i, '$1 $2.$4');
         title = title.replace(/( DD[P+]? ?)(\d)( )(\d)/i, '$1 $2.$4');


### PR DESCRIPTION
Previously, a file with `dts.5.1` would be renamed to `dts 5 1` instead of `dts 5.1`.