### PR TITLE
(Update) Remove torrentSearch and TmdbPersonCredit from phpstan excludePaths

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -457,6 +457,36 @@ parameters:
 			path: app/Http/Livewire/TorrentRequestSearch.php
 
 		-
+			message: '#^Access to an undefined property App\\Models\\Torrent\:\:\$meta\.$#'
+			identifier: property.notFound
+			count: 2
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
+			message: '#^Anonymous function should return Illuminate\\Support\\Collection\<int, string\|null\> but returns Illuminate\\Support\\Collection\<int, string\|null\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
+			message: '#^Get hook for property App\\Http\\Livewire\\TorrentSearch\:\:\$groupedTorrents should return Illuminate\\Pagination\\LengthAwarePaginator\<int, App\\Models\\TmdbMovie\|App\\Models\\TmdbTv\|null\> but returns Illuminate\\Pagination\\LengthAwarePaginator\<int, App\\Models\\TmdbMovie\|App\\Models\\TmdbTv\|null\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
+			message: '#^Get hook for property App\\Http\\Livewire\\TorrentSearch\:\:\$primaryLanguages should return Illuminate\\Support\\Collection\<int, string\|null\> but returns Illuminate\\Support\\Collection\<int, string\|null\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
+			message: '#^Parameter \#3 \$callback of method Illuminate\\Cache\\Repository\:\:flexible\(\) expects callable\(\)\: Illuminate\\Support\\Collection\<int, string\|null\>, Closure\(\)\: Illuminate\\Support\\Collection\<int, string\|null\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Livewire/TorrentSearch.php
+
+		-
 			message: '#^Method App\\Http\\Middleware\\SetLanguage\:\:setSystemLocale\(\) has parameter \$request with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,8 +17,6 @@ parameters:
     excludePaths:
         - app/Helpers/Markdown.php
         - app/Helpers/MarkdownExtra.php
-        - app/Http/Livewire/TmdbPersonCredit.php
-        - app/Http/Livewire/TorrentSearch.php
         - bootstrap/cache
     level: 7
     checkOctaneCompatibility: true


### PR DESCRIPTION
Take 2. Last time the errors were adjusted but the config wasn't actually touched (#5213).