### PR TITLE
Log failed invites for reused emails

### DIFF
--- a/app/Http/Controllers/User/InviteController.php
+++ b/app/Http/Controllers/User/InviteController.php
@@ -18,10 +18,12 @@ namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
 use App\Mail\InviteUser;
+use App\Models\Application;
 use App\Models\Invite;
 use App\Models\User;
 use App\Rules\EmailBlacklist;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Validation\Rule;
 use Ramsey\Uuid\Uuid;
@@ -101,6 +103,20 @@ class InviteController extends Controller
         if ($user->two_factor_confirmed_at === null || $user->two_factor_confirmed_at->addHours($minHours)->isFuture()) {
             return to_route('home.index')
                 ->withErrors("Two-factor authentication must be enabled for {$minHours} hours to send invites");
+        }
+
+        $email = $request->string('email')->toString();
+
+        if ($email !== '' && (
+            Invite::where('email', '=', $email)->exists()
+            || User::where('email', '=', $email)->exists()
+            || Application::where('email', '=', $email)->exists()
+        )) {
+            Log::notice('Invite rejected because email is already in use.', [
+                'email'           => $email,
+                'sender_user_id'  => $user->id,
+                'request_user_id' => $request->user()->id,
+            ]);
         }
 
         $request->validate([

--- a/tests/Feature/Http/Controllers/User/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/InviteControllerTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 use App\Models\Group;
 use App\Models\Invite;
 use App\Models\User;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 test('create returns an ok response', function (): void {
@@ -146,6 +147,40 @@ test('store returns an ok response', function (): void {
         'user_id' => $user->id,
         'email'   => $inviteEmail,
     ]);
+});
+
+test('store logs failed invite when email is already in use', function (): void {
+    $group = Group::factory()->create([]);
+
+    $user = User::factory()->create([
+        'group_id'                => $group->id,
+        'can_invite'              => 1,
+        'invites'                 => 1,
+        'two_factor_confirmed_at' => now(),
+    ]);
+
+    $existingUser = User::factory()->create();
+
+    config(['other.invites_restriced' => true]);
+    config(['other.invite_groups' => [$group->name]]);
+    config(['other.hours-until-invite-after-2fa' => 0]);
+    config(['email-blacklist.enabled' => false]);
+
+    Log::spy();
+
+    $response = $this->actingAs($user)->post(route('users.invites.store', [$user]), [
+        'email'   => $existingUser->email,
+        'message' => 'Test Invite',
+    ]);
+
+    $response->assertSessionHasErrors('email');
+    Log::shouldHaveReceived('notice')
+        ->once()
+        ->with('Invite rejected because email is already in use.', Mockery::on(
+            fn (array $context): bool => $context['email'] === $existingUser->email
+                && $context['sender_user_id'] === $user->id
+                && $context['request_user_id'] === $user->id
+        ));
 });
 
 test('store with internal note as staff user', function (): void {


### PR DESCRIPTION
Fixes #3664

## Summary
- Logs failed invite attempts when the requested email address is already present in users, invites, or applications.
- Includes the requested email, inviting user id, and authenticated request user id in the log context for staff investigation.
- Adds regression coverage for the duplicate-user-email path.

## Validation
- `composer install --no-interaction --no-scripts --ignore-platform-reqs`
- `./vendor/bin/pint app/Http/Controllers/User/InviteController.php tests/Feature/Http/Controllers/User/InviteControllerTest.php`
- `php -l app/Http/Controllers/User/InviteController.php`
- `php -l tests/Feature/Http/Controllers/User/InviteControllerTest.php`
- `git diff --check`

Note: attempted targeted `php artisan test tests/Feature/Http/Controllers/User/InviteControllerTest.php --filter "store logs failed invite"`, but local validation could not complete without the repo's expected MySQL test service (`SQLSTATE[HY000] [2002] Connection refused`).