### PR TITLE
(Update) Make chatbox URLs clickable and consistent with 'bbcode' directive

### DIFF
--- a/app/Http/Resources/ChatMessageResource.php
+++ b/app/Http/Resources/ChatMessageResource.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace App\Http\Resources;
 
 use App\Helpers\Bbcode;
+use App\Helpers\Linkify;
 use hdvinnie\LaravelJoyPixels\LaravelJoyPixels;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -44,11 +45,7 @@ class ChatMessageResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        $emojiOne = new LaravelJoyPixels();
-
-        $bbcode = new Bbcode();
-        $logger = $bbcode->parse($this->message);
-        $logger = $emojiOne->toImage($logger);
+        $logger = new LaravelJoyPixels()->toImage(new Linkify()->linky(new Bbcode()->parse($this->message)));
 
         if ($this->user_id == 1) {
             $logger = str_replace('a href="/#', 'a trigger="bot" class="chatTrigger" href="/#', $logger);


### PR DESCRIPTION
Same logic as in:
https://github.com/HDInnovations/UNIT3D/blob/5f0bb9b16164580d77c7d6ae79e2377dd4ebb246/app/Providers/AppServiceProvider.php#L64-L65

Only presentation is changed, no extra tags are added to the `messages` DB table.