### PR TITLE
(Remove) Unused parameters in chat repository

### DIFF
--- a/app/Repositories/ChatRepository.php
+++ b/app/Repositories/ChatRepository.php
@@ -199,37 +199,20 @@ class ChatRepository
         }
     }
 
-    public function systemMessage(string $message, ?int $bot = null): static
+    public function systemMessage(string $message): void
     {
-        if ($bot) {
-            $this->message(User::SYSTEM_USER_ID, $this->systemChatroom(), $message, null, $bot);
-        } else {
-            $systemBotId = Bot::query()->where('command', 'systembot')->first()->id;
+        $systemBotId = Bot::query()->where('command', 'systembot')->value('id');
 
-            $this->message(User::SYSTEM_USER_ID, $this->systemChatroom(), $message, null, $systemBotId);
-        }
-
-        return $this;
-    }
-
-    public function systemChatroom(int|Chatroom|string|null $room = null): int
-    {
         $config = config('chat.system_chatroom');
 
-        if ($room !== null) {
-            if ($room instanceof Chatroom) {
-                $room = $room->id;
-            } elseif (\is_int($room)) {
-                $room = Chatroom::query()->findOrFail($room)->id;
-            } else {
-                $room = Chatroom::query()->where('name', '=', $room)->first()->id;
-            }
-        } elseif (\is_int($config)) {
-            $room = Chatroom::query()->findOrFail($config)->id;
-        } else {
-            $room = Chatroom::query()->where('name', '=', $config)->first()->id;
-        }
+        $systemChatroomId = Chatroom::query()
+            ->when(
+                \is_int($config),
+                fn ($query) => $query->where('id', '=', $config),
+                fn ($query) => $query->where('name', '=', $config),
+            )
+            ->value('id');
 
-        return $room;
+        $this->message(User::SYSTEM_USER_ID, $systemChatroomId, $message, null, $systemBotId);
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -577,12 +577,6 @@ parameters:
 			path: app/Providers/FortifyServiceProvider.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\Chatroom\>\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Repositories/ChatRepository.php
-
-		-
 			message: '#^Call to function is_int\(\) with string\|null will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1


### PR DESCRIPTION
The optional parameters always use the default, so remove the branches that are never reached and simplify the code.