### PR TITLE
(Update) Use bun runtime for cspell

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -49,7 +49,7 @@ jobs:
                         unit3d-${{ matrix.operating-system }}-cspell-
 
             -   name: Run CSpell
-                run: bunx cspell --no-progress --cache --cache-location .cspell.cache/spell-results "**"
+                run: bunx --bun cspell --no-progress --cache --cache-location .cspell.cache/spell-results "**"
 
             -   name: Save CSpell cache
                 uses: actions/cache/save@v4


### PR DESCRIPTION
CSpell requires Node 22+ now and it's causing incompatibilities with bun. Using bun's runtime instead of node solves the problem.