### PR TITLE
(Fix) Donations: prevent time loss, fix sorting, count pending, support multiple same user donos

### DIFF
--- a/app/Http/Controllers/Staff/DonationController.php
+++ b/app/Http/Controllers/Staff/DonationController.php
@@ -73,18 +73,30 @@ class DonationController extends Controller
 
         $donation = Donation::query()->with(['user', 'package'])->findOrFail($id);
         $donation->status = ModerationStatus::APPROVED;
+
+        $latestDonation = Donation::query()
+            ->where('status', '=', ModerationStatus::APPROVED)
+            ->where('user_id', '=', $donation->user->id)
+            ->latest('updated_at')
+            ->first();
+
+        $isLifetime = $donation->package->donor_value === null ||
+            ($latestDonation && $latestDonation->ends_at === null);
+
         $donation->starts_at = $now;
 
-        if ($donation->package->donor_value > 0) {
-            $donation->ends_at = $now->addDays($donation->package->donor_value);
-        } else {
-            $donation->ends_at = null;
+        if ($latestDonation && !$isLifetime) {
+            $donation->starts_at = $latestDonation->ends_at;
+        }
+
+        if (!$isLifetime) {
+            $donation->ends_at = $donation->starts_at->copy()->addDays($donation->package->donor_value);
         }
 
         $donation->user->invites += $donation->package->invite_value ?? 0;
         $donation->user->uploaded += $donation->package->upload_value ?? 0;
         $donation->user->is_donor = true;
-        $donation->user->is_lifetime = $donation->package->donor_value === null;
+        $donation->user->is_lifetime = $isLifetime;
         $donation->user->seedbonus += $donation->package->bonus_value ?? 0;
         $donation->user->save();
 

--- a/app/Http/Controllers/Staff/DonationController.php
+++ b/app/Http/Controllers/Staff/DonationController.php
@@ -39,7 +39,7 @@ class DonationController extends Controller
         }])->latest()->paginate(25);
 
         $dailyDonations = Donation::query()
-            ->selectRaw('DATE(donations.created_at) as date, SUM(donation_packages.cost) as total')
+            ->selectRaw('DATE(donations.updated_at) as date, SUM(donation_packages.cost) as total')
             ->join('donation_packages', 'donations.package_id', '=', 'donation_packages.id')
             ->where('donations.status', '=', ModerationStatus::APPROVED)
             ->groupBy('date')
@@ -47,7 +47,7 @@ class DonationController extends Controller
             ->get();
 
         $monthlyDonations = Donation::query()
-            ->selectRaw('EXTRACT(YEAR FROM donations.created_at) as year, EXTRACT(MONTH FROM donations.created_at) as month, SUM(donation_packages.cost) as total')
+            ->selectRaw('EXTRACT(YEAR FROM donations.updated_at) as year, EXTRACT(MONTH FROM donations.updated_at) as month, SUM(donation_packages.cost) as total')
             ->join('donation_packages', 'donations.package_id', '=', 'donation_packages.id')
             ->where('donations.status', '=', ModerationStatus::APPROVED)
             ->groupBy('year', 'month')

--- a/app/Http/Controllers/Staff/HomeController.php
+++ b/app/Http/Controllers/Staff/HomeController.php
@@ -21,10 +21,10 @@ use App\Helpers\SystemInformation;
 use App\Http\Controllers\Controller;
 use App\Models\Group;
 use App\Services\Unit3dAnnounce;
+use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Spatie\SslCertificate\SslCertificate;
-use Exception;
 
 /**
  * @see \Tests\Todo\Feature\Http\Controllers\Staff\HomeControllerTest
@@ -75,6 +75,7 @@ class HomeController extends Controller
                 ->where(fn ($query) => $query->whereNull('assigned_to')->orWhere('assigned_to', '=', auth()->id()))
                 ->count(),
             'pendingApplicationsCount' => DB::table('applications')->where('status', '=', ModerationStatus::PENDING)->count(),
+            'pendingDonationsCount'    => DB::table('donations')->where('status', '=', ModerationStatus::PENDING)->count(),
             'certificate'              => $certificate,
             'uptime'                   => $systemInformation->uptime(),
             'ram'                      => $systemInformation->memory(),

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -120,7 +120,7 @@ class UserController extends Controller
                 ->first(),
             'watch'        => $user->watchlist,
             'externalUser' => ! $user->trashed() && $request->user()->group->is_modo ? Unit3dAnnounce::getUser($user->id) : false,
-            'donation'     => Donation::query()->where('status', '=', ModerationStatus::APPROVED)->where('user_id', '=', $user->id)->latest()->first(),
+            'donation'     => Donation::query()->where('status', '=', ModerationStatus::APPROVED)->where('user_id', '=', $user->id)->latest('updated_at')->first(),
         ]);
     }
 

--- a/app/View/Composers/TopNavComposer.php
+++ b/app/View/Composers/TopNavComposer.php
@@ -60,7 +60,7 @@ class TopNavComposer
             'donationPercentage' => value(function (): int|string {
                 $sum = Donation::query()
                     ->join('donation_packages', 'donations.package_id', '=', 'donation_packages.id')
-                    ->where('donations.created_at', '>=', now()->startOfMonth())
+                    ->where('donations.updated_at', '>=', now()->startOfMonth())
                     ->where('donations.status', ModerationStatus::APPROVED)
                     ->sum('donation_packages.cost');
 

--- a/database/migrations/2026_02_18_023757_change_donation_dates_to_timestamps.php
+++ b/database/migrations/2026_02_18_023757_change_donation_dates_to_timestamps.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('donations', function (Blueprint $table): void {
+            $table->timestamp('starts_at')->nullable()->change();
+            $table->timestamp('ends_at')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('donations', function (Blueprint $table): void {
+            $table->date('starts_at')->nullable()->change();
+            $table->date('ends_at')->nullable()->change();
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -499,8 +499,8 @@ CREATE TABLE `donations` (
   `package_id` int unsigned NOT NULL,
   `transaction` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `is_gifted` tinyint(1) NOT NULL DEFAULT '0',
-  `starts_at` date DEFAULT NULL,
-  `ends_at` date DEFAULT NULL,
+  `starts_at` timestamp DEFAULT NULL,
+  `ends_at` timestamp DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -3124,3 +3124,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (374,'2026_01_27_07
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (375,'2026_02_02_180456_add_foreign_keys_echoes_audibles_messages',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (376,'2026_02_03_012707_drop_keys_from_seedboxes',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (377,'2026_02_04_184040_combine_user_audibles_echoes',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (378,'2026_02_18_023757_change_donation_dates_to_timestamps',1);

--- a/resources/views/Staff/dashboard/index.blade.php
+++ b/resources/views/Staff/dashboard/index.blade.php
@@ -67,7 +67,10 @@
                                 href="{{ route('staff.donations.index') }}"
                             >
                                 <i class="{{ config('other.font-awesome') }} fa-money-bill"></i>
-                                Donations
+                                Donations ({{ $pendingDonationsCount }})
+                                @if ($pendingDonationsCount > 0)
+                                    <x-animation.notification />
+                                @endif
                             </a>
                         </p>
                         <p class="form__group form__group--horizontal">

--- a/resources/views/Staff/donation-gateway/edit.blade.php
+++ b/resources/views/Staff/donation-gateway/edit.blade.php
@@ -41,7 +41,7 @@
                         <tr>
                             <td>
                                 <input
-                                    type="text"
+                                    type="number"
                                     name="position"
                                     value="{{ $gateway->position }}"
                                     class="form__text"

--- a/resources/views/Staff/donation-gateway/index.blade.php
+++ b/resources/views/Staff/donation-gateway/index.blade.php
@@ -74,7 +74,8 @@
                                             @method('DELETE')
                                             <button
                                                 x-on:click.prevent="confirmAction"
-                                                data-b64-deletion-message="{{ base64_encode('Are you sure you want to delete this page: ' . $gateway->name . '?') }}"
+                                                data-allow-html="true"
+                                                data-b64-deletion-message="{{ base64_encode("Are you sure you want to delete this gateway:<br><br>#{$gateway->position} - <b>" . e($gateway->name) . '</b>') }}"
                                                 class="form__button form__button--text"
                                             >
                                                 {{ __('common.delete') }}

--- a/resources/views/Staff/donation-package/create.blade.php
+++ b/resources/views/Staff/donation-package/create.blade.php
@@ -28,7 +28,7 @@
                             <th>Position</th>
                             <th>Name</th>
                             <th>Description</th>
-                            <th>Cost</th>
+                            <th>Cost ({{ config('donation.currency') }})</th>
                             <th>Upload (Bytes)</th>
                             <th>Invite (#)</th>
                             <th>Bonus (#)</th>

--- a/resources/views/Staff/donation-package/edit.blade.php
+++ b/resources/views/Staff/donation-package/edit.blade.php
@@ -34,8 +34,8 @@
                                 <th>Position</th>
                                 <th>Name</th>
                                 <th>Description</th>
-                                <th>Cost</th>
-                                <th>Upload (GiB)</th>
+                                <th>Cost ({{ config('donation.currency') }})</th>
+                                <th>Upload (Bytes)</th>
                                 <th>Invite (#)</th>
                                 <th>Bonus (#)</th>
                                 <th>Supporter (Days)</th>
@@ -47,7 +47,7 @@
                             <tr>
                                 <td>
                                     <input
-                                        type="text"
+                                        type="number"
                                         name="position"
                                         value="{{ $package->position }}"
                                         class="form__text"
@@ -70,7 +70,7 @@
                                 <td>
                                     <input
                                         type="number"
-                                        step="0.01"
+                                        step="1.00"
                                         name="cost"
                                         value="{{ $package->cost }}"
                                         class="form__text"

--- a/resources/views/Staff/donation-package/index.blade.php
+++ b/resources/views/Staff/donation-package/index.blade.php
@@ -30,7 +30,7 @@
                     <tr>
                         <th>Position</th>
                         <th>Name</th>
-                        <th>Cost</th>
+                        <th>Cost ({{ config('donation.currency') }})</th>
                         <th>Upload (GiB)</th>
                         <th>Invite (#)</th>
                         <th>Bonus (#)</th>
@@ -50,7 +50,7 @@
                                     {{ $package->name }}
                                 </a>
                             </td>
-                            <td>$ {{ $package->cost }}</td>
+                            <td>{{ $package->cost }}</td>
                             <td>
                                 {{ App\Helpers\StringHelper::formatBytes($package->upload_value ?? 0) }}
                             </td>
@@ -90,7 +90,8 @@
                                             @method('DELETE')
                                             <button
                                                 x-on:click.prevent="confirmAction"
-                                                data-b64-deletion-message="{{ base64_encode('Are you sure you want to delete this page: ' . $package->name . '?') }}"
+                                                data-allow-html="true"
+                                                data-b64-deletion-message="{{ base64_encode("Are you sure you want to delete this package:<br><br>#{$package->position} - <b>" . e($package->name) . "</b> - {$package->cost}") }}"
                                                 class="form__button form__button--text"
                                             >
                                                 {{ __('common.delete') }}

--- a/resources/views/Staff/donation/index.blade.php
+++ b/resources/views/Staff/donation/index.blade.php
@@ -37,7 +37,7 @@
                         <th>Date</th>
                         <th>User</th>
                         <th>Transaction</th>
-                        <th>Cost</th>
+                        <th>Cost ({{ config('donation.currency') }})</th>
                         <th>Upload #</th>
                         <th>Invite #</th>
                         <th>Bonus #</th>
@@ -60,7 +60,7 @@
                                 class="{{ $donation->package->trashed() ? 'text-danger' : '' }}"
                                 title="{{ $donation->package->trashed() ? 'Package has been deleted' : '' }}"
                             >
-                                $ {{ $donation->package->cost }}
+                                {{ $donation->package->cost }}
                             </td>
                             <td
                                 class="{{ $donation->package->trashed() ? 'text-danger' : '' }}"
@@ -112,7 +112,8 @@
                                                 @csrf
                                                 <button
                                                     x-on:click.prevent="confirmAction"
-                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to approve this donation: ' . $donation->id . '?') }}"
+                                                    data-allow-html="true"
+                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to <b>approve</b> this donation:<br><br><b>' . e($donation->user->username) . "</b> - {$donation->created_at->diffForHumans()} - {$donation->package->cost}") }}"
                                                     class="form__button form__button--filled"
                                                 >
                                                     Approve
@@ -129,7 +130,8 @@
                                                 @csrf
                                                 <button
                                                     x-on:click.prevent="confirmAction"
-                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to reject this donation: ' . $donation->id . '?') }}"
+                                                    data-allow-html="true"
+                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to <b>reject</b> this donation:<br><br><b>' . e($donation->user->username) . "</b> - {$donation->created_at->diffForHumans()} - {$donation->package->cost}") }}"
                                                     class="form__button form__button--filled"
                                                 >
                                                     Reject

--- a/resources/views/donation/index.blade.php
+++ b/resources/views/donation/index.blade.php
@@ -115,7 +115,9 @@
 
         @foreach ($packages as $package)
             <dialog class="dialog" x-ref="dialog{{ $package->id }}">
-                <h4 class="dialog__heading">Donate $ {{ $package->cost }} USD</h4>
+                <h4 class="dialog__heading">
+                    Donate {{ $package->cost }} {{ config('donation.currency') }}
+                </h4>
                 <form
                     class="dialog__form"
                     method="POST"
@@ -148,10 +150,10 @@
                         <p class="text-info">
                             Send
                             <strong>
-                                $ {{ $package->cost }} {{ config('donation.currency') }}
+                                {{ $package->cost }} {{ config('donation.currency') }}
                             </strong>
-                            to gateway of your choice. Take note of the tx hash, receipt number, etc
-                            and input it below.
+                            to the gateway of your choice. Take note of the Tx hash, receipt number,
+                            etc. and input it below.
                         </p>
                     </div>
                     <div class="form__group--horizontal">
@@ -164,7 +166,7 @@
                                 id="package-cost"
                             />
                             <label for="package-cost" class="form__label form__label--floating">
-                                Cost
+                                Cost ({{ config('donation.currency') }})
                             </label>
                         </p>
                         <p class="form__group">
@@ -176,7 +178,7 @@
                                 name="transaction"
                             />
                             <label for="proof" class="form__label form__label--floating">
-                                Tx hash, Receipt number, Etc
+                                Tx hash, receipt number, etc.
                             </label>
                         </p>
                     </div>

--- a/resources/views/donation/index.blade.php
+++ b/resources/views/donation/index.blade.php
@@ -134,8 +134,9 @@
                                 <input
                                     class="form__text"
                                     type="text"
-                                    disabled
+                                    readonly
                                     value="{{ $gateway->address }}"
+                                    x-on:focus="$el.select()"
                                     id="{{ 'gateway-' . $gateway->id }}"
                                 />
                                 <label
@@ -161,8 +162,9 @@
                             <input
                                 class="form__text"
                                 type="text"
-                                disabled
+                                readonly
                                 value="{{ $package->cost }}"
+                                x-on:focus="$el.select()"
                                 id="package-cost"
                             />
                             <label for="package-cost" class="form__label form__label--floating">
@@ -173,6 +175,7 @@
                             <input
                                 class="form__text"
                                 type="text"
+                                autofocus
                                 value=""
                                 id="proof"
                                 name="transaction"

--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -173,9 +173,12 @@
             document.addEventListener('alpine:init', () => {
                 Alpine.data('confirmation', () => ({
                     confirmAction() {
+                        const swalMessage = atob(this.$el.dataset.b64DeletionMessage);
+                        const allowHtml = this.$el.dataset.allowHtml === 'true';
+
                         Swal.fire({
                             title: 'Are you sure?',
-                            text: atob(this.$el.dataset.b64DeletionMessage),
+                            ...(allowHtml ? { html: swalMessage } : { text: swalMessage }),
                             icon: 'warning',
                             showConfirmButton: true,
                             showCancelButton: true,

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -631,7 +631,7 @@
                     <div class="key-value__group">
                         <dt>Latest donation date</dt>
                         <dd>
-                            {{ $donation->starts_at ?? 'N/A' }}
+                            {{ $donation->updated_at ?? 'N/A' }}
                         </dd>
                     </div>
                     <div class="key-value__group">


### PR DESCRIPTION
1. Using `date` type for donation's `starts_at` and `ends_at` times leads to up to 24 hours of lost paid time for all donors. Example:
    - Admin notices a "7 days VIP" donation at 23:59 UTC on Monday, February 16th and instantly approves it
    - `starts_at` value is set to `2026-02-16` without a time (`00:00:00` internally); server time is also UTC
    - `ends_at` value is set to `2026-02-23` without a time (`00:00:00` internally)
    - On February 23rd a scheduled script `auto:remove_expired_donors` starts at `00:00:01` and sets `is_donor` for this user to `false`: https://github.com/HDInnovations/UNIT3D/blob/fd63b96269b7c17396e968ab65450d2e4222c3f1/app/Console/Commands/AutoRemoveExpiredDonors.php#L54-L56
    - Result: user only got 6 whole days of the VIP status, from Tuesday to Sunday
    - Note: `timestamp` type is chosen instead of `datetime` because it automatically adjusts values to the server timezone in case the admin decides to change it (not a single second will be lost)
    - Note: After this change users will get extra donor time depending on when the admin approves a donation and when the scheduled script starts. If it's undesirable, replace `->daily()` in `Console/Kernel.php` with `twiceDaily()`, `everySixHours()`, etc.
    - <img width="1269" height="276" alt="donate-lost" src="https://github.com/user-attachments/assets/8087f064-685b-4ea7-988e-681ea586f0b3" />

2. Donations should be sorted by `updated_at` property in sum and goal calculations. Example:
    - User sends a donation on February 28th (`created_at` = `2026-02-28`)
    - Admin notices it on March 1st and approves it (`updated_at` = `2026-03-01`)
    - It is counted towards the previous month in the charts and not counted towards the updated goal at all
    - Also change it for the profile view because "Latest donation" should mean "Latest approved donation" in case a user sends multiple ones and the admin approves them in a random order *(this is also needed for the next fix)*

3. Correctly set start and end times for donations made by the same user when the current donation is still active
    - Also display `updated_at` instead of `starts_at` for "Latest donation date" because after this change `starts_at` might be in the future
    - If there's only one active donation, these values will be the same
    - <img width="1269" height="276" alt="donate-multi" src="https://github.com/user-attachments/assets/e36feddb-09b6-44ea-98d3-abc93a09537c" />

4. Remove some hardcoded `USD` and `$` text from the donation modal
    - Also add currency inside the Cost label
    - Fix some grammar mistakes; "etc." should always have a dot
    - Use the same letter case in two places

5. Add "Pending donations count" to the Staff Dashboard, same as for Applications (with an animated badge)
