### PR TITLE
(Fix) Select background color, correct CSS property

### DIFF
--- a/resources/sass/components/form/_select.scss
+++ b/resources/sass/components/form/_select.scss
@@ -15,7 +15,7 @@
 
 .form__select {
     background-color: inherit;
-    background: var(--select-icon);
+    background-image: var(--select-icon);
     background-size: 16px;
     background-position: calc(100% - 4px) center;
     background-repeat: no-repeat;


### PR DESCRIPTION
Currently `background-color` is ignored because `background` overrides it to `transparent`.
MDN: [Shorthand_properties#tricky_edge_cases](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties#tricky_edge_cases)

`--select-icon` is a `url()`
https://github.com/HDInnovations/UNIT3D/blob/fd63b96269b7c17396e968ab65450d2e4222c3f1/resources/sass/themes/_galactic.scss#L323

Before and after:

![form-bg-color](https://github.com/user-attachments/assets/29981864-aaba-455f-9a77-84decb18f542)