### PR TITLE
Handle missing request categories

### DIFF
--- a/app/Models/TorrentRequest.php
+++ b/app/Models/TorrentRequest.php
@@ -148,7 +148,9 @@ final class TorrentRequest extends Model
      */
     public function category(): BelongsTo
     {
-        return $this->belongsTo(Category::class);
+        return $this->belongsTo(Category::class)->withDefault([
+            'name' => 'Deleted category',
+        ]);
     }
 
     /**

--- a/tests/Unit/Models/TorrentRequestTest.php
+++ b/tests/Unit/Models/TorrentRequestTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Models\TorrentRequest;
+
+describe('torrent request model', function (): void {
+    it('provides a fallback category for requests whose category was deleted', function (): void {
+        $torrentRequest = TorrentRequest::factory()->make([
+            'category_id' => 999999,
+        ]);
+
+        expect($torrentRequest->category->name)->toBe('Deleted category');
+    });
+});


### PR DESCRIPTION
/claim #3970

## Summary
- Adds a default category model for torrent requests whose referenced category has been deleted.
- Prevents the request search view from throwing when it renders a request with a stale `category_id`.
- Adds a regression test covering the deleted-category fallback.

## Validation
- `php -l app/Models/TorrentRequest.php`
- `php -l tests/Unit/Models/TorrentRequestTest.php`
- `git diff --check`

Note: I also attempted the targeted Pest test. It reached the test bootstrap but local validation is blocked by this checkout's environment/config: missing default app env values first, then MySQL unavailable; with sqlite memory it hits an existing duplicate index migration issue (`request_id already exists`).