### PR TITLE
(Fix) mediainfo max in StoreTorrentRequest

### DIFF
--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -132,7 +132,7 @@ class StoreTorrentRequest extends FormRequest
             'mediainfo' => [
                 'nullable',
                 'sometimes',
-                'max:65535',
+                'max:2097152',
             ],
             'bdinfo' => [
                 'nullable',


### PR DESCRIPTION
[Commit 05b727f](https://github.com/HDInnovations/UNIT3D/commit/05b727f72286cc4fc65923e0c9d3748293f70a62) changed mediainfo from TEXT -> LONGTEXT and the existing 65535 is a holdover from the previous datatype. 

This PR increases mediainfo to 2097152 [2MB] to match the existing LONGTEXT items.