### PR TITLE
Handle IRC announce broken pipes

### DIFF
--- a/app/Bots/IRCAnnounceBot.php
+++ b/app/Bots/IRCAnnounceBot.php
@@ -21,9 +21,9 @@ use Illuminate\Support\Facades\Log;
 class IRCAnnounceBot
 {
     /**
-     * @var resource
+     * @var resource|null
      */
-    private $socket;
+    private $socket = null;
 
     private const RPL_WELCOME = 001;
 

--- a/app/Bots/IRCAnnounceBot.php
+++ b/app/Bots/IRCAnnounceBot.php
@@ -107,10 +107,18 @@ class IRCAnnounceBot
 
     private function send(string $data): void
     {
-        if (\is_resource($this->socket)) {
-            fwrite($this->socket, $data."\r\n");
-        } else {
+        if (! \is_resource($this->socket)) {
             Log::error('Tried to send data while not connected.');
+
+            return;
+        }
+
+        $bytesWritten = @fwrite($this->socket, $data."\r\n");
+
+        if ($bytesWritten === false) {
+            Log::warning('Failed to send IRC data, closing stale socket.');
+            fclose($this->socket);
+            $this->socket = null;
         }
     }
 


### PR DESCRIPTION
/claim #3785

## Summary
- Handles broken IRC announce sockets without throwing `fwrite()` warnings/exceptions.
- Logs the failed send, closes the stale socket, and marks it disconnected so later sends follow the existing not-connected path.
- This prevents fast announce bursts from surfacing broken-pipe errors when the IRC server has closed the connection.

## Validation
- `php -l app/Bots/IRCAnnounceBot.php`
- `git diff --check`