### PR TITLE
(Fix) Explicitly define tab width for js and scss in prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -21,7 +21,8 @@
       "options": {
         "printWidth": 100,
         "semi": true,
-        "singleQuote": true
+        "singleQuote": true,
+        "tabWidth": 4
       }
     },
     {
@@ -30,7 +31,8 @@
       ],
       "options": {
         "semi": true,
-        "singleQuote": true
+        "singleQuote": true,
+        "tabWidth": 4
       }
     }
   ]


### PR DESCRIPTION
Explicitly define the tab width in prettier since not all IDEs (specifically Zed causes the issue for me) fully support .editorconfig. This can be reverted once .editorconfig is more widely supported.