### PR TITLE
(Fix) Make quick search work in Safari

### DIFF
--- a/resources/views/partials/quick-search-dropdown.blade.php
+++ b/resources/views/partials/quick-search-dropdown.blade.php
@@ -34,7 +34,11 @@
                         x-on:keydown.down.prevent="focusNextResult"
                         x-on:keydown.up.prevent="focusPreviousResult"
                     >
-                        <a class="quick-search__result-link" :href="result.url">
+                        <a
+                            class="quick-search__result-link"
+                            :href="result.url"
+                            x-on:mousedown.prevent
+                        >
                             <img class="quick-search__image" :src="getSrc(result.image)" alt="" />
                             <h2 class="quick-search__result-text">
                                 <span
@@ -99,13 +103,13 @@
                     }
                 },
                 focusFirstResult() {
-                    document.querySelector('[x-ref="searchResults"]').querySelector('a').focus();
+                    document.querySelector('[x-ref="searchResults"]')?.querySelector('a')?.focus();
                 },
                 focusLastResult() {
                     document
                         .querySelector('[x-ref="searchResults"]')
-                        .querySelector('article:last-child > a')
-                        .focus();
+                        ?.querySelector('article:last-child > a')
+                        ?.focus();
                 },
                 focusNextResult() {
                     const el = this.$el;


### PR DESCRIPTION
The quick search bar on the home page doesn't work on Safari (macOS). Neither pressing return nor clicking on a completion result triggers any action. This is because Safari does not focus <a> elements on click (macOS convention) and does not reliably bubble :active to ancestor elements. This caused the CSS :focus-within/:active visibility rule to hide the dropdown before the click event could complete navigation.

The fix is to:
- Add x-on:mousedown.prevent on result links to retain input focus
- Add Enter key handler to navigate to the first search result

Also while I'm here we can also:
- Add null-safety to arrow key focus methods

I've run the project locally and have confirmed the fix works in Safari and does not cause a regression in Firefox.