### PR TITLE
(Fix) Rename 'error' to 'alertError' to avoid conflict with native event

### DIFF
--- a/app/Http/Livewire/BlockIpAddress.php
+++ b/app/Http/Livewire/BlockIpAddress.php
@@ -71,7 +71,7 @@ class BlockIpAddress extends Component
 
             $this->dispatch('success', type: 'success', message: 'IP has successfully been deleted!');
         } else {
-            $this->dispatch('error', type: 'error', message: 'Permission denied!');
+            $this->dispatch('alertError', type: 'error', message: 'Permission denied!');
         }
     }
 

--- a/app/Http/Livewire/BookmarkButton.php
+++ b/app/Http/Livewire/BookmarkButton.php
@@ -33,7 +33,7 @@ class BookmarkButton extends Component
     final public function store(): void
     {
         if ($this->user->bookmarks()->where('torrent_id', '=', $this->torrent->id)->exists()) {
-            $this->dispatch('error', type: 'error', message: 'Torrent has already been bookmarked!');
+            $this->dispatch('alertError', type: 'error', message: 'Torrent has already been bookmarked!');
 
             return;
         }

--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -402,7 +402,7 @@ class SimilarTorrent extends Component
     final public function alertConfirm(): void
     {
         if (!auth()->user()->group->is_modo) {
-            $this->dispatch('error', type: 'error', message: 'Permission denied!');
+            $this->dispatch('alertError', type: 'error', message: 'Permission denied!');
 
             return;
         }
@@ -421,7 +421,7 @@ class SimilarTorrent extends Component
     final public function deleteRecords(): void
     {
         if (!auth()->user()->group->is_modo) {
-            $this->dispatch('error', type: 'error', message: 'Permission denied!');
+            $this->dispatch('alertError', type: 'error', message: 'Permission denied!');
 
             return;
         }

--- a/app/Http/Livewire/ThankButton.php
+++ b/app/Http/Livewire/ThankButton.php
@@ -36,13 +36,13 @@ class ThankButton extends Component
     final public function store(): void
     {
         if ($this->user->id === $this->torrent->user_id) {
-            $this->dispatch('error', type: 'error', message: 'You cannot thank your own content!');
+            $this->dispatch('alertError', type: 'error', message: 'You cannot thank your own content!');
 
             return;
         }
 
         if (Thank::query()->whereBelongsTo($this->user)->whereBelongsTo($this->torrent)->exists()) {
-            $this->dispatch('error', type: 'error', message: 'You have already thanked!');
+            $this->dispatch('alertError', type: 'error', message: 'You have already thanked!');
 
             return;
         }

--- a/app/Http/Livewire/TwoFactorAuthForm.php
+++ b/app/Http/Livewire/TwoFactorAuthForm.php
@@ -80,7 +80,7 @@ class TwoFactorAuthForm extends Component
     final public function confirmTwoFactorAuthentication(ConfirmTwoFactorAuthentication $confirm): void
     {
         if (empty($this->code)) {
-            $this->dispatch('error', type: 'error', message: 'The two factor authentication code input must not be empty.');
+            $this->dispatch('alertError', type: 'error', message: 'The two factor authentication code input must not be empty.');
 
             return;
         }

--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -158,7 +158,7 @@
         </script>
 
         <script nonce="{{ HDVinnie\SecureHeaders\SecureHeaders::nonce('script') }}">
-            window.addEventListener('error', (event) => {
+            window.addEventListener('alertError', (event) => {
                 Swal.fire({
                     title: '<strong style=" color: rgb(17,17,17);">Error</strong>',
                     icon: 'error',


### PR DESCRIPTION
_Initially added in https://github.com/HDInnovations/UNIT3D/commit/e1041d5306da041b486e4c85e46e1b2f4d69ff17#diff-0438a14b110dd559977909fcf3501a57b45db0359ff4c32f3a0188100cbae60f_

`error` is a reserved browser event name: https://developer.mozilla.org/en-US/docs/Web/API/Window/error_event

Since it was used as a custom event, SweetAlert2 tries to display a popup on every JavaScript error.
And only fails because there's no `detail` object natively, only `event.message`

How to reproduce:
1. Go to the torrent upload page
2. Pick a torrent with `test.torrent` file name
3. Open the browser console, notice two errors:

> Uncaught TypeError: can't access property "message", event.detail is undefined

> Uncaught Error: "test" does't follow scene release naming rules

Second error is addressed in #5367. It comes from:
https://github.com/HDInnovations/UNIT3D/blob/5f0bb9b16164580d77c7d6ae79e2377dd4ebb246/resources/js/unit3d/parser.js#L437-L439

But it demonstrates that all JS errors produce an additional error because of the name conflict.

Note: I haven't touched `success` because it doesn't conflict with anything and it's not an Alert, but a Toast.