### PR TITLE
(Update) Prettier, freeze the latest version, refactor the config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,7 +12,7 @@
 !/resources/js/
 /resources/js/vendor
 
-# except resources/scss, but ignores resoruces/scss/vendor
+# except resources/scss, but ignores resources/scss/vendor
 !/resources/sass/
 /resources/sass/vendor
 
@@ -20,4 +20,3 @@
 resources/views/emails
 resources/views/rss/show.blade.php
 resources/views/vendor
-resources/views/components/user_tag.blade.php

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,12 @@
   "plugins": [
     "prettier-plugin-blade"
   ],
+
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 4,
+
   "overrides": [
     {
       "files": [
@@ -9,9 +15,7 @@
       ],
       "options": {
         "parser": "blade",
-        "printWidth": 100,
-        "semi": true,
-        "singleQuote": true
+        "printWidth": 100
       }
     },
     {
@@ -19,20 +23,7 @@
         "*.js"
       ],
       "options": {
-        "printWidth": 100,
-        "semi": true,
-        "singleQuote": true,
-        "tabWidth": 4
-      }
-    },
-    {
-      "files": [
-        "*.scss"
-      ],
-      "options": {
-        "semi": true,
-        "singleQuote": true,
-        "tabWidth": 4
+        "printWidth": 100
       }
     }
   ]

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "laravel-vite-plugin": "^2.0.1",
-        "prettier": "3.7.4",
+        "prettier": "3.8.1",
         "prettier-plugin-blade": "2.0.0",
         "vite": "^8.0.0",
         "vite-plugin-static-copy": "^3.1.4",
@@ -501,7 +501,7 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
-    "prettier": ["prettier@3.7.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA=="],
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "prettier-plugin-blade": ["prettier-plugin-blade@2.0.0", "", { "peerDependencies": { "prettier": ">=3" } }, "sha512-9x7hBfGHSKsJG2UNTzFdAadLCMnsgGbLI/cUsb0+leV37yw1ojUedSAhkE1K0TleKXBXgaYpVY+71T3ClYW8WA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "laravel-vite-plugin": "^2.0.1",
-    "prettier": "3.7.4",
+    "prettier": "3.8.1",
     "prettier-plugin-blade": "2.0.0",
     "vite": "^8.0.0",
     "vite-plugin-static-copy": "^3.1.4"


### PR DESCRIPTION
Hopefully only non-breaking changes with minimal diff compared to #5351
Changelog: [Prettier](https://github.com/prettier/prettier/compare/3.7.4...3.8.1) ([release notes](https://prettier.io/blog/2026/01/14/3.8.0) and [here](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)) + [prettier-plugin-blade](https://unpkg.com/prettier-plugin-blade@2.1.21/changelog.md).

However, `printWidth` for JavaScript was changed from `100` back to `80`, as advised in https://github.com/HDInnovations/UNIT3D/pull/5351#pullrequestreview-3989086637

Unfortunately [whitespace-sensitive formatting](https://prettier.io/blog/2018/11/07/1.15.0.html#whitespace-sensitive-formatting) is still not available in v2.
So whitespace bugs for inline elements might still be added by `prettier-plugin-blade`.

But they can be fixed by disabling the formatter with `{{-- format-ignore-start --}}` and `{{-- format-ignore-end --}}` comments.