### PR TITLE
(Add) Region names in Torrent create/edit view and Staff Dashboard

### DIFF
--- a/resources/views/Staff/region/edit.blade.php
+++ b/resources/views/Staff/region/edit.blade.php
@@ -22,7 +22,8 @@
 @section('main')
     <section class="panelV2">
         <h2 class="panel__heading">
-            {{ __('common.edit') }} torrent region: {{ $region->name }}
+            {{ __('common.edit') }} torrent region:
+            {{ $region->name . ' (' . __('regions.' . $region->name) . ')' }}
         </h2>
         <div class="panel__body">
             <form

--- a/resources/views/Staff/region/index.blade.php
+++ b/resources/views/Staff/region/index.blade.php
@@ -29,6 +29,7 @@
                 <thead>
                     <tr>
                         <th>{{ __('common.position') }}</th>
+                        <th>{{ __('common.code') }}</th>
                         <th>{{ __('common.name') }}</th>
                         <th>{{ __('common.action') }}</th>
                     </tr>
@@ -41,6 +42,9 @@
                                 <a href="{{ route('staff.regions.edit', ['region' => $region]) }}">
                                     {{ $region->name }}
                                 </a>
+                            </td>
+                            <td>
+                                {{ __('regions.' . $region->name) }}
                             </td>
                             <td>
                                 <menu class="data-table__actions">
@@ -61,7 +65,8 @@
                                         </button>
                                         <dialog class="dialog" x-bind="dialogElement">
                                             <h4 class="dialog__heading">
-                                                Delete torrent region: {{ $region->name }}
+                                                Delete torrent region:
+                                                {{ $region->name . ' (' . __('regions.' . $region->name) . ')' }}
                                             </h4>
                                             <form
                                                 class="dialog__form"
@@ -92,7 +97,7 @@
                                                         ></option>
                                                         @foreach ($regions as $region)
                                                             <option value="{{ $region->id }}">
-                                                                {{ $region->name }}
+                                                                {{ $region->name . ' (' . __('regions.' . $region->name) . ')' }}
                                                             </option>
                                                         @endforeach
                                                     </select>

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -236,7 +236,7 @@
                                     value="{{ $region->id }}"
                                     @selected(old('region_id') == $region->id)
                                 >
-                                    {{ $region->name }}
+                                    {{ $region->name . ' (' . __('regions.' . $region->name) . ')' }}
                                 </option>
                             @endforeach
                         </select>

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -229,7 +229,7 @@
                                     "
                                     @selected(old('region_id') === $region->id)
                                 >
-                                    {{ $region->name }}
+                                    {{ $region->name . ' (' . __('regions.' . $region->name) . ')' }}
                                 </option>
                             @endforeach
                         </select>


### PR DESCRIPTION
I didn't find Singapore in `regions.php` so I decided to review everything else.
Original PR: #2926
Wikipedia sources: [FIFA](https://en.wikipedia.org/wiki/List_of_FIFA_country_codes), [IOC](https://en.wikipedia.org/wiki/List_of_IOC_country_codes), [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3), [Comparison](https://en.wikipedia.org/wiki/Comparison_of_alphabetic_country_codes).

Staff dashboard: a column with country names as a separate column allows admins to easily spot mistakes if they add each region manually.
Torrent upload/edit: country names are added next to the codes for consistency with search filters and to make picking the right code easier.

I thought that `regions.php` should include all 3-letter variants since some people might prefer different abbreviations.
I also added separate countries for `CEE` and `NOR` regions. The original PR mentions when it might be useful:
> If these countries sell different versions of the title, then their individual country code is used

`ISL` (Iceland) was already present in `RegionSeeder`.
New countries have been added with new IDs to preserve existing relations. Only positions have been adjusted to achieve alphabetical order.

More changes and explanations:
- `KVX` was renamed to `KOS` for Kosovo (`KVX` is obsolete)
- `SIN` was renamed to `SGP` for Singapore (also obsolete, used until 2016)
- The Bahamas -> Bahamas, same as Gambia (shorter, more consistent)
- State of Palestine -> Palestine, same as Israel (shorter, more consistent)
- Caribbean Netherlands: Bonaire, Sint Eustatius and Saba -> just Caribbean Netherlands (shorter, was the longest string)
- Added Norway after Nordic because it's both `NOR` and some people might mean the actual country
- Added alternative/official names to some countries after a comma: Côte d'Ivoire, Czechia, Malvinas, Türkiye
- Replaced `/` in "Europe / International" with a comma (for consistency)
- The only ambiguous code `BRN` was assigned to Bahrain because IOC standard has a higher priority than ISO according to the original PR (and also Brunei has a smaller population)
- Didn't add `BOE` for Bonaire because it's just one island, while `BES` represents all 3 islands
- Didn't include 4-letter codes `TRNC` and `SADR` since they have 3-letter variants `NCY` and `ESH`