### PR TITLE
(Update) Set line-height for secondary navbar items, make the height 34px

### DIFF
--- a/resources/sass/layout/_secondary-nav.scss
+++ b/resources/sass/layout/_secondary-nav.scss
@@ -38,6 +38,7 @@
     color: var(--secondary-nav-tab-fg);
     background-color: var(--secondary-nav-tab-bg);
     font-size: 14px;
+    line-height: 24px;
     border: none;
     text-align: left;
     cursor: pointer;
@@ -148,6 +149,7 @@
     text-decoration: var(--breadcrumb-inactive-text-decoration);
     color: var(--breadcrumb-fg);
     cursor: pointer;
+    line-height: 24px;
 
     &:hover {
         color: var(--breadcrumb-hover-fg);


### PR DESCRIPTION
Just trying to make the scroll offset for anchor links in #5292 less magic number-y.

Before:

<img width="1246" height="242" alt="scroll-before" src="https://github.com/user-attachments/assets/89b87680-84f9-497c-ad80-8a9598d7123c" />

---

After:

<img width="1247" height="246" alt="scroll-after" src="https://github.com/user-attachments/assets/f9c7dfaf-318a-4135-b3cf-bc71347db8e3" />

---

Top navbar height is `48px`:
https://github.com/HDInnovations/UNIT3D/blob/7cfcb3796f7aa5ac39f52e47514ca52603b94f9a/resources/sass/layout/_top_nav.scss#L5

Anchor links are mostly used for forum posts that have a gap of `18px`:
https://github.com/HDInnovations/UNIT3D/blob/7cfcb3796f7aa5ac39f52e47514ca52603b94f9a/resources/sass/components/forum/_post.scss#L7

This PR makes the secondary nav height `34px` instead of `31.33px` so that the sum `48 + 18 + 34` is actually `100px`