### PR TITLE
Add compact thanks button to torrent rows

### DIFF
--- a/app/Http/Livewire/ThankButton.php
+++ b/app/Http/Livewire/ThankButton.php
@@ -28,6 +28,8 @@ class ThankButton extends Component
 
     public ?User $user = null;
 
+    public bool $iconOnly = false;
+
     final public function mount(): void
     {
         $this->user = auth()->user();

--- a/app/Http/Livewire/TopTorrents.php
+++ b/app/Http/Livewire/TopTorrents.php
@@ -65,7 +65,7 @@ class TopTorrents extends Component
                         WHEN category_id IN (SELECT id FROM categories WHERE no_meta = 1) THEN 'no'
                     END AS meta
                 SQL)
-                ->withCount(['comments'])
+                ->withCount(['comments', 'thanks'])
                 ->when($this->tab === 'newest', fn ($query) => $query->orderByDesc('id'))
                 ->when($this->tab === 'seeded', fn ($query) => $query->orderByDesc('seeders'))
                 ->when(

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -455,6 +455,7 @@ class TorrentSearch extends Component
                 ->with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
                 ->withCount([
                     'comments',
+                    'thanks',
                     'seeds'   => fn ($query) => $query->where('active', '=', true)->where('visible', '=', true),
                     'leeches' => fn ($query) => $query->where('active', '=', true)->where('visible', '=', true),
                 ])

--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -163,6 +163,10 @@
                 <i class="{{ config('other.font-awesome') }}" x-bind="icon"></i>
             </button>
 
+            @if (config('other.thanks-system.is-enabled'))
+                @livewire('thank-button', ['torrent' => $torrent, 'iconOnly' => true], key('torrent-row-thank-'.$torrent->id))
+            @endif
+
             @if (config('torrent.download_check_page'))
                 <a
                     class="torrent-search--list__file form__standard-icon-button"

--- a/resources/views/livewire/thank-button.blade.php
+++ b/resources/views/livewire/thank-button.blade.php
@@ -1,7 +1,20 @@
-<button
-    wire:click="store({{ $torrent->id }})"
-    class="form__button form__button--outlined form__button--centered"
->
-    <i class="{{ config('other.font-awesome') }} fa-heart text-pink"></i>
-    {{ __('torrent.thank') }} ({{ $torrent->thanks_count }})
-</button>
+@php($thanksCount = $torrent->thanks_count ?? 0)
+
+@if ($iconOnly)
+    <button
+        wire:click="store"
+        class="form__standard-icon-button"
+        title="{{ __('torrent.thank') }} ({{ $thanksCount }})"
+        aria-label="{{ __('torrent.thank') }} ({{ $thanksCount }})"
+    >
+        <i class="{{ config('other.font-awesome') }} fa-heart text-pink"></i>
+    </button>
+@else
+    <button
+        wire:click="store"
+        class="form__button form__button--outlined form__button--centered"
+    >
+        <i class="{{ config('other.font-awesome') }} fa-heart text-pink"></i>
+        {{ __('torrent.thank') }} ({{ $thanksCount }})
+    </button>
+@endif

--- a/tests/Feature/View/ThankButtonTest.php
+++ b/tests/Feature/View/ThankButtonTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Torrent;
+
+test('thank button can render compact icon-only style for torrent rows', function (): void {
+    $torrent = Torrent::factory()->make();
+    $torrent->setAttribute('thanks_count', 3);
+
+    $html = view('livewire.thank-button', [
+        'iconOnly' => true,
+        'torrent'  => $torrent,
+    ])->render();
+
+    expect($html)->toContain('form__standard-icon-button')
+        ->and($html)->toContain('fa-heart')
+        ->and($html)->toContain('title="Thank (3)"')
+        ->and($html)->toContain('aria-label="Thank (3)"')
+        ->and($html)->not->toContain('form__button--outlined');
+});
+
+test('thank button keeps the full torrent-page label by default', function (): void {
+    $torrent = Torrent::factory()->make();
+    $torrent->setAttribute('thanks_count', 5);
+
+    $html = view('livewire.thank-button', [
+        'iconOnly' => false,
+        'torrent'  => $torrent,
+    ])->render();
+
+    expect($html)->toContain('form__button--outlined')
+        ->and($html)->toContain('Thank (5)')
+        ->and($html)->not->toContain('form__standard-icon-button');
+});


### PR DESCRIPTION
## Summary
- Add an icon-only mode to the existing `ThankButton` Livewire component.
- Render the compact Thanks action in torrent list rows when the thanks system is enabled.
- Load `thanks_count` for torrent rows in torrent search and top torrents.
- Keep the full torrent-page Thanks button label and count intact.

Closes #5206.

## Tests
- `docker run --rm -v "$PWD":/app -w /app unit3d-php-test ./vendor/bin/pint --test app/Http/Livewire/ThankButton.php app/Http/Livewire/TorrentSearch.php app/Http/Livewire/TopTorrents.php resources/views/livewire/thank-button.blade.php tests/Feature/View/ThankButtonTest.php`
- `git diff --check`
- `php artisan test tests/Feature/View/ThankButtonTest.php --stop-on-failure` passed locally in Docker/MySQL after temporarily replacing the existing `Route::livewire(...)` route registrations with equivalent `Route::get(...)` registrations so the app could boot under the installed Livewire 4 package. Without that temporary local-only shim, current `development` fails before this test runs with `Attribute [livewire] does not exist`.
