### PR TITLE
Highlight own pending resurrection

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -140,7 +140,10 @@ class TorrentController extends Controller
                 'history as completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                     ->where('active', '=', false)
                     ->where('seeder', '=', true),
-                'resurrections' => fn ($query) => $query->where('rewarded', '=', false),
+                'resurrections'                                => fn ($query) => $query->where('rewarded', '=', false),
+                'resurrections as resurrected_by_current_user' => fn ($query) => $query
+                    ->where('rewarded', '=', false)
+                    ->where('user_id', '=', $user->id),
             ])
             ->withSum('tips as total_tips', 'bon')
             ->withSum(['tips as user_tips' => fn ($query) => $query->where('sender_id', '=', $user->id)], 'bon')

--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -334,7 +334,14 @@
 
     @if ($torrent->resurrections_exists && $torrent->status === \App\Enums\ModerationStatus::APPROVED)
         <li class="form__group form__group--short-horizontal">
-            <button class="form__button form__button--outlined form__button--centered" disabled>
+            <button
+                @class([
+                    'form__button form__button--outlined form__button--centered',
+                    'torrent-activity-indicator--seeding' => $torrent->resurrected_by_current_user,
+                ])
+                @if ($torrent->resurrected_by_current_user) title="You requested this resurrection" @endif
+                disabled
+            >
                 {{ strtolower(__('graveyard.pending')) }}
             </button>
         </li>

--- a/tests/Feature/View/TorrentButtonsTest.php
+++ b/tests/Feature/View/TorrentButtonsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ModerationStatus;
+use App\Models\Torrent;
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+
+test('pending resurrection button is highlighted for current user', function (): void {
+    config([
+        'other.thanks-system.is-enabled' => false,
+        'torrent.magnet'                 => false,
+    ]);
+    Storage::fake('torrent-files');
+
+    $user = User::factory()->create()->load('group');
+    $user->setRelation('playlists', collect());
+    $this->actingAs($user);
+
+    $torrent = Torrent::factory()->create([
+        'free'   => 100,
+        'status' => ModerationStatus::APPROVED,
+    ]);
+    $torrent->setAttribute('bookmarks_count', 0);
+    $torrent->setAttribute('bookmarks_exists', false);
+    $torrent->setAttribute('freeleechToken_exists', false);
+    $torrent->setAttribute('resurrections_exists', true);
+    $torrent->setAttribute('resurrected_by_current_user', true);
+    $torrent->setAttribute('trump_exists', false);
+    $torrent->setAttribute('unsolvedReports', 0);
+    $torrent->setRelation('files', collect());
+    $torrent->setRelation('history', collect());
+
+    $html = view('torrent.partials.buttons', [
+        'fileTree'           => [],
+        'personal_freeleech' => false,
+        'torrent'            => $torrent,
+        'user'               => $user,
+    ])->render();
+
+    expect($html)->toContain('torrent-activity-indicator--seeding')
+        ->and($html)->toContain('You requested this resurrection');
+});


### PR DESCRIPTION
## Summary
- adds a current-user resurrection exists flag to the torrent show query
- highlights the disabled pending resurrection button when the logged-in user owns the pending resurrection
- adds focused view coverage for the highlighted pending button

Closes #5382

## Tests
- `docker run --rm -v "$PWD":/app -w /app unit3d-php-test ./vendor/bin/pint app/Http/Controllers/TorrentController.php tests/Feature/View/TorrentButtonsTest.php`
- `docker run --rm --network unit3d-test-net -v "$PWD":/app -v /tmp/unit3d-test.env:/app/.env:ro -w /app unit3d-php-test sh -lc 'set -a; . ./.env; set +a; APP_ENV=testing APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_CONNECTION=mysql DB_HOST=unit3d-test-mysql DB_PORT=3306 DB_DATABASE=unit3d_test DB_USERNAME=unit3d DB_PASSWORD=secret CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync SCOUT_DRIVER=null php artisan test tests/Feature/View/TorrentButtonsTest.php --stop-on-failure'`
- `git diff --check`
