### PR TITLE
Prevent stale cached user avatars

### DIFF
--- a/app/Http/Controllers/AuthenticatedImageController.php
+++ b/app/Http/Controllers/AuthenticatedImageController.php
@@ -30,6 +30,10 @@ class AuthenticatedImageController extends Controller
         'Cache-Control' => 'private, max-age=7200',
     ];
 
+    private const array AVATAR_HEADERS = [
+        'Cache-Control' => 'private, no-cache, must-revalidate',
+    ];
+
     public function articleImage(Article $article): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {
         $path = $article->image === null
@@ -93,7 +97,7 @@ class AuthenticatedImageController extends Controller
 
         abort_unless(file_exists($path), 404);
 
-        return response()->file($path, self::HEADERS);
+        return response()->file($path, self::AVATAR_HEADERS);
     }
 
     public function userIcon(User $user): \Symfony\Component\HttpFoundation\BinaryFileResponse


### PR DESCRIPTION
Fixes #3365

/claim #3365

## Summary
- use avatar-specific response headers for authenticated avatar images
- require revalidation for user avatars so replacing an avatar at the same URL does not leave browsers showing the stale cached image
- leave the longer cache policy unchanged for other authenticated images

## Validation
- php -l app/Http/Controllers/AuthenticatedImageController.php
- ./vendor/bin/pint app/Http/Controllers/AuthenticatedImageController.php
- git diff --check