### PR TITLE
Log failed duplicate invite attempts

### DIFF
--- a/app/Http/Controllers/User/InviteController.php
+++ b/app/Http/Controllers/User/InviteController.php
@@ -18,11 +18,13 @@ namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
 use App\Mail\InviteUser;
+use App\Models\Application;
 use App\Models\Invite;
 use App\Models\User;
 use App\Rules\EmailBlacklist;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Ramsey\Uuid\Uuid;
 use Exception;
@@ -103,7 +105,7 @@ class InviteController extends Controller
                 ->withErrors("Two-factor authentication must be enabled for {$minHours} hours to send invites");
         }
 
-        $request->validate([
+        $validator = Validator::make($request->all(), [
             'bail',
             'message'       => 'required',
             'internal_note' => Rule::unless($user->group->is_modo, 'missing'),
@@ -112,12 +114,20 @@ class InviteController extends Controller
                 'string',
                 'email:rfc,dns',
                 'max:70',
-                'unique:invites',
+                Rule::unique('invites')->whereNull('failed_at'),
                 'unique:users',
                 'unique:applications',
                 Rule::when(config('email-blacklist.enabled'), fn () => new EmailBlacklist())
             ],
         ]);
+
+        if ($validator->fails()) {
+            $this->logFailedInvite($request, $user, $validator->errors()->first('email'));
+
+            return to_route('users.invites.create', ['user' => $user])
+                ->withErrors($validator)
+                ->withInput();
+        }
 
         $user->decrement('invites');
 
@@ -134,6 +144,29 @@ class InviteController extends Controller
 
         return to_route('users.invites.create', ['user' => $user])
             ->with('success', trans('user.invite-sent-success'));
+    }
+
+    private function logFailedInvite(Request $request, User $user, ?string $failureReason): void
+    {
+        if ($failureReason === null) {
+            return;
+        }
+
+        $email = $request->input('email');
+
+        if (!User::where('email', $email)->exists() && !Application::where('email', $email)->exists()) {
+            return;
+        }
+
+        Invite::create([
+            'user_id'        => $user->id,
+            'email'          => $email,
+            'code'           => Uuid::uuid4()->toString(),
+            'internal_note'  => $request->input('internal_note'),
+            'custom'         => $request->input('message'),
+            'failed_at'      => now(),
+            'failure_reason' => $failureReason,
+        ]);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -697,7 +697,7 @@ final class User extends Authenticatable implements MustVerifyEmail
      */
     public function sentInvites(): HasMany
     {
-        return $this->hasMany(Invite::class, 'user_id');
+        return $this->hasMany(Invite::class, 'user_id')->whereNull('failed_at');
     }
 
     /**

--- a/database/migrations/2026_04_29_002400_add_failed_invite_logging.php
+++ b/database/migrations/2026_04_29_002400_add_failed_invite_logging.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invites', function (Blueprint $table): void {
+            $table->timestamp('failed_at')->nullable()->after('accepted_at');
+            $table->string('failure_reason')->nullable()->after('failed_at');
+        });
+    }
+};

--- a/resources/views/livewire/invite-log-search.blade.php
+++ b/resources/views/livewire/invite-log-search.blade.php
@@ -317,6 +317,14 @@
                                     {{ __('user.accepted-at') }}
                                     @include('livewire.includes._sort-icon', ['field' => 'accepted_at'])
                                 </th>
+                                <th wire:click="sortBy('failed_at')" role="columnheader button">
+                                    Failed At
+                                    @include('livewire.includes._sort-icon', ['field' => 'failed_at'])
+                                </th>
+                                <th wire:click="sortBy('failure_reason')" role="columnheader button">
+                                    Failure Reason
+                                    @include('livewire.includes._sort-icon', ['field' => 'failure_reason'])
+                                </th>
                                 <th wire:click="sortBy('deleted_at')" role="columnheader button">
                                     {{ __('user.deleted-on') }}
                                     @include('livewire.includes._sort-icon', ['field' => 'deleted_at'])
@@ -366,6 +374,15 @@
                                     </td>
                                     <td>
                                         <time
+                                            datetime="{{ $invite->failed_at }}"
+                                            title="{{ $invite->failed_at }}"
+                                        >
+                                            {{ $invite->failed_at ?? 'N/A' }}
+                                        </time>
+                                    </td>
+                                    <td>{{ $invite->failure_reason ?? 'N/A' }}</td>
+                                    <td>
+                                        <time
                                             datetime="{{ $invite->deleted_at }}"
                                             title="{{ $invite->deleted_at }}"
                                         >
@@ -375,7 +392,7 @@
                                 </tr>
                             @empty
                                 <tr>
-                                    <td colspan="10">No invites</td>
+                                    <td colspan="12">No invites</td>
                                 </tr>
                             @endforelse
                         </tbody>

--- a/tests/Feature/Http/Controllers/User/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/InviteControllerTest.php
@@ -199,3 +199,48 @@ test('store aborts with a 403', function (): void {
 });
 
 // test cases...
+
+test('store logs failed invite attempts for emails already in use', function (): void {
+    $group = Group::factory()->create([]);
+
+    $user = User::factory()->create([
+        'group_id'                => $group->id,
+        'can_invite'              => 1,
+        'invites'                 => 1,
+        'two_factor_confirmed_at' => now(),
+    ]);
+
+    $existingUser = User::factory()->create();
+
+    config(['other.invites_restriced' => true]);
+    config(['other.invite_groups' => [$group->name]]);
+    config(['other.hours-until-invite-after-2fa' => 0]);
+    config(['email-blacklist.enabled' => false]);
+
+    Mail::fake();
+
+    $response = $this->actingAs($user)->post(route('users.invites.store', [$user]), [
+        'email'   => $existingUser->email,
+        'message' => 'Test Invite',
+    ]);
+
+    $response->assertRedirect(route('users.invites.create', [$user]));
+    $response->assertSessionHasErrors('email');
+
+    $this->assertDatabaseHas('invites', [
+        'user_id' => $user->id,
+        'email'   => $existingUser->email,
+        'custom'  => 'Test Invite',
+    ]);
+
+    $failedInvite = Invite::where('email', $existingUser->email)->first();
+
+    expect($failedInvite->failed_at)->not()->toBeNull()
+        ->and($failedInvite->failure_reason)->not()->toBeNull();
+
+    $user->refresh();
+    expect($user->invites)->toBe(1)
+        ->and($user->sentInvites()->count())->toBe(0);
+
+    Mail::assertNothingSent();
+});


### PR DESCRIPTION
## Summary
- log failed invite attempts when the target email already belongs to a user or pending application
- expose failed-at / failure-reason fields in the staff invite log
- keep failed attempts out of normal sent-invite counts and allow future successful invites to use emails that only exist in failed log rows

## Validation
- `php -l app/Http/Controllers/User/InviteController.php`
- `php -l app/Models/User.php`
- `php -l resources/views/livewire/invite-log-search.blade.php`
- `php -l database/migrations/2026_04_29_002400_add_failed_invite_logging.php`
- `php -l tests/Feature/Http/Controllers/User/InviteControllerTest.php`
- `./vendor/bin/pint app/Http/Controllers/User/InviteController.php app/Models/User.php resources/views/livewire/invite-log-search.blade.php database/migrations/2026_04_29_002400_add_failed_invite_logging.php tests/Feature/Http/Controllers/User/InviteControllerTest.php`
- `git diff --check`

Note: targeted Laravel test execution is blocked locally by environment services/config in this checkout. MySQL is not running for the default test connection; SQLite in-memory migration also fails on an existing duplicate index name in an older migration before this test runs.

/claim #3664