### PR TITLE
Add invite email and code search

### DIFF
--- a/app/Http/Controllers/User/InviteController.php
+++ b/app/Http/Controllers/User/InviteController.php
@@ -39,9 +39,27 @@ class InviteController extends Controller
     {
         abort_unless($request->user()->group->is_modo || $request->user()->is($user), 403);
 
+        $search = trim($request->string('search')->toString());
+
+        $invites = $user->sentInvites()
+            ->withTrashed()
+            ->with(['sender.group', 'receiver.group'])
+            ->when(
+                $search !== '',
+                fn ($query) => $query->where(
+                    fn ($query) => $query
+                        ->where('email', 'LIKE', '%'.$search.'%')
+                        ->orWhere('code', 'LIKE', '%'.$search.'%')
+                )
+            )
+            ->latest()
+            ->paginate(25)
+            ->withQueryString();
+
         return view('user.invite.index', [
             'user'    => $user,
-            'invites' => $user->sentInvites()->withTrashed()->with(['sender.group', 'receiver.group'])->latest()->paginate(25),
+            'invites' => $invites,
+            'search'  => $search,
         ]);
     }
 

--- a/resources/views/user/invite/index.blade.php
+++ b/resources/views/user/invite/index.blade.php
@@ -36,6 +36,37 @@
                 </div>
             </div>
         </header>
+        <div class="panel__body" style="padding: 5px">
+            <form class="form" method="GET" action="{{ route('users.invites.index', ['user' => $user]) }}">
+                <div class="form__group--short-horizontal">
+                    <div class="form__group">
+                        <input
+                            id="search"
+                            class="form__text"
+                            type="search"
+                            name="search"
+                            value="{{ $search }}"
+                            autocomplete="off"
+                            placeholder=" "
+                        />
+                        <label class="form__label form__label--floating" for="search">
+                            {{ __('common.email') }} / {{ __('user.code') }}
+                        </label>
+                    </div>
+                    <button class="form__button form__button--filled">
+                        {{ __('common.search') }}
+                    </button>
+                    @if ($search !== '')
+                        <a
+                            class="form__button form__button--text"
+                            href="{{ route('users.invites.index', ['user' => $user]) }}"
+                        >
+                            {{ __('common.cancel') }}
+                        </a>
+                    @endif
+                </div>
+            </form>
+        </div>
         <div class="data-table-wrapper">
             <table class="data-table">
                 <thead>


### PR DESCRIPTION
Fixes #4379

/claim #4379

## Summary
- add a search form to the user/System invites page
- filter sent invites by email or invite code
- preserve the search query through pagination and add a clear link

## Validation
- php -l app/Http/Controllers/User/InviteController.php
- php -l resources/views/user/invite/index.blade.php
- ./vendor/bin/pint app/Http/Controllers/User/InviteController.php resources/views/user/invite/index.blade.php
- git diff --check