### PR TITLE
Use plain links for forum post pagination

### DIFF
--- a/resources/views/livewire/topic-post-search.blade.php
+++ b/resources/views/livewire/topic-post-search.blade.php
@@ -54,7 +54,7 @@
         </ul>
     @endif
 
-    {{ $posts->links('partials.pagination') }}
+    {{ $posts->links('partials.pagination-links') }}
     <div class="panel__body">
         @if ($posts->count() > 0)
             <ol class="topic-posts">
@@ -68,5 +68,5 @@
             No topics.
         @endif
     </div>
-    {{ $posts->links('partials.pagination') }}
+    {{ $posts->links('partials.pagination-links') }}
 </section>

--- a/resources/views/partials/pagination-links.blade.php
+++ b/resources/views/partials/pagination-links.blade.php
@@ -1,0 +1,154 @@
+@php
+    if (! isset($scrollTo)) {
+        $scrollTo = '.panelV2';
+    }
+
+    $scrollIntoViewJsSnippet =
+        $scrollTo !== false
+            ? <<<JS
+       window.scroll({ top: ((\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).offsetTop - 80)})
+    JS
+            : '';
+@endphp
+
+@if ($paginator->hasPages())
+    <nav class="pagination" role="navigation" aria-label="Pagination navigation">
+        <ul class="pagination__items">
+            @if ($paginator->onFirstPage())
+                <li class="pagination__previous pagination__previous--disabled">
+                    &lsaquo; {{ __('common.previous') }}
+                </li>
+            @else
+                <li class="pagination__previous">
+                    <a
+                        class="pagination__previous"
+                        href="{{ $paginator->previousPageUrl() }}"
+                        rel="prev"
+                    >
+                        &lsaquo; {{ __('common.previous') }}
+                    </a>
+                </li>
+            @endif
+            <li class="pagination__page-wrapper">
+                <ul class="pagination__pages">
+                    @if ($paginator->onFirstPage())
+                        <li class="pagination__current">1</li>
+                    @else
+                        <li>
+                            <a
+                                class="pagination__link"
+                                href="{{ $paginator->url(1) }}"
+                                rel="prev"
+                            >
+                                1
+                            </a>
+                        </li>
+                    @endif
+                    @if ($paginator->currentPage() - 3 > 2)
+                        @if ($paginator->currentPage() - 4 === 2)
+                            <li>
+                                <a
+                                    class="pagination__link"
+                                    href="{{ $paginator->url(2) }}"
+                                >
+                                    2
+                                </a>
+                            </li>
+                        @else
+                            <li class="pagination__ellipsis">&middot;&middot;&middot;</li>
+                        @endif
+                    @endif
+
+                    @if ($paginator instanceof \Illuminate\Pagination\LengthAwarePaginator)
+                        @for ($page = max(2, $paginator->currentPage() - 3); $page <= min($paginator->currentPage() + 3, $paginator->lastPage() - 1); $page++)
+                            @if ($page === $paginator->currentPage())
+                                <li class="pagination__current">{{ $page }}</li>
+                            @else
+                                <li>
+                                    <a
+                                        class="pagination__link"
+                                        href="{{ $paginator->url($page) }}"
+                                    >
+                                        {{ $page }}
+                                    </a>
+                                </li>
+                            @endif
+                        @endfor
+
+                        @if ($paginator->currentPage() + 3 < $paginator->lastPage() - 1)
+                            @if ($paginator->currentPage() + 4 === $paginator->lastPage() - 1)
+                                <li>
+                                    <a
+                                        class="pagination__link"
+                                        href="{{ $paginator->url($paginator->currentPage() + 4) }}"
+                                    >
+                                        {{ $paginator->currentPage() + 4 }}
+                                    </a>
+                                </li>
+                            @else
+                                <li class="pagination__ellipsis">&middot;&middot;&middot;</li>
+                            @endif
+                        @endif
+
+                        @if ($paginator->hasMorePages())
+                            <li>
+                                <a
+                                    class="pagination__link"
+                                    href="{{ $paginator->url($paginator->lastPage()) }}"
+                                    rel="next"
+                                >
+                                    {{ $paginator->lastPage() }}
+                                </a>
+                            </li>
+                        @else
+                            <li class="pagination__current">{{ $paginator->lastPage() }}</li>
+                        @endif
+                    @else
+                        @for ($page = max(2, $paginator->currentPage() - 3); $page <= $paginator->currentPage(); $page++)
+                            @if ($page === $paginator->currentPage())
+                                <li class="pagination__current">{{ $page }}</li>
+                            @else
+                                <li>
+                                    <a
+                                        class="pagination__link"
+                                        href="{{ $paginator->url($page) }}"
+                                    >
+                                        {{ $page }}
+                                    </a>
+                                </li>
+                            @endif
+                        @endfor
+
+                        @if ($paginator->hasMorePages())
+                            <li>
+                                <a
+                                    class="pagination__link"
+                                    href="{{ $paginator->url($paginator->currentPage() + 1) }}"
+                                    rel="next"
+                                >
+                                    {{ $paginator->currentPage() + 1 }}
+                                </a>
+                            </li>
+                        @endif
+                    @endif
+                </ul>
+            </li>
+
+            @if ($paginator->hasMorePages())
+                <li class="pagination__next">
+                    <a
+                        class="pagination__next"
+                        href="{{ $paginator->nextPageUrl() }}"
+                        rel="next"
+                    >
+                        {{ __('common.next') }} &rsaquo;
+                    </a>
+                </li>
+            @else
+                <li class="pagination__next pagination__next--disabled">
+                    {{ __('common.next') }} &rsaquo;
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif


### PR DESCRIPTION
/claim #4082

## Summary
- Uses plain browser links for forum topic post pagination instead of Livewire AJAX-only pagination controls.
- Keeps the existing Livewire pagination partial unchanged for other interactive search tables.
- Allows forum page links to be opened in a new tab/window with the canonical `?page=` URL instead of hitting `/livewire/update` with GET.

## Validation
- `php -l resources/views/partials/pagination-links.blade.php`
- `php -l resources/views/livewire/topic-post-search.blade.php`
- `git diff --check`

Note: I saw the prior closed PR #5310 used `wire:navigate`; this PR takes the safer plain-anchor approach for forum post pages so browser open-in-new-tab behavior does not depend on Livewire interception.