### PR TITLE
(Fix) Cspell `endscript` spelling error

### DIFF
--- a/.cspell/blade.txt
+++ b/.cspell/blade.txt
@@ -5,6 +5,7 @@ endforeach
 endforelse
 endisset
 endphp
+endscript
 endsection
 endslot
 endswitch


### PR DESCRIPTION
When merging #4874, I saw the CI green and was thinking of the addition to `.cspell/laravel.txt` I saw in #5238. But it wasn't actually merged so need to still add it.