### PR TITLE
(Fix) Fortify hardcoding middleware aliases

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,6 +21,7 @@ use App\Enums\MiddlewareGroup;
 use App\Http\Middleware\BlockIpAddress;
 use App\Http\Middleware\UpdateLastAction;
 use HDVinnie\SecureHeaders\SecureHeadersMiddleware;
+use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
@@ -97,5 +98,17 @@ class Kernel extends HttpKernel
         MiddlewareGroup::RSS->value => [
             ThrottleRequestsWithRedis::class.':'.GlobalRateLimit::RSS->value,
         ],
+    ];
+
+    /**
+     * The application's route middleware.
+     *
+     * These middleware may be assigned to groups or used individually.
+     *
+     * @var array<string, class-string>
+     */
+    protected $middlewareAliases = [
+        'guest'    => RedirectIfAuthenticated::class,
+        'throttle' => ThrottleRequestsWithRedis::class,
     ];
 }

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -92,7 +92,8 @@ return [
     |
     */
 
-    'middleware' => [MiddlewareGroup::WEB->value],
+    'middleware'      => [MiddlewareGroup::WEB->value],
+    'auth_middleware' => Illuminate\Auth\Middleware\Authenticate::class,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Fortify hard codes middleware aliases, so we have no choice but to define them in our app. With the exception of auth middleware, which fortify allows us to define ourselves.