### PR TITLE
(Fix) Change donation dates to timestamps, prevent time loss

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -108,7 +108,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(ClearResetsCommand::class)->daily();
         $schedule->command(AutoSyncTorrentsToMeilisearch::class)->everyFifteenMinutes();
         $schedule->command(AutoSyncPeopleToMeilisearch::class)->daily();
-        $schedule->command(AutoRemoveExpiredDonors::class)->daily();
+        $schedule->command(AutoRemoveExpiredDonors::class)->hourly();
         $schedule->command(AutoRemoveReseeds::class)->daily();
         $schedule->command(AutoRewardUploadContestPrize::class)->daily();
         // $schedule->command(AutoBanDisposableUsers::class)->weekends();

--- a/database/migrations/2026_02_18_023757_change_donation_dates_to_timestamps.php
+++ b/database/migrations/2026_02_18_023757_change_donation_dates_to_timestamps.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('donations', function (Blueprint $table): void {
+            $table->timestamp('starts_at')->nullable()->change();
+            $table->timestamp('ends_at')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('donations', function (Blueprint $table): void {
+            $table->date('starts_at')->nullable()->change();
+            $table->date('ends_at')->nullable()->change();
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -499,8 +499,8 @@ CREATE TABLE `donations` (
   `package_id` int unsigned NOT NULL,
   `transaction` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `is_gifted` tinyint(1) NOT NULL DEFAULT '0',
-  `starts_at` date DEFAULT NULL,
-  `ends_at` date DEFAULT NULL,
+  `starts_at` timestamp NULL DEFAULT NULL,
+  `ends_at` timestamp NULL DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -3124,3 +3124,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (374,'2026_01_27_07
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (375,'2026_02_02_180456_add_foreign_keys_echoes_audibles_messages',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (376,'2026_02_03_012707_drop_keys_from_seedboxes',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (377,'2026_02_04_184040_combine_user_audibles_echoes',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (378,'2026_02_18_023757_change_donation_dates_to_timestamps',1);


### PR DESCRIPTION
_Split from #5282_

Using `date` type for donation's `starts_at` and `ends_at` times leads to up to 24 hours of lost paid time for all donors.

This change fixes it by converting these values to a `timestamp` type.

It's better than `datettime` because no time will be lost or added even if server timezone changes.

Also run [AutoRemoveExpiredDonors](https://github.com/HDInnovations/UNIT3D/blob/development/app/Console/Commands/AutoRemoveExpiredDonors.php) script hourly to prevent extra added time.