### PR TITLE
(Add) Invite tree link for Invited by key in user profiles

### DIFF
--- a/resources/views/user/invite-tree/index.blade.php
+++ b/resources/views/user/invite-tree/index.blade.php
@@ -25,7 +25,7 @@
 
 @section('main')
     <section class="panelV2">
-        <h2 class="panel__heading">Invite tree</h2>
+        <h2 class="panel__heading">{{ __('user.invite-tree') }}</h2>
         <div class="data-table-wrapper">
             <table class="data-table">
                 <thead>

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -1010,7 +1010,11 @@
                 </h2>
                 <dl class="key-value">
                     <div class="key-value__group">
-                        <dt>{{ __('user.invited-by') }}</dt>
+                        <dt>
+                            <a href="{{ route('users.invite_tree.index', ['user' => $user]) }}">
+                                {{ __('user.invited-by') }}
+                            </a>
+                        </dt>
                         <dd>
                             @if ($invitedBy)
                                 <x-user-tag :user="$invitedBy->sender" :anon="false" />


### PR DESCRIPTION
Invite Tree feature is great, so why not add a direct link to this page in user profiles.

Functionality on the third level of the navbar can easily be overlooked.
Plus a direct link helps the admins to investigate potential bad actors faster.

I know that Gazelle doesn't have such links on profile pages too, but this is something that can be improved upon.

Also I had to make Prettier ignore this line because it kept adding whitespace bugs and turning `(Tree)` into `( Tree )` (as mentioned in #5352). I didn't want parenthesis to be clickable.