### PR TITLE
Add sitewide staff email search

### DIFF
--- a/app/Http/Livewire/UserSearch.php
+++ b/app/Http/Livewire/UserSearch.php
@@ -16,10 +16,13 @@ declare(strict_types=1);
 
 namespace App\Http\Livewire;
 
+use App\Models\Application;
 use App\Models\Group;
+use App\Models\Invite;
 use App\Models\User;
 use App\Traits\CastLivewireProperties;
 use App\Traits\LivewireSort;
+use Illuminate\Database\Eloquent\Builder;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -51,6 +54,15 @@ class UserSearch extends Component
     public string $soundexEmail = '';
 
     #[Url(history: true)]
+    public bool $searchEmailUsers = true;
+
+    #[Url(history: true)]
+    public bool $searchEmailInvites = true;
+
+    #[Url(history: true)]
+    public bool $searchEmailApplications = true;
+
+    #[Url(history: true)]
     public string $rsskey = '';
 
     #[Url(history: true)]
@@ -73,6 +85,10 @@ class UserSearch extends Component
         $this->resetPage();
     }
 
+    final protected bool $emailSearchIsActive {
+        get => $this->email !== '' || $this->soundexEmail !== '';
+    }
+
     /**
      * @var \Illuminate\Pagination\LengthAwarePaginator<int, User>
      */
@@ -84,15 +100,8 @@ class UserSearch extends Component
                 $this->soundexUsername !== '',
                 fn ($query) => $query->whereRaw('SOUNDEX(username) = SOUNDEX(?)', [$this->soundexUsername]),
             )
-            ->when($this->email !== '', fn ($query) => $query->where('email', 'LIKE', '%'.$this->email.'%'))
-            ->when(
-                $this->soundexEmail !== '',
-                fn ($query) => $query->when(
-                    str_contains($this->soundexEmail, '@'),
-                    fn ($query) => $query->whereRaw('SOUNDEX(email) = SOUNDEX(?)', [$this->soundexEmail]),
-                    fn ($query) => $query->whereRaw("SOUNDEX(SUBSTRING_INDEX(email, '@', 1)) = SOUNDEX(SUBSTRING_INDEX(?, '@', 1))", [$this->soundexEmail])
-                )
-            )
+            ->when($this->emailSearchIsActive && ! $this->searchEmailUsers, fn ($query) => $query->whereRaw('1 = 0'))
+            ->when($this->searchEmailUsers, fn ($query) => $this->applyEmailSearch($query))
             ->when($this->rsskey !== '', fn ($query) => $query->where('rsskey', 'LIKE', '%'.$this->rsskey.'%'))
             ->when($this->apikey !== '', fn ($query) => $query->where('api_token', 'LIKE', '%'.$this->apikey.'%'))
             ->when($this->passkey !== '', fn ($query) => $query->where('passkey', 'LIKE', '%'.$this->passkey.'%'))
@@ -103,17 +112,70 @@ class UserSearch extends Component
     }
 
     /**
+     * @var \Illuminate\Pagination\LengthAwarePaginator<int, Invite>
+     */
+    final protected \Illuminate\Pagination\LengthAwarePaginator $invites {
+        get => Invite::withTrashed()
+            ->with([
+                'sender'   => fn ($query) => $query->withTrashed()->with('group'),
+                'receiver' => fn ($query) => $query->withTrashed()->with('group'),
+            ])
+            ->when(
+                ! $this->emailSearchIsActive || ! $this->searchEmailInvites,
+                fn ($query) => $query->whereRaw('1 = 0'),
+                fn ($query) => $this->applyEmailSearch($query)
+            )
+            ->latest()
+            ->paginate($this->perPage, ['*'], 'invitePage');
+    }
+
+    /**
+     * @var \Illuminate\Pagination\LengthAwarePaginator<int, Application>
+     */
+    final protected \Illuminate\Pagination\LengthAwarePaginator $applications {
+        get => Application::withoutGlobalScopes()
+            ->with('moderated.group')
+            ->when(
+                ! $this->emailSearchIsActive || ! $this->searchEmailApplications,
+                fn ($query) => $query->whereRaw('1 = 0'),
+                fn ($query) => $this->applyEmailSearch($query)
+            )
+            ->latest()
+            ->paginate($this->perPage, ['*'], 'applicationPage');
+    }
+
+    /**
      * @var \Illuminate\Support\Collection<int, Group>
      */
     final protected $groups {
         get => Group::orderBy('position')->get();
     }
 
+    private function applyEmailSearch(Builder $query): Builder
+    {
+        return $query
+            ->when($this->email !== '', fn ($query) => $query->where('email', 'LIKE', '%'.$this->email.'%'))
+            ->when(
+                $this->soundexEmail !== '',
+                fn ($query) => $query->when(
+                    str_contains($this->soundexEmail, '@'),
+                    fn ($query) => $query->whereRaw('SOUNDEX(email) = SOUNDEX(?)', [$this->soundexEmail]),
+                    fn ($query) => $query->whereRaw("SOUNDEX(SUBSTRING_INDEX(email, '@', 1)) = SOUNDEX(SUBSTRING_INDEX(?, '@', 1))", [$this->soundexEmail])
+                )
+            );
+    }
+
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application
     {
         return view('livewire.user-search', [
-            'users'  => $this->users,
-            'groups' => $this->groups,
+            'applications'            => $this->applications,
+            'emailSearchIsActive'     => $this->emailSearchIsActive,
+            'groups'                  => $this->groups,
+            'invites'                 => $this->invites,
+            'searchEmailApplications' => $this->searchEmailApplications,
+            'searchEmailInvites'      => $this->searchEmailInvites,
+            'searchEmailUsers'        => $this->searchEmailUsers,
+            'users'                   => $this->users,
         ]);
     }
 }

--- a/resources/views/livewire/user-search.blade.php
+++ b/resources/views/livewire/user-search.blade.php
@@ -56,6 +56,39 @@
                     </p>
                     <p class="form__group">
                         <input
+                            id="searchEmailUsers"
+                            class="form__checkbox"
+                            type="checkbox"
+                            wire:model.live="searchEmailUsers"
+                        />
+                        <label class="form__label" for="searchEmailUsers">
+                            {{ __('common.users') }}
+                        </label>
+                    </p>
+                    <p class="form__group">
+                        <input
+                            id="searchEmailInvites"
+                            class="form__checkbox"
+                            type="checkbox"
+                            wire:model.live="searchEmailInvites"
+                        />
+                        <label class="form__label" for="searchEmailInvites">
+                            {{ __('staff.invites-log') }}
+                        </label>
+                    </p>
+                    <p class="form__group">
+                        <input
+                            id="searchEmailApplications"
+                            class="form__checkbox"
+                            type="checkbox"
+                            wire:model.live="searchEmailApplications"
+                        />
+                        <label class="form__label" for="searchEmailApplications">
+                            {{ __('staff.applications') }}
+                        </label>
+                    </p>
+                    <p class="form__group">
+                        <input
                             id="apikey"
                             class="form__text"
                             type="text"
@@ -138,7 +171,7 @@
             </form>
         </div>
     </section>
-    <div>
+    @if (! $emailSearchIsActive || $searchEmailUsers)
         <section class="panelV2">
             <h2 class="panel__heading">{{ __('common.users') }}</h2>
             <div class="data-table-wrapper">
@@ -232,5 +265,146 @@
             </div>
             {{ $users->links('partials.pagination') }}
         </section>
-    </div>
+    @endif
+
+    @if ($emailSearchIsActive && $searchEmailInvites)
+        <section class="panelV2">
+            <h2 class="panel__heading">Invite email matches</h2>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>{{ __('user.sender') }}</th>
+                            <th>{{ __('common.email') }}</th>
+                            <th>Code</th>
+                            <th>{{ __('user.created-on') }}</th>
+                            <th>{{ __('user.accepted-by') }}</th>
+                            <th>{{ __('user.deleted-on') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($invites as $invite)
+                            <tr>
+                                <td>{{ $invite->id }}</td>
+                                <td>
+                                    <x-user-tag :anon="false" :user="$invite->sender" />
+                                </td>
+                                <td>{{ $invite->email }}</td>
+                                <td>{{ $invite->code }}</td>
+                                <td>
+                                    <time
+                                        datetime="{{ $invite->created_at }}"
+                                        title="{{ $invite->created_at }}"
+                                    >
+                                        {{ $invite->created_at }}
+                                    </time>
+                                </td>
+                                <td>
+                                    @if ($invite->accepted_by === null)
+                                        N/A
+                                    @else
+                                        <x-user-tag :anon="false" :user="$invite->receiver" />
+                                    @endif
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $invite->deleted_at }}"
+                                        title="{{ $invite->deleted_at }}"
+                                    >
+                                        {{ $invite->deleted_at ?? 'N/A' }}
+                                    </time>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7">No invite email matches</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+            {{ $invites->links('partials.pagination') }}
+        </section>
+    @endif
+
+    @if ($emailSearchIsActive && $searchEmailApplications)
+        <section class="panelV2">
+            <h2 class="panel__heading">Application email matches</h2>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>{{ __('common.email') }}</th>
+                            <th>{{ __('staff.application-type') }}</th>
+                            <th>{{ __('common.created_at') }}</th>
+                            <th>{{ __('common.status') }}</th>
+                            <th>{{ __('common.moderated-by') }}</th>
+                            <th>{{ __('common.action') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($applications as $application)
+                            <tr>
+                                <td>{{ $application->id }}</td>
+                                <td>{{ $application->email }}</td>
+                                <td>{{ $application->type }}</td>
+                                <td>
+                                    <time
+                                        datetime="{{ $application->created_at }}"
+                                        title="{{ $application->created_at }}"
+                                    >
+                                        {{ $application->created_at }}
+                                    </time>
+                                </td>
+                                <td>
+                                    @switch($application->status)
+                                        @case(\App\Enums\ModerationStatus::PENDING)
+                                            <span class="application--pending">Pending</span>
+
+                                            @break
+                                        @case(\App\Enums\ModerationStatus::APPROVED)
+                                            <span class="application--approved">Approved</span>
+
+                                            @break
+                                        @case(\App\Enums\ModerationStatus::REJECTED)
+                                            <span class="application--rejected">Rejected</span>
+
+                                            @break
+                                        @default
+                                            <span class="application--unknown">Unknown</span>
+                                    @endswitch
+                                </td>
+                                <td>
+                                    @if ($application->moderated === null)
+                                        N/A
+                                    @else
+                                        <x-user-tag :anon="false" :user="$application->moderated" />
+                                    @endif
+                                </td>
+                                <td>
+                                    <menu class="data-table__actions">
+                                        <li class="data-table__action">
+                                            <a
+                                                class="form__button form__button--text"
+                                                href="{{ route('staff.applications.show', ['id' => $application->id]) }}"
+                                            >
+                                                {{ __('common.view') }}
+                                            </a>
+                                        </li>
+                                    </menu>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7">No application email matches</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+            {{ $applications->links('partials.pagination') }}
+        </section>
+    @endif
 </div>

--- a/tests/Feature/Http/Livewire/UserSearchTest.php
+++ b/tests/Feature/Http/Livewire/UserSearchTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Livewire\UserSearch;
+use App\Models\Application;
+use App\Models\Invite;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    $this->asStaffUser();
+});
+
+test('email search includes users invites and applications', function (): void {
+    $matchingUser = User::factory()->create([
+        'email'    => 'target@example.com',
+        'username' => 'matching-user',
+    ]);
+    $unmatchedUser = User::factory()->create([
+        'email'    => 'unmatched-user@example.com',
+        'username' => 'unmatched-user',
+    ]);
+    $matchingInvite = Invite::factory()->create([
+        'email' => 'target@example.com',
+        'code'  => 'MATCHINGINVITE',
+    ]);
+    $unmatchedInvite = Invite::factory()->create([
+        'email' => 'unmatched-invite@example.com',
+        'code'  => 'UNMATCHEDINVITE',
+    ]);
+    $matchingApplication = Application::factory()->create([
+        'email' => 'target@example.com',
+        'type'  => 'Matching application',
+    ]);
+    $unmatchedApplication = Application::factory()->create([
+        'email' => 'unmatched-application@example.com',
+        'type'  => 'Unmatched application',
+    ]);
+
+    Livewire::test(UserSearch::class)
+        ->set('email', 'target@example.com')
+        ->assertSee($matchingUser->username)
+        ->assertSee($matchingInvite->code)
+        ->assertSee($matchingApplication->type)
+        ->assertDontSee($unmatchedUser->username)
+        ->assertDontSee($unmatchedInvite->code)
+        ->assertDontSee($unmatchedApplication->type);
+});
+
+test('email search source toggles hide matching sections', function (): void {
+    $matchingUser = User::factory()->create([
+        'email'    => 'target@example.com',
+        'username' => 'matching-user',
+    ]);
+    $matchingInvite = Invite::factory()->create([
+        'email' => 'target@example.com',
+        'code'  => 'MATCHINGINVITE',
+    ]);
+    $matchingApplication = Application::factory()->create([
+        'email' => 'target@example.com',
+        'type'  => 'Matching application',
+    ]);
+
+    Livewire::test(UserSearch::class)
+        ->set('email', 'target@example.com')
+        ->set('searchEmailUsers', false)
+        ->set('searchEmailInvites', false)
+        ->set('searchEmailApplications', false)
+        ->assertDontSee($matchingUser->username)
+        ->assertDontSee($matchingInvite->code)
+        ->assertDontSee($matchingApplication->type);
+});


### PR DESCRIPTION
## Summary
- extends the staff user search email field to show matching users, invite log entries, and applications in separate sections
- adds source checkboxes so staff can hide user, invite, or application email matches
- reuses the existing user email and soundex email filters across the sitewide result sections

Closes #3656

## Tests
- docker run --rm -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app unit3d-php-test ./vendor/bin/pint --test app/Http/Livewire/UserSearch.php tests/Feature/Http/Livewire/UserSearchTest.php
- docker run --rm --network unit3d-test-net -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -v /tmp/unit3d-test.env:/app/.env:ro -w /app unit3d-php-test sh -lc 'set -a; . ./.env; set +a; APP_ENV=testing APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_CONNECTION=mysql DB_HOST=unit3d-test-mysql DB_PORT=3306 DB_DATABASE=unit3d_test DB_USERNAME=unit3d DB_PASSWORD=secret CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync SCOUT_DRIVER=null php artisan test tests/Feature/Http/Livewire/UserSearchTest.php --stop-on-failure'
- git diff --check