### PR TITLE
(Fix) Clearing app cache clears personal freeleeches

### DIFF
--- a/app/Http/Controllers/SimilarTorrentController.php
+++ b/app/Http/Controllers/SimilarTorrentController.php
@@ -18,6 +18,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Category;
 use App\Models\IgdbGame;
+use App\Models\PersonalFreeleech;
 use App\Models\TmdbMovie;
 use App\Models\Torrent;
 use App\Models\TorrentRequest;
@@ -88,7 +89,7 @@ class SimilarTorrentController extends Controller
                 abort(404, 'No Similar Torrents Found');
         }
 
-        $personalFreeleech = cache()->get('personal_freeleech:'.auth()->id());
+        $personalFreeleech = PersonalFreeleech::query()->where('user_id', '=', auth()->id())->exists();
 
         return view('torrent.similar', [
             'meta'               => $meta,

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -28,6 +28,7 @@ use App\Models\Distributor;
 use App\Models\History;
 use App\Models\IgdbGame;
 use App\Models\Keyword;
+use App\Models\PersonalFreeleech;
 use App\Models\Region;
 use App\Models\Resolution;
 use App\Models\Scopes\ApprovedScope;
@@ -229,7 +230,7 @@ class TorrentController extends Controller
                         || now()->isBefore($torrent->created_at->addDay())
                     )
                 ),
-            'personal_freeleech' => cache()->get('personal_freeleech:'.$user->id),
+            'personal_freeleech' => PersonalFreeleech::query()->where('user_id', '=', $user->id)->exists(),
             'mediaInfo'          => $torrent->mediainfo !== null ? (new MediaInfo())->parse($torrent->mediainfo) : null,
             'fileTree'           => $fileTree,
             'alsoDownloaded'     => cache()->flexible(

--- a/app/Http/Controllers/User/TransactionController.php
+++ b/app/Http/Controllers/User/TransactionController.php
@@ -87,7 +87,7 @@ class TransactionController extends Controller
 
                     break;
                 case $bonExchange->personal_freeleech:
-                    if (cache()->get('personal_freeleech:'.$user->id)) {
+                    if (PersonalFreeleech::query()->where('user_id', '=', $user->id)->exists()) {
                         return back()->withErrors('Your previous personal freeleech is still active.');
                     }
 

--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -21,6 +21,7 @@ use App\Models\Category;
 use App\Models\Distributor;
 use App\Models\History;
 use App\Models\IgdbGame;
+use App\Models\PersonalFreeleech;
 use App\Models\PlaylistCategory;
 use App\Models\TmdbMovie;
 use App\Models\Region;
@@ -492,7 +493,7 @@ class SimilarTorrent extends Component
     }
 
     final protected bool $personalFreeleech {
-        get => cache()->get('personal_freeleech:'.auth()->id()) ?? false;
+        get => PersonalFreeleech::query()->where('user_id', '=', auth()->id())->exists();
     }
 
     /**

--- a/app/Http/Livewire/TmdbPersonCredit.php
+++ b/app/Http/Livewire/TmdbPersonCredit.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace App\Http\Livewire;
 
 use App\Enums\Occupation;
+use App\Models\PersonalFreeleech;
 use App\Models\TmdbPerson;
 use App\Models\Torrent;
 use App\Models\User;
@@ -53,7 +54,7 @@ class TmdbPersonCredit extends Component
     }
 
     final protected bool $personalFreeleech {
-        get => cache()->get('personal_freeleech:'.auth()->user()->id) ?? false;
+        get => PersonalFreeleech::query()->where('user_id', '=', auth()->id())->exists();
     }
 
     /**

--- a/app/Http/Livewire/TopTorrents.php
+++ b/app/Http/Livewire/TopTorrents.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace App\Http\Livewire;
 
+use App\Models\PersonalFreeleech;
 use App\Models\Torrent;
 use App\Models\User;
 use App\Traits\TorrentMeta;
@@ -109,7 +110,7 @@ class TopTorrents extends Component
     }
 
     final protected bool $personalFreeleech {
-        get => cache()->get('personal_freeleech:'.$this->user->id) ?? false;
+        get => PersonalFreeleech::query()->where('user_id', '=', $this->user->id)->exists();
     }
 
     final public function render(): \Illuminate\Contracts\View\Factory | \Illuminate\Contracts\View\View | \Illuminate\Contracts\Foundation\Application

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -19,6 +19,7 @@ namespace App\Http\Livewire;
 use App\DTO\TorrentSearchFiltersDTO;
 use App\Models\Category;
 use App\Models\Distributor;
+use App\Models\PersonalFreeleech;
 use App\Models\TmdbGenre;
 use App\Models\TmdbMovie;
 use App\Models\Region;
@@ -275,7 +276,7 @@ class TorrentSearch extends Component
     }
 
     final protected bool $personalFreeleech {
-        get => cache()->get('personal_freeleech:'.auth()->id()) ?? false;
+        get => PersonalFreeleech::query()->where('user_id', '=', auth()->id())->exists();
     }
 
     /**


### PR DESCRIPTION
Personal freeleeches would otherwise show on the site as expired if the cache was empty, even if the value was in the database.