### PR TITLE
(Fix) Torrent completed highlight on torrent search page

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -469,7 +469,7 @@ class TorrentSearch extends Component
                         ->where('seeder', '=', 0),
                     'history as completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                         ->where('active', '=', 0)
-                        ->where('seeder', '=', 0),
+                        ->where('seeder', '=', 1),
                     'trump',
                 ])
                 ->selectRaw(<<<'SQL'


### PR DESCRIPTION
Typo. Every other query that searches for this is correct. Align this query to match the others.