### PR TITLE
(Fix) Accept all 2xx responses in external IRC announce bot

### DIFF
--- a/app/Bots/IRCAnnounceBotExternal.php
+++ b/app/Bots/IRCAnnounceBotExternal.php
@@ -128,7 +128,7 @@ class IRCAnnounceBotExternal
             return false;
         }
 
-        if (! $response->ok()) {
+        if (! $response->successful()) {
             Log::notice('External IRC Announce error - POST', [
                 'status' => $response->status(),
                 'body'   => $response->body(),


### PR DESCRIPTION
Changes `$response->ok()` to `$response->successful()` to handle other 2xx responses.

The previous check only accepted a 200 status code which caused successful calls (such as 204) to be incorrectly logged as errors.