### PR TITLE
Expose torrent file paths in API

### DIFF
--- a/app/Http/Resources/TorrentResource.php
+++ b/app/Http/Resources/TorrentResource.php
@@ -56,6 +56,7 @@ class TorrentResource extends JsonResource
      *             array{
      *                 index: int,
      *                 name: string,
+     *                 path: string,
      *                 size: int,
      *             },
      *         >,
@@ -111,7 +112,8 @@ class TorrentResource extends JsonResource
                 'num_file'     => $this->num_file,
                 'files'        => $this->files->map(fn ($file, $index) => [
                     'index' => $index + 1,
-                    'name'  => $file->name,
+                    'name'  => basename($file->name),
+                    'path'  => $file->name,
                     'size'  => $file->size,
                 ]),
                 'freeleech'        => $this->free.'%',


### PR DESCRIPTION
Fixes #3728

/claim #3728

## Summary
- expose each torrent file's full stored path in API responses
- keep `name` as the basename for display-friendly consumers
- document the new `path` field in the resource return shape

## Validation
- php -l app/Http/Resources/TorrentResource.php
- ./vendor/bin/pint app/Http/Resources/TorrentResource.php
- git diff --check