### PR TITLE
(Fix) Make the hidden captcha non-tabbable

### DIFF
--- a/resources/views/partials/captcha.blade.php
+++ b/resources/views/partials/captcha.blade.php
@@ -1,6 +1,12 @@
 <input type="hidden" name="_captcha" value="{{ $token }}" />
 <div style="position: fixed; transform: translateX(-10000px)">
     <label for="{{ $mustBeEmptyField }}">Name</label>
-    <input id="{{ $mustBeEmptyField }}" type="text" name="{{ $mustBeEmptyField }}" value="" />
+    <input
+        id="{{ $mustBeEmptyField }}"
+        type="text"
+        name="{{ $mustBeEmptyField }}"
+        value=""
+        tabindex="-1"
+    />
 </div>
 <input type="hidden" name="{{ $random }}" value="{{ $ts }}" />


### PR DESCRIPTION
Right now it's possible to focus the hidden captcha field by selecting the first input on the login page and pressing Tab three times.
You can even input something there to trigger an error on submit.
I don't think it should be tabbable, otherwise it's not truly hidden.
It'll still work as a honeypot for some dumb bots. And the more clever ones probably check for `translate` anyway.