### PR TITLE
Notify ticket commenters on new replies

### DIFF
--- a/app/Http/Livewire/Comments.php
+++ b/app/Http/Livewire/Comments.php
@@ -134,6 +134,16 @@ class Comments extends Component
                 // Notify ticket creator if needed
                 User::find($this->model->user_id)?->notify(new NewComment($this->model, $comment));
 
+                // Notify previous ticket commenters when a new reply is added
+                User::whereIn(
+                    'id',
+                    $this->model->comments()
+                        ->where('id', '!=', $comment->id)
+                        ->whereNotNull('user_id')
+                        ->pluck('user_id')
+                        ->unique(),
+                )->get()->each->notify(new NewComment($this->model, $comment));
+
                 break;
             case Article::class:
             case Playlist::class:


### PR DESCRIPTION
/claim #3756

## Summary
- Extends ticket comment notifications so prior participants in a help desk ticket are notified when a new reply is added.
- Keeps existing notifications for assigned staff and the ticket creator.
- Reuses the existing `NewComment` notification, whose `shouldSend()` already suppresses self-notifications.

## Validation
- `php -l app/Http/Livewire/Comments.php`
- `./vendor/bin/pint app/Http/Livewire/Comments.php`
- `git diff --check`