### PR TITLE
(Update) Lazy load avatars on home page

### DIFF
--- a/resources/views/components/forum/post.blade.php
+++ b/resources/views/components/forum/post.blade.php
@@ -161,6 +161,7 @@
                 class="post__avatar"
                 src="{{ $post->anon && auth()->user()->isNot($post->user) &&! auth()->user()->group->is_modo ? url('img/profile.png') : ($post->user->image === null ? url('img/profile.png') : route('authenticated_images.user_avatar', ['user' => $post->user])) }}"
                 alt=""
+                loading="lazy"
             />
         </figure>
         <x-user-tag class="post__author" :anon="$post->anon" :user="$post->user">

--- a/resources/views/livewire/top-users.blade.php
+++ b/resources/views/livewire/top-users.blade.php
@@ -40,6 +40,7 @@
                                     class="user-stat-card__avatar"
                                     alt=""
                                     src="{{ url('img/profile.png') }}"
+                                    loading="lazy"
                                 />
                             @else
                                 <img


### PR DESCRIPTION
Post avatars and top user avatars. Reduces the amount of HTTP requests.