### PR TITLE
(Fix) Unassign staff from tickets on demotion

### DIFF
--- a/app/Http/Controllers/Staff/UserController.php
+++ b/app/Http/Controllers/Staff/UserController.php
@@ -33,7 +33,6 @@ use App\Models\Post;
 use App\Models\PrivateMessage;
 use App\Models\Scopes\ApprovedScope;
 use App\Models\Thank;
-use App\Models\Ticket;
 use App\Models\Topic;
 use App\Models\Torrent;
 use App\Models\User;
@@ -77,12 +76,6 @@ class UserController extends Controller
         $group = Group::query()->findOrFail($request->group_id);
 
         abort_if(! $staff->group->is_owner && ($staff->group->level <= $user->group->level || $staff->group->level <= $group->level), 403);
-
-        if ($user->group->is_modo && !$group->is_modo) {
-            Ticket::query()->where('staff_id', '=', $user->id)->update([
-                'staff_id' => null,
-            ]);
-        }
 
         $user->update($request->validated());
 

--- a/app/Http/Controllers/Staff/UserController.php
+++ b/app/Http/Controllers/Staff/UserController.php
@@ -33,6 +33,7 @@ use App\Models\Post;
 use App\Models\PrivateMessage;
 use App\Models\Scopes\ApprovedScope;
 use App\Models\Thank;
+use App\Models\Ticket;
 use App\Models\Topic;
 use App\Models\Torrent;
 use App\Models\User;
@@ -76,6 +77,12 @@ class UserController extends Controller
         $group = Group::query()->findOrFail($request->group_id);
 
         abort_if(! $staff->group->is_owner && ($staff->group->level <= $user->group->level || $staff->group->level <= $group->level), 403);
+
+        if ($user->group->is_modo && !$group->is_modo) {
+            Ticket::query()->where('staff_id', '=', $user->id)->update([
+                'staff_id' => null,
+            ]);
+        }
 
         $user->update($request->validated());
 

--- a/app/Http/Livewire/Comment.php
+++ b/app/Http/Livewire/Comment.php
@@ -173,7 +173,11 @@ class Comment extends Component
                 }
 
                 if (!\in_array($this->comment->user_id, [$ticket->staff_id, $ticket->user_id, $this->user->id])) {
-                    User::query()->find($this->comment->user_id)->notify(new NewComment($this->model, $reply));
+                    $staff = User::query()->with('group')->find($this->comment->user_id);
+
+                    if ($staff?->group->is_modo) {
+                        $staff->notify(new NewComment($ticket, $reply));
+                    }
                 }
 
                 break;

--- a/app/Http/Livewire/Comments.php
+++ b/app/Http/Livewire/Comments.php
@@ -135,7 +135,16 @@ class Comments extends Component
         switch ($this->model::class) {
             case Ticket::class:
                 // Notify assigned staff if needed
-                User::query()->find($this->model->staff_id)?->notify(new NewComment($this->model, $comment));
+                if ($this->model->staff_id) {
+                    $staff = User::query()->with('group')->find($this->model->staff_id);
+
+                    if ($staff?->group->is_modo) {
+                        $staff->notify(new NewComment($this->model, $comment));
+                    } else {
+                        // Staff has been demoted since ticket was assigned, do not notify
+                        $this->model->update(['staff_id' => null]);
+                    }
+                }
 
                 // Notify ticket creator if needed
                 User::query()->find($this->model->user_id)?->notify(new NewComment($this->model, $comment));


### PR DESCRIPTION
Remove a user as an assignee from all their tickets when getting demoted from a staff user group.
This is to prevent notifications from tickets that they can no longer access.

Fixes #5281 