### PR TITLE
(Fix) Sort donations by updated_at property to prevent edge cases

### DIFF
--- a/app/Http/Controllers/Staff/DonationController.php
+++ b/app/Http/Controllers/Staff/DonationController.php
@@ -39,7 +39,7 @@ class DonationController extends Controller
         }])->latest()->paginate(25);
 
         $dailyDonations = Donation::query()
-            ->selectRaw('DATE(donations.created_at) as date, SUM(donation_packages.cost) as total')
+            ->selectRaw('DATE(donations.updated_at) as date, SUM(donation_packages.cost) as total')
             ->join('donation_packages', 'donations.package_id', '=', 'donation_packages.id')
             ->where('donations.status', '=', ModerationStatus::APPROVED)
             ->groupBy('date')
@@ -47,7 +47,7 @@ class DonationController extends Controller
             ->get();
 
         $monthlyDonations = Donation::query()
-            ->selectRaw('EXTRACT(YEAR FROM donations.created_at) as year, EXTRACT(MONTH FROM donations.created_at) as month, SUM(donation_packages.cost) as total')
+            ->selectRaw('EXTRACT(YEAR FROM donations.updated_at) as year, EXTRACT(MONTH FROM donations.updated_at) as month, SUM(donation_packages.cost) as total')
             ->join('donation_packages', 'donations.package_id', '=', 'donation_packages.id')
             ->where('donations.status', '=', ModerationStatus::APPROVED)
             ->groupBy('year', 'month')

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -120,7 +120,7 @@ class UserController extends Controller
                 ->first(),
             'watch'        => $user->watchlist,
             'externalUser' => ! $user->trashed() && $request->user()->group->is_modo ? Unit3dAnnounce::getUser($user->id) : false,
-            'donation'     => Donation::query()->where('status', '=', ModerationStatus::APPROVED)->where('user_id', '=', $user->id)->latest()->first(),
+            'donation'     => Donation::query()->where('status', '=', ModerationStatus::APPROVED)->where('user_id', '=', $user->id)->latest('updated_at')->first(),
         ]);
     }
 

--- a/app/View/Composers/TopNavComposer.php
+++ b/app/View/Composers/TopNavComposer.php
@@ -60,7 +60,7 @@ class TopNavComposer
             'donationPercentage' => value(function (): int|string {
                 $sum = Donation::query()
                     ->join('donation_packages', 'donations.package_id', '=', 'donation_packages.id')
-                    ->where('donations.created_at', '>=', now()->startOfMonth())
+                    ->where('donations.updated_at', '>=', now()->startOfMonth())
                     ->where('donations.status', ModerationStatus::APPROVED)
                     ->sum('donation_packages.cost');
 

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -631,7 +631,7 @@
                     <div class="key-value__group">
                         <dt>Latest donation date</dt>
                         <dd>
-                            {{ $donation->starts_at ?? 'N/A' }}
+                            {{ $donation->updated_at ?? 'N/A' }}
                         </dd>
                     </div>
                     <div class="key-value__group">


### PR DESCRIPTION
_Split from #5282_

`created_at` is the time when a user submitted a donation.

Until it's approved at `updated_at` time, it should not be counted as a daily/monthly donation.

If user submitted multiple donations, the owner can approve them in a random order, so we also pick the last approved donation to display in user's profile.

And if a donation was sent last month and approved this month, now it's correctly counted towards this month's goal.