### PR TITLE
(Update) Use infiniscroll for actor credits in movie/tv meta

### DIFF
--- a/.cspell/blade.txt
+++ b/.cspell/blade.txt
@@ -3,6 +3,7 @@ enderror
 endfor
 endforeach
 endforelse
+endisland
 endisset
 endphp
 endscript

--- a/app/Http/Controllers/SimilarTorrentController.php
+++ b/app/Http/Controllers/SimilarTorrentController.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Enums\Occupation;
 use App\Models\Category;
 use App\Models\IgdbGame;
 use App\Models\PersonalFreeleech;
@@ -45,7 +46,9 @@ class SimilarTorrentController extends Controller
                 $meta = TmdbMovie::query()
                     ->with([
                         'genres',
-                        'credits' => ['person', 'occupation'],
+                        'credits' => fn ($query) => $query
+                            ->where('occupation_id', '!=', Occupation::ACTOR)
+                            ->with(['person:id,still,name', 'occupation']),
                         'companies',
                         'collections.movies',
                     ])
@@ -61,7 +64,9 @@ class SimilarTorrentController extends Controller
                 $meta = TmdbTv::query()
                     ->with([
                         'genres',
-                        'credits' => ['person', 'occupation'],
+                        'credits' => fn ($query) => $query
+                            ->where('occupation_id', '!=', Occupation::ACTOR)
+                            ->with(['person:id,still,name', 'occupation']),
                         'companies',
                         'networks'
                     ])

--- a/app/Http/Livewire/WorkTmdbActorCredits.php
+++ b/app/Http/Livewire/WorkTmdbActorCredits.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Http\Livewire;
+
+use App\Enums\Occupation;
+use App\Models\TmdbMovie;
+use App\Models\TmdbTv;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Component;
+
+class WorkTmdbActorCredits extends Component
+{
+    public TmdbMovie|TmdbTv $work;
+
+    public int $page = 1;
+
+    public function loadMore(): void
+    {
+        $this->page++;
+    }
+
+    /**
+     * @var Collection<int, \App\Models\TmdbCredit>|null
+     */
+    final protected ?Collection $credits {
+        get => match ($this->work::class) {
+            TmdbMovie::class => $this->work
+                ->credits()
+                ->with(['person:id,still,name', 'occupation'])
+                ->where('occupation_id', '=', Occupation::ACTOR)
+                ->orderBy('order')
+                ->forPage($this->page, 500)
+                ->get(),
+            TmdbTv::class => $this->work
+                ->credits()
+                ->with(['person:id,still,name', 'occupation'])
+                ->where('occupation_id', '=', Occupation::ACTOR)
+                ->orderBy('order')
+                ->forPage($this->page, 500)
+                ->get(),
+        };
+    }
+
+    final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application
+    {
+        return view('livewire.work-tmdb-actor-credits', [
+            'credits' => $this->credits,
+        ]);
+    }
+}

--- a/resources/views/livewire/work-tmdb-actor-credits.blade.php
+++ b/resources/views/livewire/work-tmdb-actor-credits.blade.php
@@ -1,0 +1,28 @@
+<section class="meta__chip-container">
+    <h2 class="meta__heading">Cast</h2>
+    @island('actors')
+        @foreach ($this->credits as $credit)
+            <article class="meta-chip-wrapper">
+                <a
+                    href="{{ route('mediahub.persons.show', ['id' => $credit->person->id, 'occupationId' => $credit->occupation_id]) }}"
+                    class="meta-chip"
+                >
+                    @if ($credit->person->still)
+                        <img
+                            class="meta-chip__image"
+                            src="{{ tmdb_image('cast_face', $credit->person->still) }}"
+                            alt=""
+                            loading="lazy"
+                        />
+                    @else
+                        <i class="{{ config('other.font-awesome') }} fa-user meta-chip__icon"></i>
+                    @endif
+                    <h2 class="meta-chip__name">{{ $credit->person->name }}</h2>
+                    <h3 class="meta-chip__value">{{ $credit->character }}</h3>
+                </a>
+            </article>
+        @endforeach
+    @endisland
+
+    <div wire:intersect.margin.200px="loadMore" wire:island.append="actors"></div>
+</section>

--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -242,35 +242,10 @@
     </ul>
     <p class="meta__description">{{ $meta?->overview }}</p>
     <div class="meta__chips">
-        <section class="meta__chip-container">
-            <h2 class="meta__heading">Cast</h2>
-            @foreach ($meta?->credits?->where('occupation_id', '=', App\Enums\Occupation::ACTOR->value)?->sortBy('order') ?? [] as $credit)
-                <article class="meta-chip-wrapper">
-                    <a
-                        href="{{ route('mediahub.persons.show', ['id' => $credit->person->id, 'occupationId' => $credit->occupation_id]) }}"
-                        class="meta-chip"
-                    >
-                        @if ($credit->person->still)
-                            <img
-                                class="meta-chip__image"
-                                src="{{ tmdb_image('cast_face', $credit->person->still) }}"
-                                alt=""
-                                loading="lazy"
-                            />
-                        @else
-                            <i
-                                class="{{ config('other.font-awesome') }} fa-user meta-chip__icon"
-                            ></i>
-                        @endif
-                        <h2 class="meta-chip__name">{{ $credit->person->name }}</h2>
-                        <h3 class="meta-chip__value">{{ $credit->character }}</h3>
-                    </a>
-                </article>
-            @endforeach
-        </section>
+        <livewire:work-tmdb-actor-credits :work="$meta->withoutRelations()" />
         <section class="meta__chip-container" title="Crew">
             <h2 class="meta__heading">Crew</h2>
-            @foreach ($meta?->credits?->where('occupation_id', '!=', App\Enums\Occupation::ACTOR->value)?->sortBy('occupation.position') ?? [] as $credit)
+            @foreach ($meta?->credits?->sortBy('occupation.position') ?? [] as $credit)
                 <article class="meta-chip-wrapper">
                     <a
                         href="{{ route('mediahub.persons.show', ['id' => $credit->person->id, 'occupationId' => $credit->occupation_id]) }}"

--- a/resources/views/torrent/partials/tv-meta.blade.php
+++ b/resources/views/torrent/partials/tv-meta.blade.php
@@ -228,35 +228,10 @@
     </ul>
     <p class="meta__description">{{ $meta?->overview }}</p>
     <div class="meta__chips">
-        <section class="meta__chip-container">
-            <h2 class="meta__heading">Cast</h2>
-            @foreach ($meta?->credits?->where('occupation_id', '=', App\Enums\Occupation::ACTOR->value)?->sortBy('order') ?? [] as $credit)
-                <article class="meta-chip-wrapper">
-                    <a
-                        href="{{ route('mediahub.persons.show', ['id' => $credit->person->id, 'occupationId' => $credit->occupation_id]) }}"
-                        class="meta-chip"
-                    >
-                        @if ($credit->person->still)
-                            <img
-                                class="meta-chip__image"
-                                src="{{ tmdb_image('cast_face', $credit->person->still) }}"
-                                alt=""
-                                loading="lazy"
-                            />
-                        @else
-                            <i
-                                class="{{ config('other.font-awesome') }} fa-user meta-chip__icon"
-                            ></i>
-                        @endif
-                        <h2 class="meta-chip__name">{{ $credit->person->name }}</h2>
-                        <h3 class="meta-chip__value">{{ $credit->character }}</h3>
-                    </a>
-                </article>
-            @endforeach
-        </section>
+        <livewire:work-tmdb-actor-credits :work="$meta->withoutRelations()" />
         <section class="meta__chip-container" title="Crew">
             <h2 class="meta__heading">Crew</h2>
-            @foreach ($meta?->credits?->where('occupation_id', '!=', App\Enums\Occupation::ACTOR->value)?->sortBy('occupation.position') ?? [] as $credit)
+            @foreach ($meta?->credits?->sortBy('occupation.position') ?? [] as $credit)
                 <article class="meta-chip-wrapper">
                     <a
                         href="{{ route('mediahub.persons.show', ['id' => $credit->person->id, 'occupationId' => $credit->occupation_id]) }}"


### PR DESCRIPTION
Load 500 at a time. Reduces memory usage from 130MB on pages with 7500 credits, to 24MB.