### PR TITLE
(Add) Select all text when focusing donation gateway inputs

### DIFF
--- a/resources/views/donation/index.blade.php
+++ b/resources/views/donation/index.blade.php
@@ -132,8 +132,9 @@
                                 <input
                                     class="form__text"
                                     type="text"
-                                    disabled
+                                    readonly
                                     value="{{ $gateway->address }}"
+                                    x-on:focus="$el.select()"
                                     id="{{ 'gateway-' . $gateway->id }}"
                                 />
                                 <label
@@ -159,8 +160,9 @@
                             <input
                                 class="form__text"
                                 type="text"
-                                disabled
+                                readonly
                                 value="{{ $package->cost }}"
+                                x-on:focus="$el.select()"
                                 id="package-cost"
                             />
                             <label for="package-cost" class="form__label form__label--floating">
@@ -171,6 +173,7 @@
                             <input
                                 class="form__text"
                                 type="text"
+                                autofocus
                                 value=""
                                 id="proof"
                                 name="transaction"


### PR DESCRIPTION
_Split from #5282_

Some trackers also add a Copy button to the right of the input, but they can code it themselves.

This is just a better default to make sure people don't send money to wrong addresses. Or don't get discouraged when they see an error.