### PR TITLE
(Update) Report columns on torrent page to match staff reports page

### DIFF
--- a/resources/views/torrent/partials/reports.blade.php
+++ b/resources/views/torrent/partials/reports.blade.php
@@ -22,12 +22,12 @@
                         {{ __('common.reporter') }}
                     </th>
                     <th>
-                        {{ __('common.created_at') }}
+                        {{ __('ticket.assigned-staff') }}
                     </th>
                     <th>
-                        {{ __('common.staff') }}
+                        {{ __('common.created_at') }}
                     </th>
-                    <th>{{ __('forum.solved') }}</th>
+                    <th>{{ __('user.judge') }}</th>
                 </tr>
             </thead>
             <tbody>
@@ -45,6 +45,13 @@
                             <x-user-tag :anon="false" :user="$report->reporter" />
                         </td>
                         <td>
+                            @if ($report->assignee)
+                                <x-user-tag :anon="false" :user="$report->assignee" />
+                            @else
+                                Unassigned
+                            @endif
+                        </td>
+                        <td>
                             <time
                                 datetime="{{ $report->created_at }}"
                                 title="{{ $report->created_at }}"
@@ -53,23 +60,12 @@
                             </time>
                         </td>
                         <td>
-                            @if ($report->staff_id !== null)
-                                <x-user-tag :anon="false" :user="$report->staff" />
-                            @else
-                                Unassigned
-                            @endif
-                        </td>
-                        <td>
-                            @if ($report->solved)
-                                <i
-                                    class="{{ config('other.font-awesome') }} fa-check text-green"
-                                ></i>
-                                {{ __('common.yes') }}
+                            @if ($report->judge)
+                                <x-user-tag :anon="false" :user="$report->judge" />
                             @else
                                 <i
                                     class="{{ config('other.font-awesome') }} fa-times text-red"
                                 ></i>
-                                {{ __('common.no') }}
                             @endif
                         </td>
                     </tr>


### PR DESCRIPTION
Forgotten in #5002

Same changes as for [livewire/report-search.blade.php](https://github.com/HDInnovations/UNIT3D/pull/5002/changes#diff-0b548bc0f8b75691704f14d8b3d23320998a834b3e49ee8351558cc7b80fc8d2)

Admin table looks like this now (for a closed report):

<img width="1561" height="177" alt="report-admin" src="https://github.com/user-attachments/assets/72e0e6ac-3563-422e-a131-3aabfdf9c108" />

&nbsp;
Torrent block before (now):

<img width="1563" height="131" alt="report-before" src="https://github.com/user-attachments/assets/5f506954-6bc4-4226-9d61-2366cffefbe4" />

&nbsp;
Torrent block after (this PR):

<img width="1560" height="135" alt="report-after" src="https://github.com/user-attachments/assets/83064cac-6fd9-46de-96e0-5f565d592849" />

