### PR TITLE
Show latest reseed request date on torrent page

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -148,6 +148,10 @@ class TorrentController extends Controller
             ])
             ->withSum('tips as total_tips', 'bon')
             ->withSum(['tips as user_tips' => fn ($query) => $query->where('sender_id', '=', $user->id)], 'bon')
+            ->withMax('reseeds as latest_reseed_requested_at', 'created_at')
+            ->withCasts([
+                'latest_reseed_requested_at' => 'datetime',
+            ])
             ->withMax(['history' => fn ($query) => $query->where('seeder', '=', true)], 'updated_at')
             ->when(
                 $user->group->is_modo,

--- a/lang/en/torrent.php
+++ b/lang/en/torrent.php
@@ -167,6 +167,7 @@ return [
     'released'                 => 'Released',
     'remaining'                => 'Remaining',
     'request-reseed'           => 'Request reseed',
+    'reseed-requested-on'      => 'Reseed Requested on :datetime',
     'required-anime'           => 'Required for anime',
     'required-games'           => 'Required for games',
     'requires-reseed'          => 'Requires reseed',

--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -324,23 +324,41 @@
         </li>
     @endif
 
+    @php
+        $latestReseedRequestAt = $torrent->latest_reseed_requested_at;
+        $hasRecentReseedRequest = $latestReseedRequestAt?->isAfter(now()->subDays(30)) ?? false;
+        $reseedButtonText = $latestReseedRequestAt === null
+            ? __('torrent.request-reseed')
+            : __('torrent.reseed-requested-on', ['datetime' => $latestReseedRequestAt->toDayDateTimeString()]);
+    @endphp
+
     @if ($torrent->status === \App\Enums\ModerationStatus::APPROVED &&
     $torrent->seeders <= 2 &&
     $torrent->history->first() !== null &&
     ! $torrent->history->first()->seeder &&
     $torrent->history->first()->active)
         <li class="form__group form__group--short-horizontal">
-            <form
-                action="{{ route('reseed', ['id' => $torrent->id]) }}"
-                method="POST"
-                style="display: contents"
-            >
-                @csrf
-                <button class="form__button form__button--outlined form__button--centered">
+            @if ($hasRecentReseedRequest)
+                <button
+                    class="form__button form__button--outlined form__button--centered"
+                    disabled
+                >
                     <i class="{{ config('other.font-awesome') }} fa-envelope"></i>
-                    {{ __('torrent.request-reseed') }}
+                    {{ $reseedButtonText }}
                 </button>
-            </form>
+            @else
+                <form
+                    action="{{ route('reseed', ['id' => $torrent->id]) }}"
+                    method="POST"
+                    style="display: contents"
+                >
+                    @csrf
+                    <button class="form__button form__button--outlined form__button--centered">
+                        <i class="{{ config('other.font-awesome') }} fa-envelope"></i>
+                        {{ $reseedButtonText }}
+                    </button>
+                </form>
+            @endif
         </li>
     @endif
 

--- a/tests/Feature/View/TorrentReseedButtonsTest.php
+++ b/tests/Feature/View/TorrentReseedButtonsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ModerationStatus;
+use App\Models\History;
+use App\Models\Torrent;
+use App\Models\TorrentReseed;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+
+test('recent reseed request date is shown as a disabled torrent button', function (): void {
+    $requestedAt = now()->subDays(10)->setSecond(0)->setMicrosecond(0);
+
+    $html = renderTorrentButtonsWithReseedRequest($this, $requestedAt);
+
+    expect($html)->toContain(__('torrent.reseed-requested-on', ['datetime' => $requestedAt->toDayDateTimeString()]))
+        ->and($html)->toContain('disabled')
+        ->and($html)->not->toContain(__('torrent.request-reseed'));
+});
+
+test('older reseed request date is shown on a clickable torrent button', function (): void {
+    $requestedAt = now()->subDays(31)->setSecond(0)->setMicrosecond(0);
+
+    $html = renderTorrentButtonsWithReseedRequest($this, $requestedAt);
+
+    expect($html)->toContain(__('torrent.reseed-requested-on', ['datetime' => $requestedAt->toDayDateTimeString()]))
+        ->and($html)->toContain(route('reseed', ['id' => 1], false))
+        ->and($html)->not->toContain('disabled');
+});
+
+test('torrent query can select the latest reseed request date', function (): void {
+    $torrent = Torrent::factory()->create();
+    $user = User::factory()->create();
+    $olderRequest = now()->subDays(8);
+    $latestRequest = now()->subDays(2)->setSecond(0)->setMicrosecond(0);
+
+    TorrentReseed::create([
+        'torrent_id'     => $torrent->id,
+        'user_id'        => $user->id,
+        'requests_count' => 1,
+        'created_at'     => $olderRequest,
+        'updated_at'     => $olderRequest,
+    ]);
+
+    TorrentReseed::create([
+        'torrent_id'     => $torrent->id,
+        'user_id'        => User::factory()->create()->id,
+        'requests_count' => 1,
+        'created_at'     => $latestRequest,
+        'updated_at'     => $latestRequest,
+    ]);
+
+    $loadedTorrent = Torrent::query()
+        ->withMax('reseeds as latest_reseed_requested_at', 'created_at')
+        ->withCasts([
+            'latest_reseed_requested_at' => 'datetime',
+        ])
+        ->findOrFail($torrent->id);
+
+    expect($loadedTorrent->latest_reseed_requested_at)->toBeInstanceOf(Carbon::class)
+        ->and($loadedTorrent->latest_reseed_requested_at->equalTo($latestRequest))->toBeTrue();
+});
+
+function renderTorrentButtonsWithReseedRequest(Tests\TestCase $test, Carbon $requestedAt): string
+{
+    config([
+        'other.thanks-system.is-enabled' => false,
+        'torrent.magnet'                 => false,
+    ]);
+    Storage::fake('torrent-files');
+
+    $user = User::factory()->create()->load('group');
+    $user->setRelation('playlists', collect());
+    $test->actingAs($user);
+
+    $torrent = Torrent::factory()->create([
+        'id'         => 1,
+        'free'       => 100,
+        'seeders'    => 1,
+        'status'     => ModerationStatus::APPROVED,
+        'created_at' => now(),
+    ]);
+    $history = History::factory()->make([
+        'active'     => true,
+        'seeder'     => false,
+        'torrent_id' => $torrent->id,
+        'user_id'    => $user->id,
+    ]);
+
+    $torrent->setAttribute('bookmarks_count', 0);
+    $torrent->setAttribute('bookmarks_exists', false);
+    $torrent->setAttribute('freeleechToken_exists', false);
+    $torrent->setAttribute('latest_reseed_requested_at', $requestedAt);
+    $torrent->setAttribute('resurrections_exists', false);
+    $torrent->setAttribute('trump_exists', false);
+    $torrent->setAttribute('unsolvedReports', 0);
+    $torrent->setRelation('files', collect());
+    $torrent->setRelation('history', collect([$history]));
+
+    return view('torrent.partials.buttons', [
+        'fileTree'           => [],
+        'personal_freeleech' => false,
+        'torrent'            => $torrent,
+        'user'               => $user,
+    ])->render();
+}


### PR DESCRIPTION
## Summary
- Load the latest torrent reseed request timestamp on the torrent show query.
- Show `Reseed Requested on <date> <time>` on the reseed button when a request exists.
- Disable the reseed button when the latest request is within 30 days, while keeping older requests clickable.
- Add focused view/query coverage for recent and older reseed request states.

Closes #5034.

## Tests
- `docker run --rm -v "$PWD":/app -w /app unit3d-php-test ./vendor/bin/pint --test app/Http/Controllers/TorrentController.php lang/en/torrent.php tests/Feature/View/TorrentReseedButtonsTest.php`
- `git diff --check`
- `php artisan test tests/Feature/View/TorrentReseedButtonsTest.php --stop-on-failure` passed locally in Docker/MySQL after temporarily replacing the existing `Route::livewire(...)` route registrations with equivalent `Route::get(...)` registrations so the app could boot under the installed Livewire 4 package. Without that temporary local-only shim, current `development` fails before this test runs with `Attribute [livewire] does not exist`.
