### PR TITLE
Add user groups link to top nav

### DIFF
--- a/resources/views/partials/top-nav.blade.php
+++ b/resources/views/partials/top-nav.blade.php
@@ -184,6 +184,12 @@
                 @endforeach
 
                 <li>
+                    <a href="{{ route('groups_requirements') }}">
+                        <i class="{{ config('other.font-awesome') }} fa-users"></i>
+                        {{ __('common.user') }} {{ __('common.groups') }}
+                    </a>
+                </li>
+                <li>
                     <a href="{{ route('subtitles.index') }}">
                         <i class="{{ config('other.font-awesome') }} fa-closed-captioning"></i>
                         {{ __('common.subtitles') }}

--- a/tests/Feature/View/TopNavTest.php
+++ b/tests/Feature/View/TopNavTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+test('top nav exposes user group requirements from other menu', function (): void {
+    $user = User::factory()->create()->load('group');
+
+    $this->actingAs($user);
+
+    $html = view('partials.top-nav', [
+        'donationPercentage'    => 0,
+        'downloadCount'         => 0,
+        'events'                => collect(),
+        'hasActiveWarning'      => false,
+        'hasUnmoderatedTorrent' => false,
+        'hasUnreadNotification' => false,
+        'hasUnreadPm'           => false,
+        'hasUnreadTicket'       => false,
+        'hasUnresolvedReport'   => false,
+        'leechCount'            => 0,
+        'pages'                 => collect(),
+        'peerCount'             => 0,
+        'uploadCount'           => 0,
+        'user'                  => $user,
+    ])->render();
+
+    expect($html)->toContain(route('groups_requirements'))
+        ->and($html)->toContain(__('common.user').' '.__('common.groups'));
+});


### PR DESCRIPTION
## Summary
- adds a User Groups entry under the top nav Other dropdown
- links directly to the existing group requirements page for easier rank progression discovery
- covers the link with a focused top-nav render test

Closes #5104

## Tests
- `docker run --rm -v "$PWD":/app -w /app unit3d-php-test ./vendor/bin/pint --test tests/Feature/View/TopNavTest.php tests/Feature/Http/Controllers/HomeControllerTest.php`
- `docker run --rm --network unit3d-test-net -v "$PWD":/app -v /tmp/unit3d-test.env:/app/.env:ro -w /app unit3d-php-test sh -lc 'set -a; . ./.env; set +a; APP_ENV=testing APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_CONNECTION=mysql DB_HOST=unit3d-test-mysql DB_PORT=3306 DB_DATABASE=unit3d_test DB_USERNAME=unit3d DB_PASSWORD=secret CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync SCOUT_DRIVER=null php artisan test tests/Feature/View/TopNavTest.php --stop-on-failure'`
- `git diff --check`

Note: I also tried `php artisan test tests/Feature/Http/Controllers/HomeControllerTest.php --stop-on-failure`, but this local Docker run fails before the assertion on a missing Vite manifest at `/app/public/build/manifest.json`.
