### PR TITLE
(Update) Replace and remove Thanks in password reset and emails

### DIFF
--- a/app/Notifications/MassEmail.php
+++ b/app/Notifications/MassEmail.php
@@ -70,8 +70,7 @@ class MassEmail extends Notification implements ShouldQueue
         return (new MailMessage())
             ->subject($this->subject)
             ->line($this->message)
-            ->action('Login Now', route('login'))
-            ->line('Thank you for using 🚀'.config('other.title'));
+            ->action('Login Now', route('login'));
     }
 
     /**

--- a/app/Notifications/UserBan.php
+++ b/app/Notifications/UserBan.php
@@ -73,8 +73,7 @@ class UserBan extends Notification implements ShouldQueue
         return (new MailMessage())
             ->greeting('You have been banned 😭')
             ->line('You have been banned from '.config('other.title').' for '.$this->ban->ban_reason)
-            ->action('Need Support?', $chatUrl)
-            ->line('Thank you for using 🚀'.config('other.title'));
+            ->action('Need Support?', $chatUrl);
     }
 
     /**

--- a/app/Notifications/UserBanExpire.php
+++ b/app/Notifications/UserBanExpire.php
@@ -69,8 +69,7 @@ class UserBanExpire extends Notification implements ShouldQueue
     {
         return (new MailMessage())
             ->greeting('You have been unbanned 🤩')
-            ->line('You have been unbanned from '.config('other.title'))
-            ->line('Thank you for using 🚀'.config('other.title'));
+            ->line('You have been unbanned from '.config('other.title'));
     }
 
     /**

--- a/app/Notifications/UserEmailChange.php
+++ b/app/Notifications/UserEmailChange.php
@@ -71,8 +71,7 @@ class UserEmailChange extends Notification implements ShouldQueue
         return (new MailMessage())
             ->greeting('Your Email Address Has Been Changed!')
             ->line('Your email address regarding account '.$this->user->username.' has been changed from '.$this->oldEmail.' to '.$this->newEmail.'. If you feel this was done in error, please create a helpdesk ticket.')
-            ->action('Helpdesk', route('tickets.index'))
-            ->line('Thank you for using 🚀'.config('other.title'));
+            ->action('Helpdesk', route('tickets.index'));
     }
 
     /**

--- a/app/Notifications/UserManualWarningExpire.php
+++ b/app/Notifications/UserManualWarningExpire.php
@@ -74,8 +74,7 @@ class UserManualWarningExpire extends Notification implements ShouldQueue
         return (new MailMessage())
             ->greeting('Manual Warning Expired!')
             ->line('Your Warning has expired!')
-            ->action('View Profile!', $profileUrl)
-            ->line('Thank you for using 🚀'.config('other.title'));
+            ->action('View Profile!', $profileUrl);
     }
 
     /**

--- a/app/Notifications/UserMaxWarningsReached.php
+++ b/app/Notifications/UserMaxWarningsReached.php
@@ -73,8 +73,7 @@ class UserMaxWarningsReached extends Notification implements ShouldQueue
         return (new MailMessage())
             ->greeting('Max Hit and Run Warnings Reached!')
             ->line('You have hit the limit on active Hit and Run Warnings! Your download privileges have been revoked!')
-            ->action('View Unsatisfied Torrents to seed off your warnings or wait until they expire!', $profileUrl)
-            ->line('Thank you for using 🚀'.config('other.title'));
+            ->action('View Unsatisfied Torrents to seed off your warnings or wait until they expire!', $profileUrl);
     }
 
     /**

--- a/app/Notifications/UserPreWarning.php
+++ b/app/Notifications/UserPreWarning.php
@@ -71,8 +71,7 @@ class UserPreWarning extends Notification implements ShouldQueue
         return (new MailMessage())
             ->greeting('Hit and Run Pre Warning Received!')
             ->line('You have received an automated hit and run PRE WARNING on one or more torrents!')
-            ->action('View your unsatisfied torrents and start seeding before you are issued a permanent WARNING!', route('users.history.index', ['user' => $this->user]))
-            ->line('Thank you for using 🚀'.config('other.title'));
+            ->action('View your unsatisfied torrents and start seeding before you are issued a permanent WARNING!', route('users.history.index', ['user' => $this->user]));
     }
 
     /**

--- a/app/Notifications/UserWarning.php
+++ b/app/Notifications/UserWarning.php
@@ -71,8 +71,7 @@ class UserWarning extends Notification implements ShouldQueue
         return (new MailMessage())
             ->greeting('Hit and Run Warning Received!')
             ->line('You have received an automated hit and run WARNING on one or more torrents!')
-            ->action('View your unsatisfied torrents and seed off your warnings or wait until they expire!', route('users.history.index', ['user' => $this->user]))
-            ->line('Thank you for using 🚀'.config('other.title'));
+            ->action('View your unsatisfied torrents and seed off your warnings or wait until they expire!', route('users.history.index', ['user' => $this->user]));
     }
 
     /**

--- a/app/Notifications/UserWarningExpired.php
+++ b/app/Notifications/UserWarningExpired.php
@@ -73,8 +73,7 @@ class UserWarningExpired extends Notification implements ShouldQueue
         return (new MailMessage())
             ->greeting('Warning Expired')
             ->line('One or more of your warnings have expired or been seeded off.')
-            ->action('View Profile!', $profileUrl)
-            ->line('Thank you for using 🚀'.config('other.title'));
+            ->action('View Profile!', $profileUrl);
     }
 
     /**

--- a/lang/en/passwords.php
+++ b/lang/en/passwords.php
@@ -27,7 +27,7 @@ return [
 
     'password' => 'Passwords must be at least six characters and match the confirmation.',
     'reset'    => 'Your password has been reset!',
-    'sent'     => 'Thanks! If the email address matches an account, a password reset link will be sent.',
+    'sent'     => 'Success: If the email address matches an account, a password reset link will be sent.',
     'token'    => 'This password reset token is invalid.',
     'user'     => 'We can\'t find a user with that e-mail address.',
 ];

--- a/resources/views/emails/deny-application.blade.php
+++ b/resources/views/emails/deny-application.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
 # Your {{ config('other.title') }} application
-Your application has been denied for the following reason:
-{{ $deniedMessage }}
-Thanks,
+Your application has been denied for the following reason:<br>
+{{ $deniedMessage }}<br><br>
+{{ __('Regards') }},<br>
 {{ config('other.title') }}
 @endcomponent

--- a/resources/views/emails/test-email.blade.php
+++ b/resources/views/emails/test-email.blade.php
@@ -1,6 +1,6 @@
 @component('mail::message')
 # Test email
-Your test email has been successfully delivered! Looks like your mail configs are on point!
-Thanks,
+Your test email has been successfully delivered! Looks like your mail configs are on point!<br><br>
+{{ __('Regards') }},<br>
 {{ config('other.title') }}
 @endcomponent


### PR DESCRIPTION
1. It seems strange to thank a user who forgot a password and used the password reset form.
Make it consistent with other Success messages:
https://github.com/HDInnovations/UNIT3D/blob/6af8f5c94f5185f8986abe0f1f068a875fc4ef99/resources/views/auth/forgot-password.blade.php#L48-L52

2. Replace "Thanks" with "Regards" in Deny Application and Test emails.
Same idea, plus make it consistent with `email.blade.php`:
https://github.com/HDInnovations/UNIT3D/blob/6160f12d818ac18b3765cfc0e3f601c1c0f7d22e/resources/views/vendor/notifications/email.blade.php#L43-L48
3. Add `<br>` tags since this text goes into a single `<p>` tag.