### PR TITLE
(Fix) Make torrent file cleaning migration from 2023 work again

### DIFF
--- a/database/migrations/2023_02_09_113903_clean_torrent_files.php
+++ b/database/migrations/2023_02_09_113903_clean_torrent_files.php
@@ -14,9 +14,8 @@ declare(strict_types=1);
  * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
  */
 
-use App\Helpers\Bencode;
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Artisan;
 
 return new class () extends Migration {
     /**
@@ -24,33 +23,6 @@ return new class () extends Migration {
      */
     public function up(): void
     {
-        $directory = public_path().'/files/torrents/';
-
-        DB::table('torrents')->select('file_name')->orderBy('id')->chunk(100, function ($torrents) use ($directory): void {
-            foreach ($torrents as $torrent) {
-                if (file_exists($directory.$torrent->file_name)) {
-                    $dict = Bencode::bdecode_file($directory.$torrent->file_name);
-
-                    // Whitelisted keys
-                    $dict = array_intersect_key($dict, [
-                        'announce'   => '',
-                        'comment'    => '',
-                        'created by' => '',
-                        'encoding'   => '',
-                        'info'       => '',
-                    ]);
-
-                    $dict['announce'] = config('app.url').'/announce/PID';
-
-                    $comment = config('torrent.comment', null);
-
-                    if ($comment !== null) {
-                        $result['comment'] = $comment;
-                    }
-
-                    file_put_contents($directory.$torrent->file_name, Bencode::bencode($dict));
-                }
-            }
-        });
+        Artisan::call('clean:torrent_files');
     }
 };


### PR DESCRIPTION
- Initially added in #2598
- Hasn't been updated in #4497

The need to clean torrent files hasn't been mentioned anywhere in the release notes.

The fact that this migration has been broken since #4497 and that `announce-list` stopped being removed from torrent files since #2598 lead to a situation of real passkeys **leaking** to users who downloaded certain torrents.

After I understood the problem and ran the clean command manually, the bug in #5364 duplicated all files and threw them into a distant path.

Very cool, very nice. Lovely, even.