### PR TITLE
(Fix) Torrent upload/edit inputs are not updated on category/type change

### DIFF
--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -127,7 +127,6 @@
                         class="form__select"
                         required
                         x-model="cat"
-                        x-bind="categorySelect"
                     >
                         <option hidden selected disabled value=""></option>
                         @foreach ($categories as $id => $category)
@@ -678,11 +677,6 @@
                                 this.$el.value = Number(matches[1]);
                                 this.$event.preventDefault();
                             }
-                        },
-                    },
-                    categorySelect: {
-                        ['x-on:change']() {
-                            this.cats[this.cat].type = this.cats[this.$event.target.value].type;
                         },
                     },
                 }));

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -74,7 +74,6 @@
                         name="category_id"
                         x-model="cat"
                         x-ref="catId"
-                        x-bind="categorySelect"
                     >
                         <option value="{{ old('category_id') ?? $torrent->category_id }}" selected>
                             {{ $torrent->category->name }} ({{ __('torrent.current') }})
@@ -96,7 +95,6 @@
                         name="type_id"
                         x-model="type"
                         x-ref="typeId"
-                        x-bind="typeSelect"
                     >
                         <option value="{{ old('type_id') ?? $torrent->type->id }}" selected>
                             {{ $torrent->type->name }} ({{ __('torrent.current') }})
@@ -613,16 +611,6 @@
                         {{ Js::from(old('anime_exists_on_mal', $torrent->mal) !== null) }},
                     igdb_game_exists:
                         {{ Js::from(old('game_exists_on_igdb', $torrent->igdb) !== null) }},
-                    typeSelect: {
-                        ['x-on:change']() {
-                            this.types[this.type].name = this.types[this.$event.target.value].name;
-                        },
-                    },
-                    categorySelect: {
-                        ['x-on:change']() {
-                            this.cats[this.cat].type = this.cats[this.$event.target.value].type;
-                        },
-                    },
                 }));
             });
         </script>


### PR DESCRIPTION
Caused by #5303

How to reproduce:
1. Open the torrent upload page
2. Change category to TV - season/episode inputs appear
3. Change category to Movie - inputs are not removed

Or:
1. Edit a Movie torrent
2. Change type to Full Disc - distributor/region inputs appear
3. Change type to Remux - inputs are not removed

I don't know Alpine well and I needed a quick fix, so I asked the AI to help:
<details>
<summary>ChatGPT answer</summary>
:robot:

The issue comes from this change in the **category select change handler**.

### Before (working)

Your old template had:

```html
@change="cats[cat].type = cats[$event.target.value].type;"
```

This explicitly used **`$event.target.value`** to get the new selected category.

### After (broken)

You moved it into an Alpine object:

```js
categorySelect: {
    ['x-on:change']() {
        this.cats[this.cat].type = this.cats[this.$event.target.value].type;
    },
},
```

But **Alpine does not provide `$event` automatically inside object handlers** like this.\
So `this.$event` is `undefined`, meaning the code silently fails.

That’s why changing the category **does nothing now**.

## Simple solution

You actually **don't need the change handler at all** because `x-model="cat"` already updates `cat`.

So everything depending on:

```html
x-show="cats[cat].type === 'tv'"
```

will react automatically.

Meaning you can remove the whole handler:

```html
<select
    x-ref="catId"
    name="category_id"
    id="autocat"
    class="form__select"
    required
    x-model="cat"
>
```

No `x-bind="categorySelect"` needed.

</details>