### PR TITLE
(Add) Trigger navigation on Enter key for quick search

### DIFF
--- a/resources/views/partials/quick-search-dropdown.blade.php
+++ b/resources/views/partials/quick-search-dropdown.blade.php
@@ -9,6 +9,7 @@
             x-ref="quickSearch"
             x-on:keydown.down.prevent="focusFirstResult"
             x-on:keydown.up.prevent="focusLastResult"
+            x-on:keydown.enter="navigateToFirstResult"
             x-on:focus="searchPerformed = true"
         />
         <template x-if="searchResults === null">
@@ -89,6 +90,13 @@
                     this.searchText = '';
                     this.searchResults = [];
                     this.searchPerformed = false;
+                },
+                navigateToFirstResult() {
+                    if (Array.isArray(this.searchResults) && this.searchResults.length > 0) {
+                        window.location.href = this.searchResults[0].url;
+                    } else if (this.searchText.length > 0) {
+                        window.location.href = `/torrents?name=${encodeURIComponent(this.searchText)}`;
+                    }
                 },
                 focusFirstResult() {
                     document.querySelector('[x-ref="searchResults"]').querySelector('a').focus();


### PR DESCRIPTION
Press Enter in the quick search input to navigate directly to the first search result.