### PR TITLE
(Remove) Redundant TMDB ID value check that's always true

### DIFF
--- a/resources/js/unit3d/helper.js
+++ b/resources/js/unit3d/helper.js
@@ -184,11 +184,8 @@ class uploadExtensionBuilder {
     }
     hook() {
         let name = document.querySelector('#title');
-        let tmdb_movie = document.querySelector('#auto_tmdb_movie');
-        let tmdb_tv = document.querySelector('#auto_tmdb_tv');
-        let imdb = document.querySelector('#autoimdb');
 
-        if (!name.value.trim() && (!tmdb_movie.value.trim() || !tmdb_tv.value.trim())) {
+        if (!name.value.trim()) {
             let torrent = document.querySelector('#torrent');
             let release;
             if (!name.value) {


### PR DESCRIPTION
To reproduce:
- Open Torrent Upload form
- Set Title and some IDs: TMDB movie/TV ID, IMDB ID, MAL ID or TVDB ID
- Pick a .torrent file
- Observe that all IDs are reset

Note: this doesn't happen when you change the category first.
But it does happen if you set it on page load with `torrents/create?category_id=2`

I'm not sure why `cat = $refs.catId.value` was needed in `@change` originally for #2243
Because `cat` is assigned here anyway:
https://github.com/HDInnovations/UNIT3D/blob/735b4b7031a8374f5873f6f4ef4c237ca24d166e/resources/views/torrent/create.blade.php#L44-L48

Values are reset because they listen to `cat` changes:
https://github.com/HDInnovations/UNIT3D/blob/735b4b7031a8374f5873f6f4ef4c237ca24d166e/resources/views/torrent/create.blade.php#L316

When you change the category from the dropdown list, IDs should reset - this is correct.
Also IDs are retrieved through TMDB API when the Title is not set and .torrent is selected.
But after you fill all the inputs in the upload form yourself, they shouldn't be touched.