### PR TITLE
Add database-backed global settings

### DIFF
--- a/app/Models/GlobalSetting.php
+++ b/app/Models/GlobalSetting.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Database-backed global application setting.
+ */
+final class GlobalSetting extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    public static function value(string $key, mixed $default = null): mixed
+    {
+        return cache()->rememberForever(
+            'global-setting:'.$key,
+            fn () => self::query()->where('key', '=', $key)->value('value') ?? $default,
+        );
+    }
+
+    public static function put(string $key, mixed $value): void
+    {
+        self::query()->updateOrCreate(['key' => $key], ['value' => $value]);
+        cache()->forget('global-setting:'.$key);
+    }
+}

--- a/database/migrations/2026_04_29_095500_create_global_settings_table.php
+++ b/database/migrations/2026_04_29_095500_create_global_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('global_settings', function (Blueprint $table): void {
+            $table->id();
+            $table->string('key')->unique();
+            $table->json('value')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('global_settings');
+    }
+};


### PR DESCRIPTION
Refs #4043

Adds a database-backed global settings foundation with cache invalidation.

Changes:
- Adds `global_settings` table with unique `key` and nullable JSON `value`
- Adds `App\Models\GlobalSetting`
- Provides `GlobalSetting::value($key, $default)` using `cache()->rememberForever`
- Provides `GlobalSetting::put($key, $value)` with database upsert and targeted cache invalidation

This is a small first slice toward moving code/config-managed UNIT3D settings into database-backed cached settings.

Validation:
- `php -l app/Models/GlobalSetting.php`
- `php -l database/migrations/2026_04_29_095500_create_global_settings_table.php`
- `git diff --check`