### PR TITLE
(Update) Use a custom event to show torrent title parser error, disable it

### DIFF
--- a/resources/js/unit3d/helper.js
+++ b/resources/js/unit3d/helper.js
@@ -203,8 +203,8 @@ class uploadExtensionBuilder {
 
             /* PARSING */
             release = title_parser.parse(name.value, {
-                strict: true, // if no main tags found, will throw an exception
-                flagged: true, // add flags to generated relese name (like STV, REMASTERED, READNFO)
+                strict: false, // if no main tags found, will throw an exception
+                flagged: true, // add flags to generated release name (like STV, REMASTERED, READNFO)
                 erase: [], // add expressions to erase before parsing
                 defaults: {
                     language: 'ENGLISH',

--- a/resources/js/unit3d/parser.js
+++ b/resources/js/unit3d/parser.js
@@ -435,7 +435,8 @@ function parse(name, options = { strict: false, flagged: true, erase: [], defaul
         .filter((property) => release[property]).length;
 
     if (options.strict && !valid) {
-        throw new Error('"' + release.original + '" does\'t follow scene release naming rules');
+        const message = '"' + release.original + '" doesn\'t follow scene release naming rules';
+        window.dispatchEvent(new CustomEvent('alertError', { detail: { message } }));
     }
 
     return release;


### PR DESCRIPTION
_Initially added in https://github.com/HDInnovations/UNIT3D/commit/969afb8e1985fbeba8e84f174632b0055a49fa4c_

Throwing a JS error is not the right approach to inform users about some error.
So let's change it to a custom event instead. Requires #5366 to be merged first.

But since no one has ever seen this message, change `strict` to `false` to avoid sudden popups.
Trackers can adjust these options manually on their side.