### PR TITLE
(Fix) Chatbox receiver_id message validation

### DIFF
--- a/app/Bots/NerdBot.php
+++ b/app/Bots/NerdBot.php
@@ -311,8 +311,8 @@ class NerdBot
         }
 
         if ($type === 'public') {
-            $this->chatRepository->message($target->id, $target->chatroom->id, $message, null, null);
-            $this->chatRepository->message(User::SYSTEM_USER_ID, $target->chatroom->id, $txt, null, $this->bot->id);
+            $this->chatRepository->message($target->id, $target->chatroom->id, $message, null);
+            $this->chatRepository->message(User::SYSTEM_USER_ID, $target->chatroom->id, $txt, $this->bot->id);
 
             return response('success');
         }

--- a/app/Bots/SystemBot.php
+++ b/app/Bots/SystemBot.php
@@ -193,8 +193,8 @@ class SystemBot
         }
 
         if ($type === 'public') {
-            $this->chatRepository->message($target->id, $target->chatroom->id, $message, null, null);
-            $this->chatRepository->message(User::SYSTEM_USER_ID, $target->chatroom->id, $txt, null, $this->bot->id);
+            $this->chatRepository->message($target->id, $target->chatroom->id, $message, null);
+            $this->chatRepository->message(User::SYSTEM_USER_ID, $target->chatroom->id, $txt, $this->bot->id);
 
             return response('success');
         }

--- a/app/Http/Controllers/API/ChatController.php
+++ b/app/Http/Controllers/API/ChatController.php
@@ -203,9 +203,8 @@ class ChatController extends Controller
             return new ChatMessageResource($message);
         }
 
-        $receiverId = null;
         $botId = null;
-        $message = $this->chatRepository->message($userId, $roomId, $message, $receiverId, $botId);
+        $message = $this->chatRepository->message($userId, $roomId, $message, $botId);
 
         return response('success');
     }

--- a/app/Repositories/ChatRepository.php
+++ b/app/Repositories/ChatRepository.php
@@ -26,13 +26,13 @@ use App\Models\User;
 
 class ChatRepository
 {
-    public function message(int $userId, int $roomId, string $message, ?int $receiver = null, ?int $bot = null): Message
+    public function message(int $userId, int $roomId, string $message, ?int $bot = null): Message
     {
         $message = Message::query()->create([
             'user_id'     => $userId,
             'chatroom_id' => $roomId,
             'message'     => $message,
-            'receiver_id' => $receiver,
+            'receiver_id' => null,
             'bot_id'      => $bot,
         ]);
 
@@ -41,7 +41,7 @@ class ChatRepository
         return $message;
     }
 
-    public function botMessage(int $botId, string $message, ?int $receiver = null): void
+    public function botMessage(int $botId, string $message, int $receiver): void
     {
         $message = Message::query()->create([
             'bot_id'      => $botId,
@@ -62,7 +62,7 @@ class ChatRepository
         $message->delete();
     }
 
-    public function privateMessage(int $userId, string $message, ?int $receiver = null, ?int $bot = null, ?bool $ignore = null): Message
+    public function privateMessage(int $userId, string $message, int $receiver, ?int $bot = null, ?bool $ignore = null): Message
     {
         $message = Message::query()->create([
             'user_id'     => $userId,
@@ -186,6 +186,6 @@ class ChatRepository
             )
             ->value('id');
 
-        $this->message(User::SYSTEM_USER_ID, $systemChatroomId, $message, null, $systemBotId);
+        $this->message(User::SYSTEM_USER_ID, $systemChatroomId, $message, $systemBotId);
     }
 }


### PR DESCRIPTION
Messages to a chatroom should not be possible to set a receiver_id. It's not used anywhere now, but in the past it must have been possible as there are few records in an older database. Unfortunately, mysql doesn't allow adding check constraint to a column that has referential actions, otherwise I would have added a check constraint for (chatroom_id IS NULL XOR receiver_id IS NULL).