### PR TITLE
(Update) Restrict torrent file previewer dialog to the first 5000 files.

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -91,7 +91,6 @@ class TorrentController extends Controller
                 'comments',
                 'category',
                 'featured',
-                'files',
                 'game' => [
                     'genres',
                     'companies',
@@ -164,6 +163,8 @@ class TorrentController extends Controller
                 ])
             )
             ->findOrFail($id);
+
+        $torrent->setRelation('files', $torrent->files()->limit(5000)->get());
 
         $fileTree = [];
 

--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -197,6 +197,13 @@
                     <li x-bind="tabButton" data-tab="list">List</li>
                 </menu>
                 <div class="dialog__form" x-bind="tabPanel" data-tab="hierarchy" style="gap: 0">
+                    @if ($torrent->files->count() >= 5000)
+                        <div style="padding-bottom: 12px; color: red">
+                            Only the first 5000 files are shown. Download the .torrent file to view
+                            the full contents.
+                        </div>
+                    @endif
+
                     @if ($torrent->folder !== null)
                         <span
                             style="
@@ -237,6 +244,15 @@
                             </tr>
                         </thead>
                         <tbody>
+                            @if ($torrent->files->count() >= 5000)
+                                <tr>
+                                    <td colspan="3" style="padding-bottom: 12px; color: red">
+                                        Only the first 5000 files are shown. Download the .torrent
+                                        file to view the full contents.
+                                    </td>
+                                </tr>
+                            @endif
+
                             @foreach ($torrent->files as $index => $file)
                                 <tr>
                                     <td style="text-align: right">{{ $index + 1 }}</td>


### PR DESCRIPTION
A torrent with 24k files uses 144MB of memory to show the torrent page. Limiting it to the first 5000 files reduces it to 40MB of memory.