### PR TITLE
Open rendered description links in new tabs

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -21,6 +21,8 @@ use Illuminate\Support\Str;
 
 class Bbcode
 {
+    private const string EXTERNAL_LINK_ATTRIBUTES = ' target="_blank" rel="noopener noreferrer"';
+
     /**
      * @return array<
      *     string,
@@ -301,12 +303,12 @@ class Bbcode
         $source = str_replace('[hr]', '<hr>', $source);
         $source = preg_replace_callback(
             '/\[url](.*?)\[\/url]/i',
-            fn ($matches) => '<a href="'.self::sanitizeUrl($matches[1]).'">'.self::sanitizeUrl($matches[1]).'</a>',
+            fn ($matches) => '<a href="'.self::sanitizeUrl($matches[1]).'"'.self::EXTERNAL_LINK_ATTRIBUTES.'>'.self::sanitizeUrl($matches[1]).'</a>',
             $source
         );
         $source = preg_replace_callback(
             '/\[url=(.*?)](.*?)\[\/url]/i',
-            fn ($matches) => '<a href="'.self::sanitizeUrl($matches[1]).'">'.$matches[2].'</a>',
+            fn ($matches) => '<a href="'.self::sanitizeUrl($matches[1]).'"'.self::EXTERNAL_LINK_ATTRIBUTES.'>'.$matches[2].'</a>',
             $source ?? ''
         );
         $source = preg_replace_callback(

--- a/app/Helpers/Linkify.php
+++ b/app/Helpers/Linkify.php
@@ -40,7 +40,7 @@ class Linkify
 
         $highlighter = new HtmlHighlighter(
             'http', // string - scheme to use for urls matched by top level domain
-            ['rel' => 'noopener noreferrer'], // string[] - key/value map of tag attributes
+            ['target' => '_blank', 'rel' => 'noopener noreferrer'], // string[] - key/value map of tag attributes
             '',     // string - content to add before highlight: {here}<a...
             ''      // string - content to add after highlight: ...</a>{here}
         );

--- a/tests/Unit/Helpers/BbcodeLinkTest.php
+++ b/tests/Unit/Helpers/BbcodeLinkTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Helpers\Bbcode;
+use App\Helpers\Linkify;
+
+test('bbcode url links open in a new tab', function (): void {
+    $html = (new Bbcode())->parse('[url=https://example.com]Example[/url]');
+
+    expect($html)->toBe('<a href="https://example.com" target="_blank" rel="noopener noreferrer">Example</a>');
+});
+
+test('auto-linked urls open in a new tab', function (): void {
+    $html = (new Linkify())->linky('Visit https://example.com');
+
+    expect($html)
+        ->toContain('href="https://example.com"')
+        ->toContain('target="_blank"')
+        ->toContain('rel="noopener noreferrer"');
+});


### PR DESCRIPTION
## Summary
- add `target="_blank"` to auto-linked bare URLs rendered by `Linkify`
- add `target="_blank"` to `[url]` BBCode links rendered in descriptions/messages
- keep `rel="noopener noreferrer"` on generated external links

Fixes #4475

## Tests
- `docker run --rm -v "$PWD":/app -w /app unit3d-php-test ./vendor/bin/pint --test app/Helpers/Bbcode.php app/Helpers/Linkify.php tests/Unit/Helpers/BbcodeLinkTest.php`
- `git diff --check`
- `php artisan test tests/Unit/Helpers/BbcodeLinkTest.php --stop-on-failure` inside Docker/MySQL: 2 passed, 4 assertions

Note: the focused Laravel test was run with a temporary local-only route shim for the current `Route::livewire(...)` boot failure on `development` (`Attribute [livewire] does not exist`). The shim was reverted before commit.