### PR TITLE
(Fix) DB::table() and soft deletion inconsistency

### DIFF
--- a/app/Console/Commands/AutoGroup.php
+++ b/app/Console/Commands/AutoGroup.php
@@ -63,7 +63,7 @@ class AutoGroup extends Command
                 'torrents as uploads',
                 'warnings' => fn ($query) => $query->where('active', '=', true),
             ])
-            ->withAvg('history as avg_seedtime', 'seedtime');
+            ->withAvg(['history as avg_seedtime' => fn ($query) => $query->withTrashed()], 'seedtime');
 
         if ($userIds !== []) {
             $userQuery->whereIntegerInRaw('id', $userIds);

--- a/app/Console/Commands/AutoTorrentBalance.php
+++ b/app/Console/Commands/AutoTorrentBalance.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\History;
+use App\Models\Torrent;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
@@ -45,8 +47,9 @@ class AutoTorrentBalance extends Command
     final public function handle(): void
     {
         DB::transaction(static function (): void {
-            DB::table('torrents')->joinSub(
-                DB::table('history')
+            Torrent::query()->withoutGlobalScopes()->joinSub(
+                History::query()
+                    ->withTrashed()
                     ->select('torrent_id')
                     ->selectRaw('SUM(actual_uploaded) - SUM(actual_downloaded) AS balance')
                     ->groupBy('torrent_id'),

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\Group;
+use App\Models\History;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class GroupController extends Controller
 {
@@ -32,7 +32,7 @@ class GroupController extends Controller
         return view('group.index', [
             'current'           => now(),
             'user'              => $user,
-            'user_avg_seedtime' => DB::table('history')->where('user_id', '=', $user->id)->avg('seedtime'),
+            'user_avg_seedtime' => History::query()->withTrashed()->where('user_id', '=', $user->id)->avg('seedtime'),
             'user_account_age'  => (int) now()->diffInSeconds($user->created_at, true),
             'user_seed_size'    => $user->seedingTorrents()->sum('size'),
             'user_uploads'      => $user->torrents()->count(),

--- a/app/Http/Controllers/Staff/HomeController.php
+++ b/app/Http/Controllers/Staff/HomeController.php
@@ -20,6 +20,8 @@ use App\Enums\ModerationStatus;
 use App\Helpers\SystemInformation;
 use App\Http\Controllers\Controller;
 use App\Models\Group;
+use App\Models\Scopes\ApprovedScope;
+use App\Models\Torrent;
 use App\Services\Unit3dAnnounce;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -54,8 +56,8 @@ class HomeController extends Controller
                 ->selectRaw('SUM(group_id = ?) AS banned', [Group::query()->where('slug', '=', 'banned')->soleValue('id')])
                 ->selectRaw('SUM(group_id = ?) AS validating', [Group::query()->where('slug', '=', 'validating')->soleValue('id')])
                 ->first()),
-            'torrents' => cache()->flexible('dashboard_torrents', [60 * 5, 60 * 10], fn () => DB::table('torrents')
-                ->whereNull('deleted_at')
+            'torrents' => cache()->flexible('dashboard_torrents', [60 * 5, 60 * 10], fn () => Torrent::query()
+                ->withoutGlobalScope(ApprovedScope::class)
                 ->selectRaw('COUNT(*) AS total')
                 ->selectRaw('SUM(status = 0) AS pending')
                 ->selectRaw('SUM(status = 1) AS approved')

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -163,7 +163,7 @@ class StatsController extends Controller
         return view('stats.users.seedtime', [
             'users' => User::query()
                 ->with('group')
-                ->withSum('history as seedtime', 'seedtime')
+                ->withSum(['history as seedtime' => fn ($query) => $query->withTrashed()], 'seedtime')
                 ->orderByDesc('seedtime')
                 ->take(100)
                 ->get(),

--- a/app/Http/Controllers/User/HistoryController.php
+++ b/app/Http/Controllers/User/HistoryController.php
@@ -17,9 +17,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
+use App\Models\History;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class HistoryController extends Controller
 {
@@ -32,7 +32,8 @@ class HistoryController extends Controller
 
         return view('user.history.index', [
             'user'    => $user,
-            'history' => DB::table('history')
+            'history' => History::query()
+                ->withTrashed()
                 ->where('user_id', '=', $user->id)
                 ->where('created_at', '>', $user->created_at)
                 ->selectRaw('sum(actual_uploaded) as upload')

--- a/app/Http/Controllers/User/InviteTreeController.php
+++ b/app/Http/Controllers/User/InviteTreeController.php
@@ -102,8 +102,8 @@ class InviteTreeController extends Controller
                 'receiver' => fn ($query) => $query
                     ->withTrashed()
                     ->with('group')
-                    ->withAvg('history', 'seedtime')
-                    ->withSum('history', 'seedtime')
+                    ->withAvg(['history' => fn ($query) => $query->withTrashed()], 'seedtime')
+                    ->withSum(['history' => fn ($query) => $query->withTrashed()], 'seedtime')
                     ->withSum('seedingTorrents', 'size')
                     ->withCount([
                         'warnings' => function ($query): void {

--- a/app/Http/Controllers/User/PeerController.php
+++ b/app/Http/Controllers/User/PeerController.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
+use App\Models\History;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -32,7 +33,8 @@ class PeerController extends Controller
 
         return view('user.peer.index', [
             'user'    => $user,
-            'history' => DB::table('history')
+            'history' => History::query()
+                ->withTrashed()
                 ->where('user_id', '=', $user->id)
                 ->where('created_at', '>', $user->created_at)
                 ->selectRaw('sum(actual_uploaded) as upload')

--- a/app/Http/Controllers/User/TorrentController.php
+++ b/app/Http/Controllers/User/TorrentController.php
@@ -17,9 +17,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
+use App\Models\History;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class TorrentController extends Controller
 {
@@ -32,7 +32,8 @@ class TorrentController extends Controller
 
         return view('user.torrent.index', [
             'user'    => $user,
-            'history' => DB::table('history')
+            'history' => History::query()
+                ->withTrashed()
                 ->where('user_id', '=', $user->id)
                 ->where('created_at', '>', $user->created_at)
                 ->selectRaw('sum(actual_uploaded) as upload')

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -20,13 +20,13 @@ use App\Enums\ModerationStatus;
 use App\Http\Controllers\Controller;
 use App\Models\BonTransactions;
 use App\Models\Donation;
+use App\Models\History;
 use App\Models\Invite;
 use App\Models\Peer;
 use App\Models\User;
 use App\Services\Unit3dAnnounce;
 use Assada\Achievements\Model\AchievementProgress;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
@@ -64,7 +64,8 @@ class UserController extends Controller
         return view('user.profile.show', [
             'user'      => $user,
             'followers' => $user->followers()->latest()->limit(25)->get(),
-            'history'   => DB::table('history')
+            'history'   => History::query()
+                ->withTrashed()
                 ->where('user_id', '=', $user->id)
                 ->where('created_at', '>', $user->created_at)
                 ->selectRaw('SUM(actual_uploaded) as upload_sum')

--- a/app/Http/Livewire/TopUsers.php
+++ b/app/Http/Livewire/TopUsers.php
@@ -120,7 +120,7 @@ class TopUsers extends Component
             'top-users:seedtimes',
             [3600, 3600 * 2],
             fn () => User::query()
-                ->withSum('history as seedtime', 'seedtime')
+                ->withSum(['history as seedtime' => fn ($query) => $query->withTrashed()], 'seedtime')
                 ->with('group')
                 ->where('id', '!=', User::SYSTEM_USER_ID)
                 ->whereDoesntHave('group', fn ($query) => $query->whereIn('slug', ['banned', 'validating', 'disabled', 'pruned']))

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -24,6 +24,7 @@ use App\Models\TmdbGenre;
 use App\Models\TmdbMovie;
 use App\Models\Region;
 use App\Models\Resolution;
+use App\Models\Scopes\ApprovedScope;
 use App\Models\Torrent;
 use App\Models\TmdbTv;
 use App\Models\Type;
@@ -37,7 +38,6 @@ use Livewire\Component;
 use Livewire\WithPagination;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Meilisearch\Client;
-use Illuminate\Support\Facades\DB;
 
 class TorrentSearch extends Component
 {
@@ -238,8 +238,8 @@ class TorrentSearch extends Component
         get => cache()->flexible(
             'torrent-search:health',
             [3600, 3600 * 2],
-            fn () => DB::table('torrents')
-                ->whereNull('deleted_at')
+            fn () => Torrent::query()
+                ->withoutGlobalScope(ApprovedScope::class)
                 ->selectRaw('COUNT(*) AS total')
                 ->selectRaw('SUM(seeders > 0) AS alive')
                 ->selectRaw('SUM(seeders = 0) AS dead')


### PR DESCRIPTION
These DB::table() instances are relics from when sites were using soft deletion before UNIT3D had full support for it. Fix the inconsistencies by using `->withoutGlobalScope()` and `->withTrashed()` while maintaining the previous intended logic. fixes #5116.