### PR TITLE
Require password before disabling two-factor auth

### DIFF
--- a/app/Http/Livewire/TwoFactorAuthForm.php
+++ b/app/Http/Livewire/TwoFactorAuthForm.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace App\Http\Livewire;
 
+use Illuminate\Support\Facades\Hash;
 use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
@@ -44,6 +45,11 @@ class TwoFactorAuthForm extends Component
      * The OTP code for confirming two-factor authentication.
      */
     public string $code;
+
+    /**
+     * The current password confirmation for disabling two-factor authentication.
+     */
+    public string $password = '';
 
     /**
      * Mount the component.
@@ -115,8 +121,15 @@ class TwoFactorAuthForm extends Component
      */
     final public function disableTwoFactorAuthentication(DisableTwoFactorAuthentication $disable): void
     {
+        if (!$this->showingConfirmation && !Hash::check($this->password, auth()->user()->password)) {
+            $this->dispatch('error', type: 'error', message: 'The provided password is incorrect.');
+
+            return;
+        }
+
         $disable(auth()->user());
 
+        $this->password = '';
         $this->showingQrCode = false;
         $this->showingConfirmation = false;
         $this->showingRecoveryCodes = false;

--- a/resources/views/livewire/two-factor-auth-form.blade.php
+++ b/resources/views/livewire/two-factor-auth-form.blade.php
@@ -128,6 +128,20 @@
                         {{ __('Cancel') }}
                     </button>
                 @else
+                    <div class="form__group">
+                        <input
+                            id="password"
+                            class="form__text"
+                            type="password"
+                            autocomplete="current-password"
+                            wire:model.live="password"
+                            wire:keydown.enter="disableTwoFactorAuthentication"
+                            placeholder=" "
+                        />
+                        <label class="form__label form__label--floating" for="password">
+                            {{ __('Current Password') }}
+                        </label>
+                    </div>
                     <button
                         class="form__button form__button--filled"
                         wire:click="disableTwoFactorAuthentication"


### PR DESCRIPTION
Fixes #4364

/claim #4364

## Summary
- require the current password before disabling confirmed two-factor authentication
- keep setup cancellation passwordless so users can still cancel an unfinished 2FA setup
- clear the password field after a successful disable

## Validation
- php -l app/Http/Livewire/TwoFactorAuthForm.php
- php -l resources/views/livewire/two-factor-auth-form.blade.php
- ./vendor/bin/pint app/Http/Livewire/TwoFactorAuthForm.php resources/views/livewire/two-factor-auth-form.blade.php
- git diff --check