### PR TITLE
Add configurable footer page order

### DIFF
--- a/app/Http/Controllers/Staff/PageController.php
+++ b/app/Http/Controllers/Staff/PageController.php
@@ -33,7 +33,10 @@ class PageController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.page.index', [
-            'pages' => Page::all(),
+            'pages' => Page::query()
+                ->orderBy('footer_position')
+                ->orderBy('id')
+                ->get(),
         ]);
     }
 
@@ -51,6 +54,8 @@ class PageController extends Controller
     public function store(StorePageRequest $request): \Illuminate\Http\RedirectResponse
     {
         Page::create($request->validated());
+
+        $this->clearPageCache();
 
         return to_route('staff.pages.index')
             ->with('success', 'Page has been created successfully');
@@ -73,6 +78,8 @@ class PageController extends Controller
     {
         $page->update($request->validated());
 
+        $this->clearPageCache();
+
         return to_route('staff.pages.index')
             ->with('success', 'Page has been edited successfully');
     }
@@ -86,7 +93,15 @@ class PageController extends Controller
     {
         $page->delete();
 
+        $this->clearPageCache();
+
         return to_route('staff.pages.index')
             ->with('success', 'Page has been deleted successfully');
+    }
+
+    private function clearPageCache(): void
+    {
+        cache()->forget('cached-pages');
+        cache()->forget('cached-footer-pages');
     }
 }

--- a/app/Http/Requests/Staff/StorePageRequest.php
+++ b/app/Http/Requests/Staff/StorePageRequest.php
@@ -44,6 +44,11 @@ class StorePageRequest extends FormRequest
                 'required',
                 'string',
             ],
+            'footer_position' => [
+                'required',
+                'integer',
+                'min:0',
+            ],
         ];
     }
 }

--- a/app/Http/Requests/Staff/UpdatePageRequest.php
+++ b/app/Http/Requests/Staff/UpdatePageRequest.php
@@ -44,6 +44,11 @@ class UpdatePageRequest extends FormRequest
                 'required',
                 'string',
             ],
+            'footer_position' => [
+                'required',
+                'integer',
+                'min:0',
+            ],
         ];
     }
 }

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -29,6 +29,7 @@ use AllowDynamicProperties;
  * @property int                             $id
  * @property string|null                     $name
  * @property string|null                     $content
+ * @property int                             $footer_position
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  */
@@ -46,6 +47,18 @@ final class Page extends Model
      * @var string[]
      */
     protected $guarded = ['id', 'created_at', 'updated_at'];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'footer_position' => 'integer',
+        ];
+    }
 
     /**
      * Set the pages content after it has been purified.

--- a/app/View/Composers/FooterComposer.php
+++ b/app/View/Composers/FooterComposer.php
@@ -15,7 +15,15 @@ class FooterComposer
     public function compose(View $view): void
     {
         $view->with([
-            'pages' => cache()->flexible('cached-pages', [3600, 3600 * 2], fn () => Page::select(['id', 'name', 'created_at'])->take(6)->get())
+            'pages' => cache()->flexible(
+                'cached-footer-pages',
+                [3600, 3600 * 2],
+                fn () => Page::select(['id', 'name', 'footer_position', 'created_at'])
+                    ->orderBy('footer_position')
+                    ->orderBy('id')
+                    ->take(6)
+                    ->get()
+            ),
         ]);
     }
 }

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -33,8 +33,9 @@ class PageFactory extends Factory
     public function definition(): array
     {
         return [
-            'name'    => $this->faker->name(),
-            'content' => $this->faker->text(),
+            'name'            => $this->faker->name(),
+            'content'         => $this->faker->text(),
+            'footer_position' => $this->faker->numberBetween(0, 100),
         ];
     }
 }

--- a/database/migrations/2026_05_13_000000_add_footer_position_to_pages_table.php
+++ b/database/migrations/2026_05_13_000000_add_footer_position_to_pages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pages', function (Blueprint $table): void {
+            $table->unsignedInteger('footer_position')->default(0)->after('content');
+        });
+    }
+};

--- a/resources/views/Staff/page/create.blade.php
+++ b/resources/views/Staff/page/create.blade.php
@@ -35,6 +35,21 @@
                         {{ __('staff.page') }} {{ __('common.name') }}
                     </label>
                 </p>
+                <p class="form__group">
+                    <input
+                        id="footer_position"
+                        class="form__text"
+                        inputmode="numeric"
+                        min="0"
+                        name="footer_position"
+                        required
+                        type="number"
+                        value="{{ old('footer_position', 0) }}"
+                    />
+                    <label class="form__label form__label--floating" for="footer_position">
+                        Footer Position
+                    </label>
+                </p>
                 @livewire('bbcode-input', ['name' => 'content', 'label' => __('common.content'), 'required' => true])
                 <p class="form__group">
                     <button class="form__button form__button--filled">

--- a/resources/views/Staff/page/edit.blade.php
+++ b/resources/views/Staff/page/edit.blade.php
@@ -47,6 +47,21 @@
                         {{ __('common.name') }}
                     </label>
                 </p>
+                <p class="form__group">
+                    <input
+                        id="footer_position"
+                        class="form__text"
+                        inputmode="numeric"
+                        min="0"
+                        name="footer_position"
+                        required
+                        type="number"
+                        value="{{ old('footer_position', $page->footer_position) }}"
+                    />
+                    <label class="form__label form__label--floating" for="footer_position">
+                        Footer Position
+                    </label>
+                </p>
                 @livewire('bbcode-input', ['name' => 'content', 'label' => __('common.content'), 'required' => true, 'content' => $page->content])
                 <p class="form__group">
                     <button class="form__button form__button--filled">

--- a/resources/views/Staff/page/index.blade.php
+++ b/resources/views/Staff/page/index.blade.php
@@ -31,6 +31,7 @@
                 <thead>
                     <tr>
                         <th>{{ __('common.title') }}</th>
+                        <th>Footer Position</th>
                         <th>{{ __('common.date') }}</th>
                         <th>{{ __('common.actions') }}</th>
                     </tr>
@@ -43,6 +44,7 @@
                                     {{ $page->name }}
                                 </a>
                             </td>
+                            <td>{{ $page->footer_position }}</td>
                             <td>
                                 <time
                                     datetime="{{ $page->created_at }}"
@@ -91,7 +93,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="3">No pages</td>
+                            <td colspan="4">No pages</td>
                         </tr>
                     @endforelse
                 </tbody>

--- a/tests/Feature/Http/Controllers/Staff/PageControllerTest.php
+++ b/tests/Feature/Http/Controllers/Staff/PageControllerTest.php
@@ -22,6 +22,12 @@ use Database\Seeders\GroupSeeder;
 
 use function Pest\Laravel\assertDatabaseHas;
 
+beforeEach(function (): void {
+    $this->withoutVite();
+    $this->withoutMiddleware(App\Http\Middleware\UpdateLastAction::class);
+    $this->withoutMiddleware(Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class);
+});
+
 test('create returns an ok response', function (): void {
     $this->seed(GroupSeeder::class);
 
@@ -49,7 +55,14 @@ test('edit returns an ok response', function (): void {
 });
 
 test('index returns an ok response', function (): void {
-    $pages = Page::factory()->times(3)->create();
+    Page::factory()->create(['footer_position' => 30]);
+    Page::factory()->create(['footer_position' => 10]);
+    Page::factory()->create(['footer_position' => 20]);
+
+    $pages = Page::query()
+        ->orderBy('footer_position')
+        ->orderBy('id')
+        ->get();
 
     $this->get(route('staff.pages.index'))
         ->assertOk()
@@ -69,15 +82,17 @@ test('store returns an ok response', function (): void {
     $page = Page::factory()->make();
 
     $this->post(route('staff.pages.store'), [
-        'name'    => $page->name,
-        'content' => $page->content,
+        'name'            => $page->name,
+        'content'         => $page->content,
+        'footer_position' => $page->footer_position,
     ])
         ->assertRedirect(route('staff.pages.index'))
         ->assertSessionHasNoErrors();
 
     assertDatabaseHas('pages', [
-        'name'    => $page->name,
-        'content' => $page->content,
+        'name'            => $page->name,
+        'content'         => $page->content,
+        'footer_position' => $page->footer_position,
     ]);
 });
 
@@ -94,10 +109,12 @@ test('update returns an ok response', function (): void {
 
     $name = fake()->name;
     $content = fake()->text;
+    $footerPosition = 50;
 
     $this->patch(route('staff.pages.update', ['page' => $page]), [
-        'name'    => $name,
-        'content' => $content,
+        'name'            => $name,
+        'content'         => $content,
+        'footer_position' => $footerPosition,
     ])
         ->assertRedirect(route('staff.pages.index'))
         ->assertSessionHasNoErrors();
@@ -107,5 +124,7 @@ test('update returns an ok response', function (): void {
     expect($page->name)
         ->toBe($name)
         ->and($page->content)
-        ->toBe($content);
+        ->toBe($content)
+        ->and($page->footer_position)
+        ->toBe($footerPosition);
 });

--- a/tests/Unit/Http/Requests/Staff/StorePageRequestTest.php
+++ b/tests/Unit/Http/Requests/Staff/StorePageRequestTest.php
@@ -38,5 +38,10 @@ test('rules', function (): void {
             'required',
             'string',
         ],
+        'footer_position' => [
+            'required',
+            'integer',
+            'min:0',
+        ],
     ], $actual);
 });

--- a/tests/Unit/Http/Requests/Staff/UpdatePageRequestTest.php
+++ b/tests/Unit/Http/Requests/Staff/UpdatePageRequestTest.php
@@ -38,5 +38,10 @@ test('rules', function (): void {
             'required',
             'string',
         ],
+        'footer_position' => [
+            'required',
+            'integer',
+            'min:0',
+        ],
     ], $actual);
 });

--- a/tests/Unit/View/Composers/FooterComposerTest.php
+++ b/tests/Unit/View/Composers/FooterComposerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Models\Page;
+use App\View\Composers\FooterComposer;
+use Illuminate\View\View;
+
+test('footer composer orders pages by configured footer position', function (): void {
+    cache()->forget('cached-footer-pages');
+
+    $thirdPage = Page::factory()->create(['footer_position' => 30]);
+    $firstPage = Page::factory()->create(['footer_position' => 10]);
+    $secondPage = Page::factory()->create(['footer_position' => 20]);
+
+    $view = Mockery::mock(View::class);
+
+    $view->shouldReceive('with')
+        ->once()
+        ->withArgs(function (array $data) use ($firstPage, $secondPage, $thirdPage): bool {
+            expect($data['pages']->pluck('id')->all())
+                ->toBe([$firstPage->id, $secondPage->id, $thirdPage->id]);
+
+            return true;
+        });
+
+    (new FooterComposer())->compose($view);
+});


### PR DESCRIPTION
Closes #4015.

## Summary
- add a `footer_position` field for pages and expose it in staff page create/edit/list views
- order footer pages by `footer_position` with `id` as a stable fallback
- clear cached page/footer page lists after page create, update, and delete

## Testing
- `docker run --rm -v "$PWD":/app -w /app unit3d-php-test ./vendor/bin/pint --test app/Models/Page.php app/View/Composers/FooterComposer.php app/Http/Controllers/Staff/PageController.php app/Http/Requests/Staff/StorePageRequest.php app/Http/Requests/Staff/UpdatePageRequest.php database/factories/PageFactory.php database/migrations/2026_05_13_000000_add_footer_position_to_pages_table.php tests/Feature/Http/Controllers/Staff/PageControllerTest.php tests/Unit/Http/Requests/Staff/StorePageRequestTest.php tests/Unit/Http/Requests/Staff/UpdatePageRequestTest.php tests/Unit/View/Composers/FooterComposerTest.php`
- `php artisan test tests/Unit/Http/Requests/Staff/StorePageRequestTest.php tests/Unit/Http/Requests/Staff/UpdatePageRequestTest.php tests/Unit/View/Composers/FooterComposerTest.php tests/Feature/Http/Controllers/Staff/PageControllerTest.php --stop-on-failure` (run in a local Docker PHP image with MySQL)
