### PR TITLE
(Add) Focus the textarea when replying or editing a comment

### DIFF
--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -89,9 +89,14 @@
             @endif
         </aside>
         @if ($isEditing)
-            <form wire:submit="editComment" class="form edit-comment">
+            <form
+                wire:submit="editComment"
+                class="form edit-comment"
+                x-init="$nextTick(() => $refs.editBox.focus())"
+            >
                 <p class="form__group">
                     <textarea
+                        x-ref="editBox"
                         name="comment"
                         id="edit-comment"
                         class="form__textarea"
@@ -144,9 +149,15 @@
             @endif
 
             @if ($isReplying)
-                <form wire:submit="postReply" class="form reply-comment" x-data="toggle">
+                <form
+                    wire:submit="postReply"
+                    class="form reply-comment"
+                    x-data="toggle"
+                    x-init="$nextTick(() => $refs.replyBox.focus())"
+                >
                     <p class="form__group">
                         <textarea
+                            x-ref="replyBox"
                             name="comment"
                             id="reply-comment"
                             class="form__textarea"


### PR DESCRIPTION
Right now textarea for Reply and Edit buttons is just awkwardly added to the DOM.

Unlike the Quote button that actually sets the focus:
https://github.com/HDInnovations/UNIT3D/blob/8b88f4c8182eb3d3912ffef425c3224dcfd596f4/resources/views/livewire/comment.blade.php#L45-L46