### PR TITLE
(Update) Don't cache personal fl and tokens outside of announce

### DIFF
--- a/app/Console/Commands/AutoRemovePersonalFreeleech.php
+++ b/app/Console/Commands/AutoRemovePersonalFreeleech.php
@@ -56,7 +56,7 @@ class AutoRemovePersonalFreeleech extends Command
             // Delete The Record From DB
             $pfl->delete();
 
-            cache()->put('personal_freeleech:'.$pfl->user_id, false);
+            cache()->forget('personal_freeleech:'.$pfl->user_id);
             Unit3dAnnounce::removePersonalFreeleech($pfl->user_id);
         }
 

--- a/app/Http/Controllers/TorrentBuffController.php
+++ b/app/Http/Controllers/TorrentBuffController.php
@@ -243,7 +243,10 @@ class TorrentBuffController extends Controller
         $user = $request->user();
         $torrent = Torrent::query()->withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
-        $activeToken = cache()->get('freeleech_token:'.$user->id.':'.$torrent->id);
+        $activeToken = FreeleechToken::query()
+            ->where('user_id', '=', $user->id)
+            ->where('torrent_id', '=', $torrent->id)
+            ->exists();
 
         if ($user->fl_tokens >= 1 && !$activeToken) {
             $freeleechToken = new FreeleechToken();
@@ -256,7 +259,7 @@ class TorrentBuffController extends Controller
             $user->fl_tokens -= 1;
             $user->save();
 
-            cache()->put('freeleech_token:'.$user->id.':'.$torrent->id, true);
+            cache()->forget('freeleech_token:'.$user->id.':'.$torrent->id);
 
             $torrent->searchable();
 

--- a/app/Http/Controllers/TorrentDownloadController.php
+++ b/app/Http/Controllers/TorrentDownloadController.php
@@ -93,7 +93,10 @@ class TorrentDownloadController extends Controller
         if (
             $settings?->auto_freeleech_apply &&
             $user->fl_tokens >= max(1, $settings->auto_freeleech_min_tokens) &&
-            !cache()->get("freeleech_token:{$user->id}:{$torrent->id}")
+            FreeleechToken::query()
+                ->where('user_id', '=', $user->id)
+                ->where('torrent_id', '=', $torrent->id)
+                ->doesntExist()
         ) {
             FreeleechToken::query()->create([
                 'user_id'    => $user->id,
@@ -103,7 +106,7 @@ class TorrentDownloadController extends Controller
             Unit3dAnnounce::addFreeleechToken($user->id, $torrent->id);
 
             $user->decrement('fl_tokens');
-            cache()->put("freeleech_token:{$user->id}:{$torrent->id}", true);
+            cache()->forget("freeleech_token:{$user->id}:{$torrent->id}");
 
             $torrent->searchable();
         }

--- a/app/Http/Controllers/User/TransactionController.php
+++ b/app/Http/Controllers/User/TransactionController.php
@@ -93,7 +93,7 @@ class TransactionController extends Controller
 
                     PersonalFreeleech::query()->create(['user_id' => $user->id]);
 
-                    cache()->put('personal_freeleech:'.$user->id, true);
+                    cache()->forget('personal_freeleech:'.$user->id);
 
                     Unit3dAnnounce::addPersonalFreeleech($user->id);
 


### PR DESCRIPTION
That way if you're using an external announce, the cache doesn't have irrelevant data.