### PR TITLE
(Fix) Selecting whitespace around folder name in torrent file preview

### DIFF
--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -212,9 +212,7 @@
                                 class="{{ config('other.font-awesome') }} fa-folder"
                                 style="grid-area: icon; padding-right: 4px"
                             ></i>
-                            <span style="padding-right: 4px; word-break: break-all">
-                                {{ $torrent->folder }}
-                            </span>
+                            {{-- format-ignore-start --}}<span style="padding-right: 4px; word-break: break-all">{{ $torrent->folder }}</span>{{-- format-ignore-end --}}
                             <span style="grid-area: count; padding-right: 4px">
                                 ({{ $torrent->files_count }})
                             </span>


### PR DESCRIPTION
Makes it easier to triple-click to copy-paste the folder name.