### PR TITLE
(Remove) `COMPOSER_AUTH` env var from ci setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,8 +38,6 @@ runs:
                     unit3d-${{ inputs.operating-system }}-php${{ inputs.php-version }}-composer-
 
         -   name: Install Composer dependencies
-            env:
-                COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
             run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --optimize-autoloader
             shell: bash
 


### PR DESCRIPTION
This secret never existed, so just returned null. We should just remove the environment variable instead. Reusable actions don't support accessing secrets, so this should have started erroring when ci setup was converted to a reusable action. I'm going to assume caching is the reason why this didn't error until now. But now it's erroring, so time to fix it.