### PR TITLE
(Update) Improve auto freeleech logic, sort by regex and size

### DIFF
--- a/app/Helpers/TorrentHelper.php
+++ b/app/Helpers/TorrentHelper.php
@@ -56,11 +56,13 @@ class TorrentHelper
 
         if (!$torrent->free) {
             $autoFreeleeches = AutomaticTorrentFreeleech::query()
-                ->orderBy('position')
                 ->where(fn ($query) => $query->whereNull('category_id')->orWhere('category_id', '=', $torrent->category_id))
                 ->where(fn ($query) => $query->whereNull('type_id')->orWhere('type_id', '=', $torrent->type_id))
                 ->where(fn ($query) => $query->whereNull('resolution_id')->orWhere('resolution_id', '=', $torrent->resolution_id))
-                ->where(fn ($query) => $query->whereNull('size')->orWhere('size', '<', $torrent->size))
+                ->where(fn ($query) => $query->whereNull('size')->orWhere('size', '<=', $torrent->size))
+                ->orderByRaw('name_regex IS NULL')  // regex rules first
+                ->orderByDesc('position')           // then regex priority
+                ->orderByDesc('size')               // then size tiers
                 ->get();
 
             foreach ($autoFreeleeches as $autoFreeleech) {


### PR DESCRIPTION
Auto freeleech feature introduced in #3486 is most welcome.

Issue 1:
1. A happy owner goes into the Staff Dashboard and adds two simplest rules:

    <img width="1225" height="228" alt="auto-free" src="https://github.com/user-attachments/assets/c69f70cc-b04c-4c10-82ef-81e511b24577" />

3. A user uploads a 120 GB torrent to the tracker
4. Freeleech value is set to 50% instead of 100% _(???)_

Issue 2:
1. A user uploads a torrent exactly 50 GB (53687091200 bytes) in size
2. No freeleech buff is set (because of `<` instead of `<=`)

This PR fixes both issues.

It is not correct to just sort by position and expect everyone to magically know that auto freeleech rules should be sorted manually and that lower position means higher priority.

Regex rules should take priority because they are made for exceptions like title matching.
A regex rule that's added later (higher position) should take priority over earlier rules, otherwise it wouldn't have been added.
Then we sort by size regardless of positions.

Most trackers probably don't use regex matching, so they won't need to worry about positioning at all.

This PR is more of a bug fix, but I named it "update" as to not hurt anyone's feelings.