### PR TITLE
(Fix) Lifetime donor download slot check

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -110,7 +110,7 @@ final class AnnounceController extends Controller
             $this->checkMaxConnections($torrent, $user);
 
             // Check Download Slots.
-            if (($user->is_lifetime === false || $user->group->download_slots !== null) && config('announce.slots_system.enabled')) {
+            if ($user->is_lifetime === false && config('announce.slots_system.enabled')) {
                 $visible = $this->checkDownloadSlots($queries, $torrent, $user, $group);
             } else {
                 $visible = true;


### PR DESCRIPTION
This PR adjusts the Lifetime Donor download slot limit enforcement criteria. The existing check enforces the download slot limit on lifetime donors whenever their assigned group has a non-null download_slots value, due to the || condition in the if block.

Based upon the verbiage in the lifetime donor blade, I do not believe this is the expected behavior. See [donation/index.blade.php#L48](https://github.com/HDInnovations/UNIT3D/blob/8b88f4c8182eb3d3912ffef425c3224dcfd596f4/resources/views/donation/index.blade.php#L48).

Removing `$user->group->download_slots !== null` from the if block defers the evaluation of slot limits for all non-lifetime donors when the slot system is enabled to the checkDownloadSlots func which already gracefully handles null and non null slot limits.