### PR TITLE
(Fix) Handle null release_date with collection movies

### DIFF
--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -366,13 +366,13 @@
                                             <h3 class="meta-chip__value">
                                                 <strong>
                                                     {{ $movie->title }}
-                                                    ({{ substr($movie->release_date ?? '', 0, 4) }})
+                                                    ({{ $movie->release_date?->format('Y') }})
                                                 </strong>
                                             </h3>
                                         @else
                                             <h3 class="meta-chip__value">
                                                 {{ $movie->title }}
-                                                ({{ substr($movie->release_date ?? '', 0, 4) }})
+                                                ({{ $movie->release_date?->format('Y') }})
                                             </h3>
                                         @endif
                                     </a>

--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -366,13 +366,13 @@
                                             <h3 class="meta-chip__value">
                                                 <strong>
                                                     {{ $movie->title }}
-                                                    ({{ $movie->release_date->format('Y') }})
+                                                    ({{ substr($movie->release_date ?? '', 0, 4) }})
                                                 </strong>
                                             </h3>
                                         @else
                                             <h3 class="meta-chip__value">
                                                 {{ $movie->title }}
-                                                ({{ $movie->release_date->format('Y') }})
+                                                ({{ substr($movie->release_date ?? '', 0, 4) }})
                                             </h3>
                                         @endif
                                     </a>


### PR DESCRIPTION
The movie-meta.blade throws a "Call to a member function format() on null" error when attempting to view any item that is a part of a collection when one item in that collection lacks a release date.

Changed $movie->release_date->format('Y') to substr($movie->release_date ?? '', 0, 4) to match the same date handling format used elsewhere in the file.

NOTE: This will leave the empty parentheses when release_date is null. This is a pretty obscure edge case so the stability of matching existing patterns is probably preferable. Alternatively, the line could be wrapped in a ternary to also hide parentheses.