### PR TITLE
(Fix) Incorrect column selected in clients extra stats

### DIFF
--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -360,7 +360,6 @@ class StatsController extends Controller
                 [3600, 2 * 24 * 3600],
                 fn () => Peer::query()
                     ->select([
-                        'agent',
                         DB::raw("SUBSTRING_INDEX(SUBSTRING_INDEX(agent, '/', 1), ' ', 1) AS prefix"),
                         DB::raw('COUNT(DISTINCT torrent_id) AS single_seed_count'),
                     ])


### PR DESCRIPTION
This column isn't used and isn't aggregated in the group by (causing an error in mysql strict mode), so remove it from the select clause.

fixes #5226