### PR TITLE
(Fix) Settings secondary nav not showing active state for sub-pages

### DIFF
--- a/resources/views/user/buttons/user.blade.php
+++ b/resources/views/user/buttons/user.blade.php
@@ -110,7 +110,7 @@
 @if ($isProfileOwner || $isModo)
     <li class="nav-tab-menu">
         <a
-            class="{{ Route::is('users.general_settings.edit', 'user_security', 'user_privacy', 'user_notification') ? 'nav-tab--active__link' : 'nav-tab__link' }}"
+            class="{{ Route::is('users.general_settings.edit', 'users.email.edit', 'users.password.edit', 'users.passkeys.index', 'users.rsskeys.index', 'users.apikeys.index', 'users.two_factor_auth.edit', 'users.privacy_settings.edit', 'users.notification_settings.edit') ? 'nav-tab--active__link' : 'nav-tab__link' }}"
             href="{{ route('users.general_settings.edit', ['user' => $user]) }}"
         >
             {{ __('user.settings') }}


### PR DESCRIPTION
Fixes #5224 
The Settings parent menu item in the user profile secondary nav only sets 'active' when on the General settings page, but not when on any other settings sub-pages (E-mail, Password, Passkey, RSS key, API key, Two-factor authentication, Privacy, or Notification).

The issue is caused because the Route::is() check uses legacy route names ('user_security', 'user_privacy', 'user_notification') that don't seem to exist any more.

This PR updates the Route::is() check to include all actual route names used by the settings menu items:
- users.general_settings.edit
- users.email.edit
- users.password.edit
- users.passkeys.index
- users.rsskeys.index
- users.apikeys.index
- users.two_factor_auth.edit
- users.privacy_settings.edit
- users.notification_settings.edit