### PR TITLE
Allow WebP and GIF torrent images

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -371,7 +371,7 @@ class TorrentController extends Controller
             403
         );
 
-        $torrent->update($request->validated());
+        $torrent->update($request->safe()->except(['torrent-cover', 'torrent-banner']));
 
         // Cover Image for No-Meta Torrents
         if ($request->hasFile('torrent-cover')) {
@@ -550,7 +550,7 @@ class TorrentController extends Controller
             'user_id'      => $user->id,
             'moderated_at' => now(),
             'moderated_by' => User::SYSTEM_USER_ID,
-        ] + $request->safe()->except(['torrent']));
+        ] + $request->safe()->except(['torrent', 'nfo', 'torrent-cover', 'torrent-banner']));
 
         // Populate the status/seeders/leechers/times_completed fields for the external tracker
         $torrent->refresh();

--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -120,6 +120,20 @@ class StoreTorrentRequest extends FormRequest
                     }
                 },
             ],
+            'torrent-cover' => [
+                'nullable',
+                'sometimes',
+                'file',
+                'image',
+                'mimes:jpg,jpeg,png,webp,gif',
+            ],
+            'torrent-banner' => [
+                'nullable',
+                'sometimes',
+                'file',
+                'image',
+                'mimes:jpg,jpeg,png,webp,gif',
+            ],
             'name' => [
                 'required',
                 Rule::unique('torrents')->whereNull('deleted_at'),

--- a/app/Http/Requests/UpdateTorrentRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequest.php
@@ -89,6 +89,20 @@ class UpdateTorrentRequest extends FormRequest
                 'sometimes',
                 'max:2097152',
             ],
+            'torrent-cover' => [
+                'nullable',
+                'sometimes',
+                'file',
+                'image',
+                'mimes:jpg,jpeg,png,webp,gif',
+            ],
+            'torrent-banner' => [
+                'nullable',
+                'sometimes',
+                'file',
+                'image',
+                'mimes:jpg,jpeg,png,webp,gif',
+            ],
             'category_id' => [
                 'required',
                 'exists:categories,id',

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -102,7 +102,7 @@
                         id="torrent-cover"
                         class="upload-form-file form__file"
                         type="file"
-                        accept=".jpg, .jpeg"
+                        accept=".jpg, .jpeg, .png, .webp, .gif"
                         name="torrent-cover"
                     />
                 </p>
@@ -114,7 +114,7 @@
                         id="torrent-banner"
                         class="upload-form-file form__file"
                         type="file"
-                        accept=".jpg, .jpeg"
+                        accept=".jpg, .jpeg, .png, .webp, .gif"
                         name="torrent-banner"
                     />
                 </p>

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -52,7 +52,7 @@
                     <input
                         id="torrent-cover"
                         class="form__file"
-                        accept=".jpg, .jpeg, .png"
+                        accept=".jpg, .jpeg, .png, .webp, .gif"
                         name="torrent-cover"
                         type="file"
                     />
@@ -64,7 +64,7 @@
                     <input
                         id="torrent-banner"
                         class="form__file"
-                        accept=".jpg, .jpeg, .png"
+                        accept=".jpg, .jpeg, .png, .webp, .gif"
                         name="torrent-banner"
                         type="file"
                     />

--- a/tests/Unit/Http/Requests/TorrentImageUploadRulesTest.php
+++ b/tests/Unit/Http/Requests/TorrentImageUploadRulesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Requests\StoreTorrentRequest;
+use App\Http\Requests\UpdateTorrentRequest;
+use App\Models\Category;
+use App\Models\Torrent;
+use App\Models\Type;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+function makeTorrentImageUploadRulesRequest(?Torrent $torrent = null): Request
+{
+    $category = Category::factory()->create([
+        'no_meta'    => true,
+        'music_meta' => false,
+        'game_meta'  => false,
+        'tv_meta'    => false,
+        'movie_meta' => false,
+    ]);
+    $type = Type::factory()->create();
+    $user = User::factory()->create();
+
+    $request = Request::create('/torrents', $torrent === null ? 'POST' : 'PATCH', [
+        'category_id' => $category->id,
+        'type_id'     => $type->id,
+    ]);
+    $request->setUserResolver(fn () => $user);
+
+    if ($torrent !== null) {
+        $request->setRouteResolver(
+            fn () => new class ($torrent->id) {
+                public function __construct(private readonly int $torrentId)
+                {
+                }
+
+                public function parameter(string $name, mixed $default = null): mixed
+                {
+                    return $name === 'id' ? (string) $this->torrentId : $default;
+                }
+            }
+        );
+    }
+
+    return $request;
+}
+
+test('store torrent request allows webp and gif torrent images', function (): void {
+    $rules = (new StoreTorrentRequest())->rules(makeTorrentImageUploadRulesRequest());
+
+    expect($rules['torrent-cover'])->toContain('mimes:jpg,jpeg,png,webp,gif')
+        ->and($rules['torrent-banner'])->toContain('mimes:jpg,jpeg,png,webp,gif');
+});
+
+test('update torrent request allows webp and gif torrent images', function (): void {
+    $torrent = Torrent::factory()->create();
+    $rules = (new UpdateTorrentRequest())->rules(makeTorrentImageUploadRulesRequest($torrent));
+
+    expect($rules['torrent-cover'])->toContain('mimes:jpg,jpeg,png,webp,gif')
+        ->and($rules['torrent-banner'])->toContain('mimes:jpg,jpeg,png,webp,gif');
+});


### PR DESCRIPTION
## Summary
- allow no-meta torrent cover and banner uploads to select JPG, PNG, WebP, and GIF files in create/edit forms
- validate optional torrent cover/banner uploads server-side as image files with the supported extensions
- keep uploaded images normalized to the existing stored JPG filenames so display routes do not change

Closes #5103

## Tests
- docker run --rm -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app unit3d-php-test ./vendor/bin/pint --test app/Http/Requests/StoreTorrentRequest.php app/Http/Requests/UpdateTorrentRequest.php app/Http/Controllers/TorrentController.php tests/Unit/Http/Requests/TorrentImageUploadRulesTest.php
- docker run --rm --network unit3d-test-net -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -v /tmp/unit3d-test.env:/app/.env:ro -w /app unit3d-php-test sh -lc 'set -a; . ./.env; set +a; APP_ENV=testing APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_CONNECTION=mysql DB_HOST=unit3d-test-mysql DB_PORT=3306 DB_DATABASE=unit3d_test DB_USERNAME=unit3d DB_PASSWORD=secret CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync SCOUT_DRIVER=null php artisan test tests/Unit/Http/Requests/TorrentImageUploadRulesTest.php --stop-on-failure'
- git diff --check