### PR TITLE
(Fix) Use relative path for Torrent file cleaning command

### DIFF
--- a/app/Console/Commands/CleanTorrentFiles.php
+++ b/app/Console/Commands/CleanTorrentFiles.php
@@ -61,7 +61,7 @@ class CleanTorrentFiles extends Command
                         'info'       => '',
                     ]);
 
-                    Storage::disk('torrent-files')->put($filePath, Bencode::bencode($dict));
+                    Storage::disk('torrent-files')->put($torrent->file_name, Bencode::bencode($dict));
                 }
             }
         });


### PR DESCRIPTION
- Initial feature: #4471
- Issue caused by: #4497

`->put()` requires a relative path: https://laravel.com/docs/12.x/filesystem#the-local-driver

Otherwise this command recreates a full directory structure inside `app/files/torrents/files` starting from `/` root.
And puts new torrent files there instead of replacing them.