### PR TITLE
(Update) Optimize file-tree display

### DIFF
--- a/resources/sass/pages/_torrent.scss
+++ b/resources/sass/pages/_torrent.scss
@@ -115,3 +115,32 @@
 .torrent__times-completed-count.torrent__times-completed-count {
     color: var(--torrent-row-completed-fg);
 }
+
+/* File Tree
+---------------------------------------------------------------------------- */
+
+.file-tree__wrapper {
+    display: grid;
+    grid-template-areas: 'icon2 name count . size';
+    grid-template-columns: 24px auto auto 1fr auto;
+    gap: 4px;
+}
+
+.file-tree__icon {
+    grid-area: icon2;
+}
+
+.file-tree__name {
+    word-break: break-all;
+    grid-area: name;
+}
+
+.file-tree__size {
+    grid-area: size;
+    white-space: nowrap;
+    text-align: right;
+}
+
+.file-tree__count {
+    grid-area: count;
+}

--- a/resources/views/torrent/partials/file-tree-node.blade.php
+++ b/resources/views/torrent/partials/file-tree-node.blade.php
@@ -7,40 +7,18 @@
             'list-style-type: none' => $node['type'] === 'file',
         ])
     >
-        <span
-            style="
-                display: grid;
-                grid-template-areas: 'icon2 folder count . size';
-                grid-template-columns: 24px auto auto 1fr auto;
-                gap: 4px;
-            "
-        >
+        <span class="file-tree__wrapper">
             @if ($node['type'] === 'file')
-                <i class="{{ config('other.font-awesome') }} fa-file" style="grid-area: icon2"></i>
-                <span style="word-break: break-all">
-                    {{ $key }}
-                </span>
-                <span
-                    style="grid-area: size; white-space: nowrap; text-align: right"
-                    title="{{ $node['size'] }}&nbsp;B"
-                >
+                <i class="{{ config('other.font-awesome') }} fa-file file-tree__icon"></i>
+                <span class="file-tree__name">{{ $key }}</span>
+                <span class="file-tree__size" title="{{ $node['size'] }}&nbsp;B">
                     {{ App\Helpers\StringHelper::formatBytes($node['size'], 2) }}
                 </span>
             @else
-                <i
-                    class="{{ config('other.font-awesome') }} fa-folder"
-                    style="grid-area: icon2"
-                ></i>
-                <span>
-                    {{ $key }}
-                </span>
-
-                <span style="grid-area: count">({{ $node['count'] }})</span>
-                <span
-                    class="text-info"
-                    style="grid-area: size; white-space: nowrap; text-align: right"
-                    title="{{ $node['size'] }}&nbsp;B"
-                >
+                <i class="{{ config('other.font-awesome') }} fa-folder file-tree__icon"></i>
+                <span class="file-tree__name">{{ $key }}</span>
+                <span class="file-tree__count">({{ $node['count'] }})</span>
+                <span class="text-info file-tree__size" title="{{ $node['size'] }}&nbsp;B">
                     {{ App\Helpers\StringHelper::formatBytes($node['size'], 2) }}
                 </span>
             @endif


### PR DESCRIPTION
Reduces html quanity on discs with 10s of thousands of files (35MB -> 27MB). Should be optimized more properly in the future, but this is low-lying fruit.