### PR TITLE
(Remove) Unused chatbox auto deleting message limits

### DIFF
--- a/app/Repositories/ChatRepository.php
+++ b/app/Repositories/ChatRepository.php
@@ -36,8 +36,6 @@ class ChatRepository
             'bot_id'      => $bot,
         ]);
 
-        $this->checkMessageLimits($roomId);
-
         broadcast(new MessageSent($message));
 
         return $message;
@@ -174,29 +172,6 @@ class ChatRepository
             ->latest('id')
             ->limit(config('chat.message_limit'))
             ->get();
-    }
-
-    public function checkMessageLimits(int $roomId): void
-    {
-        $messages = $this->messages($roomId);
-        $limit = config('chat.message_limit');
-        $count = $messages->count();
-
-        // Lets purge all old messages and keep the database to the limit settings
-        if ($count > $limit) {
-            $deleteCount = $count - $limit;
-
-            for ($x = 1; $x <= $deleteCount; $x++) {
-                $message = $messages->last();
-                echo $message['id']."\n";
-
-                $message = Message::query()->find($message->id);
-
-                if ($message->receiver_id === null) {
-                    $message->delete();
-                }
-            }
-        }
     }
 
     public function systemMessage(string $message): void


### PR DESCRIPTION
This functionality never worked. It first takes n messages in `messages()`, then counts the number of messages, then compares the count to n, then deletes every message that has an index lower than count minus n. But, because the count is always equal or lower than n, no messages are ever deleted. Because this feature has existed for so long as is, it would probably scare people if it started deleting data. So, let's remove its unused usecase instead.