### PR TITLE
(Fix) Dialog for downloading all of user's .torrent files

### DIFF
--- a/resources/views/user/buttons/user.blade.php
+++ b/resources/views/user/buttons/user.blade.php
@@ -306,9 +306,9 @@
                 @endif
 
                 <li class="nav-tabV2">
-                    <a class="nav-tab__link" popovertarget="user-download-torrents">
+                    <button class="nav-tab__link" popovertarget="user-download-torrents">
                         Download torrent files
-                    </a>
+                    </button>
 
                     <dialog id="user-download-torrents" class="dialog" popover>
                         <h3 class="dialog__heading">Download torrent files</h3>


### PR DESCRIPTION
We need to use buttons for the html to work or else the dialog doesn't open. This was the only case that used `a` instead of `button`.