### PR TITLE
(Fix) Update selected option logic in giveaway edit view

### DIFF
--- a/resources/views/Staff/giveaway/edit.blade.php
+++ b/resources/views/Staff/giveaway/edit.blade.php
@@ -273,13 +273,13 @@
                                                     >
                                                         <option
                                                             value="bon"
-                                                            @selected($giveaway->type === 'bon')
+                                                            @selected($prize->type === 'bon')
                                                         >
                                                             {{ __('bon.bon') }}
                                                         </option>
                                                         <option
                                                             value="fl_tokens"
-                                                            @selected($giveaway->type === 'fl_tokens')
+                                                            @selected($prize->type === 'fl_tokens')
                                                         >
                                                             {{ __('common.fl_tokens') }}
                                                         </option>


### PR DESCRIPTION
This pull request makes a minor fix to the giveaway edit form to ensure that the correct prize type is selected when editing a giveaway. Currently, it defaults to BON when you edit a prize.

* Updated the `@selected` directive in the `resources/views/Staff/giveaway/edit.blade.php` form so it checks `$prize->type` instead of `$giveaway->type`, ensuring the correct option is pre-selected based on the prize's type.