### PR TITLE
Use withoutTimestamps for bulk updates

### DIFF
--- a/app/Console/Commands/AutoCorrectHistory.php
+++ b/app/Console/Commands/AutoCorrectHistory.php
@@ -20,7 +20,6 @@ use App\Models\History;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Exception;
-use Illuminate\Support\Facades\DB;
 use Throwable;
 
 class AutoCorrectHistory extends Command
@@ -46,13 +45,12 @@ class AutoCorrectHistory extends Command
      */
     final public function handle(): void
     {
-        History::query()
-            ->where('active', '=', 1)
-            ->where('updated_at', '<', Carbon::now()->subHours(2))
-            ->update([
-                'active'     => 0,
-                'updated_at' => DB::raw('updated_at'),
-            ]);
+        History::withoutTimestamps(
+            fn () => History::query()
+                ->where('active', '=', 1)
+                ->where('updated_at', '<', Carbon::now()->subHours(2))
+                ->update(['active' => 0])
+        );
 
         $this->comment('Automated history record correction command complete');
     }

--- a/app/Console/Commands/AutoHighspeedTag.php
+++ b/app/Console/Commands/AutoHighspeedTag.php
@@ -53,20 +53,21 @@ class AutoHighspeedTag extends Command
             ->filter(fn ($ip) => filter_var($ip, FILTER_VALIDATE_IP) !== false)
             ->map(fn ($ip) => inet_pton($ip));
 
-        Torrent::withoutGlobalScope(ApprovedScope::class)
-            ->leftJoinSub(
-                Peer::where('seeder', '=', 1)
-                    ->where('active', '=', 1)
-                    ->distinct()
-                    ->select('torrent_id')
-                    ->whereIn('ip', $seedboxIps),
-                'highspeed_torrents',
-                fn ($join) => $join->on('torrents.id', '=', 'highspeed_torrents.torrent_id')
-            )
-            ->update([
-                'highspeed'  => DB::raw('CASE WHEN highspeed_torrents.torrent_id IS NOT NULL THEN TRUE ELSE FALSE END'),
-                'updated_at' => DB::raw('updated_at'),
-            ]);
+        Torrent::withoutTimestamps(
+            fn () => Torrent::withoutGlobalScope(ApprovedScope::class)
+                ->leftJoinSub(
+                    Peer::where('seeder', '=', 1)
+                        ->where('active', '=', 1)
+                        ->distinct()
+                        ->select('torrent_id')
+                        ->whereIn('ip', $seedboxIps),
+                    'highspeed_torrents',
+                    fn ($join) => $join->on('torrents.id', '=', 'highspeed_torrents.torrent_id')
+                )
+                ->update([
+                    'highspeed' => DB::raw('CASE WHEN highspeed_torrents.torrent_id IS NOT NULL THEN TRUE ELSE FALSE END'),
+                ])
+        );
 
         $this->comment('Automated high speed torrents command complete');
     }

--- a/app/Console/Commands/AutoWarning.php
+++ b/app/Console/Commands/AutoWarning.php
@@ -81,13 +81,12 @@ class AutoWarning extends Command
                 'active'     => true,
             ]);
 
-            History::query()
-                ->where('torrent_id', '=', $hr->torrent_id)
-                ->where('user_id', '=', $hr->user_id)
-                ->update([
-                    'hitrun'     => true,
-                    'updated_at' => DB::raw('updated_at'),
-                ]);
+            History::withoutTimestamps(
+                fn () => History::query()
+                    ->where('torrent_id', '=', $hr->torrent_id)
+                    ->where('user_id', '=', $hr->user_id)
+                    ->update(['hitrun' => true])
+            );
 
             // Add +1 To Users Warnings Count In Users Table
             $hr->user->increment('hitandruns');

--- a/app/Http/Controllers/Staff/FlushController.php
+++ b/app/Http/Controllers/Staff/FlushController.php
@@ -24,7 +24,6 @@ use App\Models\Peer;
 use App\Repositories\ChatRepository;
 use Illuminate\Support\Carbon;
 use Exception;
-use Illuminate\Support\Facades\DB;
 
 /**
  * @see \Tests\Todo\Feature\Http\Controllers\Staff\FlushControllerTest
@@ -53,13 +52,12 @@ class FlushController extends Controller
         $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2))->get();
 
         foreach ($peers as $peer) {
-            History::query()
-                ->where('torrent_id', '=', $peer->torrent_id)
-                ->where('user_id', '=', $peer->user_id)
-                ->update([
-                    'active'     => false,
-                    'updated_at' => DB::raw('updated_at'),
-                ]);
+            History::withoutTimestamps(
+                fn () => History::query()
+                    ->where('torrent_id', '=', $peer->torrent_id)
+                    ->where('user_id', '=', $peer->user_id)
+                    ->update(['active' => false])
+            );
 
             Peer::query()
                 ->where('torrent_id', '=', $peer->torrent_id)

--- a/app/Http/Controllers/User/PeerController.php
+++ b/app/Http/Controllers/User/PeerController.php
@@ -67,13 +67,12 @@ class PeerController extends Controller
             ->where('updated_at', '<', $cutoff)
             ->delete();
 
-        $user->history()
-            ->where('active', '=', 1)
-            ->where('updated_at', '<', $cutoff)
-            ->update([
-                'active'     => 0,
-                'updated_at' => DB::raw('updated_at'),
-            ]);
+        History::withoutTimestamps(
+            fn () => $user->history()
+                ->where('active', '=', 1)
+                ->where('updated_at', '<', $cutoff)
+                ->update(['active' => 0])
+        );
 
         $user->decrement('own_flushes');
 


### PR DESCRIPTION
/claim #4298

## Summary
- Replaces several `updated_at => DB::raw('updated_at')` bulk-update hacks with `Model::withoutTimestamps(...)`.
- Keeps the intended behavior of changing the target columns without bumping `updated_at`.
- Covers peer/history cleanup, hit-and-run marking, and high-speed torrent tagging paths.
- Removes now-unused `DB` imports where the raw timestamp workaround was the only usage.

## Validation
- `php -l app/Http/Controllers/User/PeerController.php`
- `php -l app/Http/Controllers/Staff/FlushController.php`
- `php -l app/Console/Commands/AutoHighspeedTag.php`
- `php -l app/Console/Commands/AutoCorrectHistory.php`
- `php -l app/Console/Commands/AutoWarning.php`
- `./vendor/bin/pint app/Http/Controllers/User/PeerController.php app/Http/Controllers/Staff/FlushController.php app/Console/Commands/AutoHighspeedTag.php app/Console/Commands/AutoCorrectHistory.php app/Console/Commands/AutoWarning.php`
- `git diff --check`