### PR TITLE
(Refactor) Remove redundant ci action cache save step 

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,91 @@
+name: Initial Setup
+
+inputs:
+    php-version:
+        type: string
+        default: ""
+    operating-system:
+        required: true
+        type: string
+
+runs:
+    using: "composite"
+    steps:
+        # 1. Setup PHP
+        -   name: Setup PHP
+            uses: shivammathur/setup-php@v2
+            with:
+                php-version: ${{ inputs.php-version }}
+                extensions: curl, dom, gd, libxml, mbstring, zip, mysql, xml, intl, bcmath, redis-phpredis/phpredis@6.0.1
+                ini-values: error_reporting=E_ALL
+                coverage: pcov
+                tools: composer:v2
+            env:
+                REDIS_CONFIGURE_OPTS: --enable-redis
+
+        # 2. Composer Dependencies
+        -   name: Get Composer cache directory
+            id: composer-cache
+            run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+            shell: bash
+
+        -   name: Restore Composer cache
+            uses: actions/cache/restore@v4
+            with:
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+                restore-keys: |
+                    unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-composer-
+
+        -   name: Install Composer dependencies
+            env:
+                COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+            run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --optimize-autoloader
+            shell: bash
+
+        -   name: Save Composer cache
+            uses: actions/cache/save@v4
+            with:
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+
+        # 3. Bun Dependencies
+        -   name: Setup Bun
+            uses: oven-sh/setup-bun@v2
+            with:
+                bun-version: latest
+
+        -   name: Restore Bun cache
+            uses: actions/cache/restore@v4
+            with:
+                path: ~/.bun/install/cache
+                key: unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-bun-${{ hashFiles('**/bun.lockb') }}
+                restore-keys: |
+                    unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-bun-
+
+        -   name: Install Bun dependencies
+            run: bun ci
+            shell: bash
+
+        -   name: Compile assets
+            run: bun run build
+            shell: bash
+
+        -   name: Save Bun cache
+            uses: actions/cache/save@v4
+            with:
+                path: ~/.bun/install/cache
+                key: unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-bun-${{ hashFiles('**/bun.lockb') }}
+
+        # 4. Prepare Application
+        -   name: Prepare Laravel environment
+            run: cp .env.example .env
+            shell: bash
+
+        -   name: Generate application key
+            run: php artisan key:generate
+            shell: bash
+
+        -   name: Clear application cache
+            run: php artisan clear:all_cache
+            shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,7 +30,7 @@ runs:
             shell: bash
 
         -   name: Restore Composer cache
-            uses: actions/cache/restore@v4
+            uses: actions/cache@v4
             with:
                 path: ${{ steps.composer-cache.outputs.dir }}
                 key: unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -43,12 +43,6 @@ runs:
             run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --optimize-autoloader
             shell: bash
 
-        -   name: Save Composer cache
-            uses: actions/cache/save@v4
-            with:
-                path: ${{ steps.composer-cache.outputs.dir }}
-                key: unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-
         # 3. Bun Dependencies
         -   name: Setup Bun
             uses: oven-sh/setup-bun@v2
@@ -56,7 +50,7 @@ runs:
                 bun-version: latest
 
         -   name: Restore Bun cache
-            uses: actions/cache/restore@v4
+            uses: actions/cache@v4
             with:
                 path: ~/.bun/install/cache
                 key: unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-bun-${{ hashFiles('**/bun.lockb') }}
@@ -70,12 +64,6 @@ runs:
         -   name: Compile assets
             run: bun run build
             shell: bash
-
-        -   name: Save Bun cache
-            uses: actions/cache/save@v4
-            with:
-                path: ~/.bun/install/cache
-                key: unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-bun-${{ hashFiles('**/bun.lockb') }}
 
         # 4. Prepare Application
         -   name: Prepare Laravel environment

--- a/.github/workflows/compile-assets-test.yml
+++ b/.github/workflows/compile-assets-test.yml
@@ -17,66 +17,8 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            # 2. Setup PHP
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+            # 2. Setup
+            -   uses: ./.github/actions/setup
                 with:
                     php-version: ${{ matrix.php-version }}
-                    extensions: curl, dom, gd, libxml, mbstring, zip, mysql, xml, intl, bcmath, redis-phpredis/phpredis@6.0.1
-                    ini-values: error_reporting=E_ALL
-                    coverage: pcov
-                    tools: composer:v2
-                env:
-                    REDIS_CONFIGURE_OPTS: --enable-redis
-
-            # 3. Composer Dependencies
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: Restore Composer cache
-                uses: actions/cache/restore@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: |
-                        unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-
-
-            -   name: Install Composer dependencies
-                env:
-                    COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
-                run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --optimize-autoloader
-
-            -   name: Save Composer cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-
-            # 4. Bun Dependencies
-            -   name: Setup Bun
-                uses: oven-sh/setup-bun@v2
-                with:
-                    bun-version: latest
-
-            -   name: Restore Bun cache
-                uses: actions/cache/restore@v4
-                with:
-                    path: ~/.bun/install/cache
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-bun-${{ hashFiles('**/bun.lockb') }}
-                    restore-keys: |
-                        unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-bun-
-
-            -   name: Install Bun dependencies
-                run: bun ci
-
-            -   name: Compile assets
-                run: bun run build
-
-            -   name: Save Bun cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ~/.bun/install/cache
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-bun-${{ hashFiles('**/bun.lockb') }}
+                    operating-system: ${{ matrix.operating-system }}

--- a/.github/workflows/larastan.yml
+++ b/.github/workflows/larastan.yml
@@ -35,50 +35,13 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            # 2. Setup PHP
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+            # 2. Setup
+            -   uses: ./.github/actions/setup
                 with:
                     php-version: ${{ matrix.php-version }}
-                    extensions: bcmath, ctype, dom, fileinfo, json, libxml, mbstring, openssl, pdo, tokenizer, xml, zip
-                    coverage: none
+                    operating-system: ${{ matrix.operating-system }}
 
-            # 3. Composer Dependencies
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: Restore Composer cache
-                uses: actions/cache/restore@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: |
-                        unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-
-
-            -   name: Install Composer dependencies
-                env:
-                    COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
-                run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-
-            -   name: Save Composer cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-
-            # 4. Prepare Application
-            -   name: Prepare Laravel environment
-                run: cp .env.example .env
-
-            -   name: Generate application key
-                run: php artisan key:generate
-
-            -   name: Clear application cache
-                run: php artisan optimize:clear
-
-            # 5. PHPStan Analysis
+            # 3. PHPStan Analysis
             -   name: Restore PHPStan cache
                 uses: actions/cache/restore@v4
                 with:

--- a/.github/workflows/larastan.yml
+++ b/.github/workflows/larastan.yml
@@ -43,7 +43,7 @@ jobs:
 
             # 3. PHPStan Analysis
             -   name: Restore PHPStan cache
-                uses: actions/cache/restore@v4
+                uses: actions/cache@v4
                 with:
                     path: .phpstan.cache
                     key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-phpstan-${{ github.run_id }}
@@ -52,10 +52,3 @@ jobs:
 
             -   name: Run Larastan
                 run: ./vendor/bin/phpstan analyse -vvv --memory-limit=2G
-
-            -   name: Save PHPStan cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: .phpstan.cache
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-phpstan-${{ github.run_id }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,44 +17,13 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            # 2. Setup PHP
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+            # 2. Setup
+            -   uses: ./.github/actions/setup
                 with:
                     php-version: ${{ matrix.php-version }}
-                    extensions: curl, dom, gd, libxml, mbstring, zip, mysql, xml, intl, bcmath, redis-phpredis/phpredis@6.0.1
-                    ini-values: error_reporting=E_ALL
-                    coverage: pcov
-                    tools: composer:v2
-                env:
-                    REDIS_CONFIGURE_OPTS: --enable-redis
+                    operating-system: ${{ matrix.operating-system }}
 
-            # 3. Composer Dependencies
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: Restore Composer cache
-                uses: actions/cache/restore@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: |
-                        unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-
-
-            -   name: Install Composer dependencies
-                env:
-                    COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
-                run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --optimize-autoloader
-
-            -   name: Save Composer cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-
-            # 4. Run Pint
+            # 3. Run Pint
             -   name: Restore Pint cache
                 uses: actions/cache/restore@v4
                 with:
@@ -73,7 +42,7 @@ jobs:
                     path: .pint.cache
                     key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-pint-${{ github.run_id }}
 
-            # 5. Commit Changes
+            # 4. Commit Changes
             -   name: Commit changes
                 uses: stefanzweifel/git-auto-commit-action@v7
                 with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
 
             # 3. Run Pint
             -   name: Restore Pint cache
-                uses: actions/cache/restore@v4
+                uses: actions/cache@v4
                 with:
                     path: .pint.cache
                     key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-pint-${{ github.run_id }}
@@ -34,13 +34,6 @@ jobs:
 
             -   name: Run Pint
                 run: ./vendor/bin/pint -v
-
-            -   name: Save Pint cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: .pint.cache
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-pint-${{ github.run_id }}
 
             # 4. Commit Changes
             -   name: Commit changes

--- a/.github/workflows/phpunit-test.yml
+++ b/.github/workflows/phpunit-test.yml
@@ -36,81 +36,13 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            # 2. Setup PHP
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+            # 2. Setup
+            -   uses: ./.github/actions/setup
                 with:
                     php-version: ${{ matrix.php-version }}
-                    extensions: curl, dom, gd, libxml, mbstring, zip, mysql, xml, intl, bcmath, redis-phpredis/phpredis@6.0.1
-                    ini-values: error_reporting=E_ALL
-                    coverage: pcov
-                    tools: composer:v2
-                env:
-                    REDIS_CONFIGURE_OPTS: --enable-redis
+                    operating-system: ${{ matrix.operating-system }}
 
-            # 3. Composer Dependencies
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: Restore Composer cache
-                uses: actions/cache/restore@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: |
-                        unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-
-
-            -   name: Install Composer dependencies
-                env:
-                    COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
-                run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --optimize-autoloader
-
-            -   name: Save Composer cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-
-            # 4. Bun Dependencies
-            -   name: Setup Bun
-                uses: oven-sh/setup-bun@v2
-                with:
-                    bun-version: latest
-
-            -   name: Restore Bun cache
-                uses: actions/cache/restore@v4
-                with:
-                    path: ~/.bun/install/cache
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-bun-${{ hashFiles('**/bun.lockb') }}
-                    restore-keys: |
-                        unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-bun-
-
-            -   name: Install Bun dependencies
-                run: bun ci
-
-            -   name: Compile assets
-                run: bun run build
-
-            -   name: Save Bun cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ~/.bun/install/cache
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-bun-${{ hashFiles('**/bun.lockb') }}
-
-            # 5. Prepare Application
-            -   name: Prepare Laravel environment
-                run: cp .env.example .env
-
-            -   name: Generate application key
-                run: php artisan key:generate
-
-            -   name: Clear application cache
-                run: php artisan clear:all_cache
-
-            # 6. PHPUnit Tests
+            # 3. PHPUnit Tests
             -   name: Restore PHPUnit cache
                 uses: actions/cache/restore@v4
                 with:

--- a/.github/workflows/phpunit-test.yml
+++ b/.github/workflows/phpunit-test.yml
@@ -44,7 +44,7 @@ jobs:
 
             # 3. PHPUnit Tests
             -   name: Restore PHPUnit cache
-                uses: actions/cache/restore@v4
+                uses: actions/cache@v4
                 with:
                     path: .phpunit.cache
                     key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-phpunit-${{ github.run_id }}
@@ -60,10 +60,3 @@ jobs:
                     DB_DATABASE: unit3d
                     DB_PASSWORD: null
                     CACHE_STORE: array
-
-            -   name: Save PHPUnit cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: .phpunit.cache
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-phpunit-${{ github.run_id }}

--- a/.github/workflows/prettier-blade.yml
+++ b/.github/workflows/prettier-blade.yml
@@ -22,7 +22,7 @@ jobs:
                     bun-version: latest
 
             -   name: Restore Bun cache
-                uses: actions/cache/restore@v4
+                uses: actions/cache@v4
                 with:
                     path: ~/.bun/install/cache
                     key: unit3d-${{ matrix.operating-system }}-bun-${{ hashFiles('**/bun.lockb') }}
@@ -32,16 +32,9 @@ jobs:
             -   name: Install Bun dependencies
                 run: bun ci
 
-            -   name: Save Bun cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ~/.bun/install/cache
-                    key: unit3d-${{ matrix.operating-system }}-bun-${{ hashFiles('**/bun.lockb') }}
-
             # 3. Format Files
             -   name: Restore Prettier cache
-                uses: actions/cache/restore@v4
+                uses: actions/cache@v4
                 with:
                     path: .prettier.cache
                     key: unit3d-${{ matrix.operating-system }}-prettier-${{ github.run_id }}
@@ -50,13 +43,6 @@ jobs:
 
             -   name: Run Prettier
                 run: bunx prettier --cache --cache-location .prettier.cache/format-results -w *
-
-            -   name: Save Prettier cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: .prettier.cache
-                    key: unit3d-${{ matrix.operating-system }}-prettier-${{ github.run_id }}
 
             # 4. Commit Changes
             -   name: Commit changes

--- a/.github/workflows/schema-dump.yml
+++ b/.github/workflows/schema-dump.yml
@@ -35,54 +35,13 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            # 2. Setup PHP
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+            # 2. Setup
+            -   uses: ./.github/actions/setup
                 with:
                     php-version: ${{ matrix.php-version }}
-                    extensions: curl, dom, gd, libxml, mbstring, zip, mysql, xml, intl, bcmath, redis-phpredis/phpredis@6.0.1
-                    ini-values: error_reporting=E_ALL
-                    coverage: none
-                    tools: composer:v2
-                env:
-                    REDIS_CONFIGURE_OPTS: --enable-redis
+                    operating-system: ${{ matrix.operating-system }}
 
-            # 3. Composer Dependencies
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: Restore Composer cache
-                uses: actions/cache/restore@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: |
-                        unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-
-
-            -   name: Install Composer dependencies
-                env:
-                    COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
-                run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-
-            -   name: Save Composer cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-
-            # 4. Prepare Application
-            -   name: Prepare Laravel environment
-                run: cp .env.example .env
-
-            -   name: Generate application key
-                run: php artisan key:generate
-
-            -   name: Clear application cache
-                run: php artisan optimize:clear
-
-            # 5. Generate Schema Dump
+            # 3. Generate Schema Dump
             -   name: Run Migrations
                 run: php artisan migrate --force --schema-path=database/schema/mysql-schema-new.sql
                 env:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -22,7 +22,7 @@ jobs:
                     bun-version: latest
 
             -   name: Restore Bun cache
-                uses: actions/cache/restore@v4
+                uses: actions/cache@v4
                 with:
                     path: ~/.bun/install/cache
                     key: unit3d-${{ matrix.operating-system }}-bun-${{ hashFiles('**/bun.lockb') }}
@@ -32,16 +32,9 @@ jobs:
             -   name: Install Bun dependencies
                 run: bun ci
 
-            -   name: Save Bun cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ~/.bun/install/cache
-                    key: unit3d-${{ matrix.operating-system }}-bun-${{ hashFiles('**/bun.lockb') }}
-
             # 3. Run Spell Check
             -   name: Restore CSpell cache
-                uses: actions/cache/restore@v4
+                uses: actions/cache@v4
                 with:
                     path: .cspell.cache
                     key: unit3d-${{ matrix.operating-system }}-cspell-${{ github.run_id }}
@@ -50,10 +43,3 @@ jobs:
 
             -   name: Run CSpell
                 run: bunx cspell --no-progress --cache --cache-location .cspell.cache/spell-results "**"
-
-            -   name: Save CSpell cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: .cspell.cache
-                    key: unit3d-${{ matrix.operating-system }}-cspell-${{ github.run_id }}

--- a/.github/workflows/type-coverage.yml
+++ b/.github/workflows/type-coverage.yml
@@ -17,69 +17,42 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            # 2. Setup PHP
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+            # 2. Setup
+            -   uses: ./.github/actions/setup
                 with:
                     php-version: ${{ matrix.php-version }}
-                    extensions: bcmath, ctype, dom, fileinfo, json, libxml, mbstring, openssl, pdo, tokenizer, xml, zip
-                    coverage: none
+                    operating-system: ${{ matrix.operating-system }}
 
-            # 3. Composer Dependencies
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: Restore Composer cache
-                uses: actions/cache/restore@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-                    restore-keys: |
-                        unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-
-
-            -   name: Install Composer dependencies
-                env:
-                    COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
-                run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-
-            -   name: Save Composer cache
-                uses: actions/cache/save@v4
-                if: always()
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: unit3d-${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-
-            # 4. Type Coverage Analysis
+            # 3. Type Coverage Analysis
             -   name: Restore baseline coverage cache
                 uses: actions/cache/restore@v4
                 id: cache-baseline
                 with:
                     path: baseline-type-coverage.txt
                     key: type-coverage-baseline-master
-            
+
             -   name: Run Type Coverage
                 run: |
                     ./vendor/bin/pest --type-coverage --min=0 > type-coverage.txt
                     cat type-coverage.txt
-            
+
             -   name: Extract Coverage Percentage
                 id: coverage
                 run: |
                     COVERAGE=$(grep -oP 'Total: \K[0-9.]+' type-coverage.txt || echo "0")
                     echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
                     echo "Type Coverage: $COVERAGE%"
-            
+
             -   name: Compare Coverage Against Baseline
                 if: github.event_name == 'pull_request'
                 run: |
                     CURRENT_COVERAGE=${{ steps.coverage.outputs.percentage }}
-                    
+
                     if [ -f baseline-type-coverage.txt ]; then
                         BASELINE_COVERAGE=$(cat baseline-type-coverage.txt)
                         echo "📊 Current Coverage: $CURRENT_COVERAGE%"
                         echo "📈 Baseline Coverage: $BASELINE_COVERAGE%"
-                        
+
                         # Use bc for floating point comparison
                         if (( $(echo "$CURRENT_COVERAGE < $BASELINE_COVERAGE" | bc -l) )); then
                             DIFF=$(echo "$BASELINE_COVERAGE - $CURRENT_COVERAGE" | bc -l)
@@ -94,19 +67,19 @@ jobs:
                         echo "⚠️  No baseline coverage found. Skipping comparison."
                         echo "::warning::No baseline type coverage found. Baseline will be established when merged to master."
                     fi
-            
+
             -   name: Save Baseline Coverage to File
                 if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'HDInnovations/UNIT3D'
                 run: |
                     echo "${{ steps.coverage.outputs.percentage }}" > baseline-type-coverage.txt
-            
+
             -   name: Save Baseline Coverage Cache
                 if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'HDInnovations/UNIT3D'
                 uses: actions/cache/save@v4
                 with:
                     path: baseline-type-coverage.txt
                     key: type-coverage-baseline-master
-            
+
             -   name: Create Coverage Badge
                 if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'HDInnovations/UNIT3D'
                 uses: schneegans/dynamic-badges-action@v1.7.0


### PR DESCRIPTION
The `cache` action automatically saves the path at the end of the job.

Depends on #5288 