### PR TITLE
(Fix) Refund download command didn't consider partial downloads

### DIFF
--- a/app/Console/Commands/AutoRefundDownload.php
+++ b/app/Console/Commands/AutoRefundDownload.php
@@ -52,7 +52,7 @@ class AutoRefundDownload extends Command
         $COMMAND_RUN_PERIOD = 24 * 60 * 60; // This command is run every 24 hours
 
         History::query()
-            ->selectRaw('LEAST(1, history.seedtime / ?) * torrents.size - history.refunded_download as refunded_download_delta', [$FULL_REFUND_SEEDTIME])
+            ->selectRaw('LEAST(history.downloaded, LEAST(1, history.seedtime / ?) * torrents.size) - history.refunded_download as refunded_download_delta', [$FULL_REFUND_SEEDTIME])
             ->join('torrents', 'torrents.id', '=', 'history.torrent_id')
             ->join('users', 'users.id', '=', 'history.user_id')
             ->join('groups', 'groups.id', '=', 'users.group_id')
@@ -68,7 +68,7 @@ class AutoRefundDownload extends Command
                     ->orWhere('torrents.refundable', '=', true)
             ))
             ->update([
-                'history.refunded_download' => DB::raw('history.refunded_download + (@delta := LEAST(1, history.seedtime / '.(int) $FULL_REFUND_SEEDTIME.') * torrents.size - history.refunded_download)'),
+                'history.refunded_download' => DB::raw('history.refunded_download + (@delta := LEAST(history.downloaded, LEAST(1, history.seedtime / '.(int) $FULL_REFUND_SEEDTIME.') * torrents.size) - history.refunded_download)'),
                 'users.downloaded'          => DB::raw('GREATEST(0, users.downloaded - @delta)'),
                 'history.updated_at'        => DB::raw('history.updated_at'),
             ]);


### PR DESCRIPTION
We shouldn't refund the whole size of the torrent if the user didn't fully download it.