### PR TITLE
(Remove) Extra icon class names from Staff and Internal pages

### DIFF
--- a/resources/views/page/internal.blade.php
+++ b/resources/views/page/internal.blade.php
@@ -29,7 +29,7 @@
                         <h3 class="user-card__username">
                             {{ $user->username }}
                         </h3>
-                        <i class="fal {{ $user->group->icon }} user-card__icon"></i>
+                        <i class="{{ $user->group->icon }} user-card__icon"></i>
                         @if ($user->title !== null)
                             <p class="user-card__title">
                                 {{ __('page.staff-title') }}: {{ $user->title }}

--- a/resources/views/page/staff.blade.php
+++ b/resources/views/page/staff.blade.php
@@ -23,7 +23,7 @@
                         <h3 class="user-card__username">
                             {{ $user->username }}
                         </h3>
-                        <i class="fal {{ $user->group->icon }} user-card__icon"></i>
+                        <i class="{{ $user->group->icon }} user-card__icon"></i>
                         @if ($user->title !== null)
                             <p class="user-card__title">
                                 {{ __('page.staff-title') }}: {{ $user->title }}


### PR DESCRIPTION
`.fal` sets the font name to `Pro`: https://github.com/HDInnovations/UNIT3D/blob/d274132f358eb876b97e31308bfaddfc7340ab26/resources/sass/base/_typography.scss#L32-L35

`.fab` sets it to `Brands`, but it has a lower specificity:
https://github.com/HDInnovations/UNIT3D/blob/d274132f358eb876b97e31308bfaddfc7340ab26/resources/sass/base/_typography.scss#L20-L22

This leads to some broken icons.

Before:
<img width="1011" height="237" alt="before" src="https://github.com/user-attachments/assets/3ba5a348-8d0a-450b-bcb8-cec2664c79bb" />
After:
<img width="1007" height="235" alt="after" src="https://github.com/user-attachments/assets/6d6d6ddc-3a0f-4cc0-9f06-5bb1e0cb59ab" />

Introduced in https://github.com/HDInnovations/UNIT3D/commit/8f68c461bd642e51259a0dad72527757c0b90535