### PR TITLE
Add current-user wiki placeholders

### DIFF
--- a/app/Models/Wiki.php
+++ b/app/Models/Wiki.php
@@ -21,6 +21,7 @@ use App\Traits\Auditable;
 use GrahamCampbell\Markdown\Facades\Markdown;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Auth;
 use AllowDynamicProperties;
 
 /**
@@ -55,6 +56,23 @@ final class Wiki extends Model
      */
     public function getContentHtml(): string
     {
-        return Markdown::convert(htmlspecialchars_decode((new Bbcode())->parse($this->content, false), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5))->getContent();
+        $content = $this->replaceCurrentUserPlaceholders($this->content);
+
+        return Markdown::convert(htmlspecialchars_decode((new Bbcode())->parse($content, false), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5))->getContent();
+    }
+
+    private function replaceCurrentUserPlaceholders(string $content): string
+    {
+        $user = Auth::user();
+
+        if ($user === null) {
+            return $content;
+        }
+
+        return str_replace(
+            ['{user}', '{username}', '{user_id}'],
+            [$user->username, $user->username, (string) $user->id],
+            $content,
+        );
     }
 }


### PR DESCRIPTION
Refs #3661

Adds current-user placeholders for wiki content so links can resolve to the user who clicks/views the page.

Example wiki link:

`/users/{username}/passkeys`

When rendered for a logged-in user, `{username}` is replaced with the authenticated user's username.

Changes:
- Replaces `{user}`, `{username}`, and `{user_id}` in wiki content before BBCode/Markdown rendering
- Leaves content unchanged for guests
- Keeps the existing rendering pipeline intact

Validation:
- `php -l app/Models/Wiki.php`
- `git diff --check`