### PR TITLE
Add spacing after custom user icons

### DIFF
--- a/resources/sass/components/_user-tag.scss
+++ b/resources/sass/components/_user-tag.scss
@@ -14,3 +14,7 @@
 .user-tag__link ~ a {
     margin-left: 0.5ch;
 }
+
+.user-tag__custom-icon {
+    margin-right: 0.5ch;
+}

--- a/resources/views/components/user-tag.blade.php
+++ b/resources/views/components/user-tag.blade.php
@@ -25,7 +25,7 @@
                 {{ $user->username }}
             </a>
             @if ($user->icon !== null)
-                <i>
+                <i class="user-tag__custom-icon">
                     <img
                         @style([
                             'max-height: 22px;' =>
@@ -78,7 +78,7 @@
             {{ $user->username }}
         </a>
         @if ($user->icon !== null)
-            <i>
+            <i class="user-tag__custom-icon">
                 <img
                     @style([
                         'max-height: 22px;' =>


### PR DESCRIPTION
Fixes #4192

/claim #4192

## Summary
- add a dedicated custom user icon class
- add right-side spacing so lifetime donor/donor icons do not touch custom icons

## Validation
- php -l resources/views/components/user-tag.blade.php
- ./vendor/bin/pint resources/views/components/user-tag.blade.php
- git diff --check