### PR TITLE
Include last announce in torrent deletion PMs

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -454,9 +454,19 @@ class TorrentController extends Controller
 
         abort_unless($user->group->is_modo || ($user->id === $torrent->user_id && now()->lt($torrent->created_at->addDay())), 403);
 
+        $histories = History::query()
+            ->where('torrent_id', '=', $torrent->id)
+            ->get(['user_id', 'updated_at']);
+
         Notification::send(
-            User::query()->whereHas('history', fn ($query) => $query->where('torrent_id', '=', $torrent->id))->get(),
-            new TorrentDeleted($torrent, $request->message),
+            User::query()->whereKey($histories->pluck('user_id'))->get(),
+            new TorrentDeleted(
+                $torrent,
+                $request->message,
+                $histories
+                    ->mapWithKeys(fn (History $history) => [$history->user_id => $history->updated_at?->toJSON()])
+                    ->all(),
+            ),
         );
 
         // Reset Requests

--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -428,6 +428,7 @@ class SimilarTorrent extends Component
 
         $torrents = Torrent::query()->whereKey($this->checked)->get();
         $users = [];
+        $lastAnnouncedAtByUserIdAndTorrentId = [];
         $title = match (true) {
             $this->category->movie_meta => ($movie = TmdbMovie::query()->find($this->tmdbId))->title.($movie->release_date === null ? '' : ' ('.$movie->release_date->format('Y').')'),
             $this->category->tv_meta    => ($tv = TmdbTv::query()->find($this->tmdbId))->name.($tv->first_air_date === null ? '' : ' ('.$tv->first_air_date->format('Y').')'),
@@ -436,10 +437,12 @@ class SimilarTorrent extends Component
         };
 
         foreach ($torrents as $torrent) {
-            foreach (History::query()->where('torrent_id', '=', $torrent->id)->get() as $pm) {
-                if (!\in_array($pm->user_id, $users)) {
-                    $users[] = $pm->user_id;
+            foreach (History::query()->where('torrent_id', '=', $torrent->id)->get(['user_id', 'torrent_id', 'updated_at']) as $history) {
+                if (!\in_array($history->user_id, $users)) {
+                    $users[] = $history->user_id;
                 }
+
+                $lastAnnouncedAtByUserIdAndTorrentId[$history->user_id][$history->torrent_id] = $history->updated_at?->toJSON();
             }
 
             // Reset Requests
@@ -478,7 +481,7 @@ class SimilarTorrent extends Component
 
         Notification::send(
             array_map(fn ($userId) => new User(['id' => $userId]), $users),
-            new TorrentsDeleted($torrents, $title, $this->reason)
+            new TorrentsDeleted($torrents, $title, $this->reason, $lastAnnouncedAtByUserIdAndTorrentId)
         );
 
         $this->checked = [];

--- a/app/Notifications/TorrentDeleted.php
+++ b/app/Notifications/TorrentDeleted.php
@@ -23,12 +23,16 @@ use App\Notifications\Channels\SystemNotificationChannel;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Carbon;
 
 class TorrentDeleted extends Notification implements ShouldQueue, SystemNotificationInterface
 {
     use Queueable;
 
-    public function __construct(public Torrent $torrent, public string $reason)
+    /**
+     * @param array<int, string|null> $lastAnnouncedAtByUserId
+     */
+    public function __construct(public Torrent $torrent, public string $reason, public array $lastAnnouncedAtByUserId = [])
     {
     }
 
@@ -54,10 +58,23 @@ class TorrentDeleted extends Notification implements ShouldQueue, SystemNotifica
             'message' => <<<BBCODE
             [b]Torrent removed:[/b] {$this->torrent->name} was removed from the site.
 
-            You were listed as an uploader, seeder, or leecher on this torrent. You can remove it from your client.
+            You were listed as an uploader, seeder, or leecher on this torrent. {$this->lastAnnounceMessage($notifiable)} You can remove it from your client if it is still active.
             
             [b]Reason:[/b] {$this->reason}
             BBCODE
         ];
+    }
+
+    private function lastAnnounceMessage(User $notifiable): string
+    {
+        $lastAnnouncedAt = $this->lastAnnouncedAtByUserId[$notifiable->id] ?? null;
+
+        if ($lastAnnouncedAt === null) {
+            return 'No last announce timestamp was found for this torrent.';
+        }
+
+        $lastAnnouncedAt = Carbon::parse($lastAnnouncedAt);
+
+        return 'Your last announce for this torrent was '.$lastAnnouncedAt->diffForHumans().' ('.$lastAnnouncedAt->utc()->format('Y-m-d H:i:s \U\T\C').').';
     }
 }

--- a/app/Notifications/TorrentsDeleted.php
+++ b/app/Notifications/TorrentsDeleted.php
@@ -24,15 +24,17 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Carbon;
 
 class TorrentsDeleted extends Notification implements ShouldQueue, SystemNotificationInterface
 {
     use Queueable;
 
     /**
-     * @param Collection<int, Torrent> $torrents
+     * @param Collection<int, Torrent>            $torrents
+     * @param array<int, array<int, string|null>> $lastAnnouncedAtByUserIdAndTorrentId
      */
-    public function __construct(public Collection $torrents, public string $title, public string $reason)
+    public function __construct(public Collection $torrents, public string $title, public string $reason, public array $lastAnnouncedAtByUserIdAndTorrentId = [])
     {
     }
 
@@ -59,13 +61,33 @@ class TorrentsDeleted extends Notification implements ShouldQueue, SystemNotific
             [b]Attention:[/b] The following torrents have been removed from our site.
 
             [list]
-            [*]{$this->torrents->pluck('name')->join("\n[*]")}
+            [*]{$this->torrentLines($notifiable)}
             [/list]
 
-            Our system shows that you were either the uploader, a seeder or a leecher on said torrent. We just wanted to let you know you can safely remove it from your client.
+            Our system shows that you were either the uploader, a seeder or a leecher on said torrent. You can safely remove it from your client if it is still active.
 
             [b]Removal Reason:[/b] {$this->reason}
             BBCODE
         ];
+    }
+
+    private function torrentLines(User $notifiable): string
+    {
+        return $this->torrents
+            ->map(fn (Torrent $torrent) => $torrent->name.$this->lastAnnounceSuffix($notifiable, $torrent))
+            ->join("\n[*]");
+    }
+
+    private function lastAnnounceSuffix(User $notifiable, Torrent $torrent): string
+    {
+        $lastAnnouncedAt = $this->lastAnnouncedAtByUserIdAndTorrentId[$notifiable->id][$torrent->id] ?? null;
+
+        if ($lastAnnouncedAt === null) {
+            return ' (last announce: not found)';
+        }
+
+        $lastAnnouncedAt = Carbon::parse($lastAnnouncedAt);
+
+        return ' (last announce: '.$lastAnnouncedAt->diffForHumans().' on '.$lastAnnouncedAt->utc()->format('Y-m-d H:i:s \U\T\C').')';
     }
 }

--- a/tests/Unit/Notifications/TorrentDeletedTest.php
+++ b/tests/Unit/Notifications/TorrentDeletedTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Models\Torrent;
+use App\Models\User;
+use App\Notifications\TorrentDeleted;
+use App\Notifications\TorrentsDeleted;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
+
+afterEach(function (): void {
+    Carbon::setTestNow();
+});
+
+test('torrent deleted notification includes the users last announce timestamp', function (): void {
+    Carbon::setTestNow(Carbon::parse('2026-05-13 12:00:00 UTC'));
+
+    $lastAnnouncedAt = Carbon::parse('2026-05-13 09:00:00 UTC');
+
+    $notification = new TorrentDeleted(
+        new Torrent(['id' => 10, 'name' => 'Ubuntu ISO']),
+        'Dupe',
+        [7 => $lastAnnouncedAt->toJSON()],
+    );
+
+    $message = $notification->toSystemNotification(new User(['id' => 7]))['message'];
+
+    expect($message)
+        ->toContain('Your last announce for this torrent was 3 hours ago')
+        ->toContain('2026-05-13 09:00:00 UTC')
+        ->toContain('You can remove it from your client if it is still active.');
+});
+
+test('bulk torrent deleted notification includes per torrent last announce timestamps', function (): void {
+    Carbon::setTestNow(Carbon::parse('2026-05-13 12:00:00 UTC'));
+
+    $firstAnnouncedAt = Carbon::parse('2026-05-13 10:00:00 UTC');
+    $secondAnnouncedAt = Carbon::parse('2026-05-13 11:30:00 UTC');
+
+    $notification = new TorrentsDeleted(
+        new Collection([
+            new Torrent(['id' => 10, 'name' => 'Ubuntu 1080p']),
+            new Torrent(['id' => 11, 'name' => 'Ubuntu 2160p']),
+        ]),
+        'Ubuntu',
+        'Dupe',
+        [
+            7 => [
+                10 => $firstAnnouncedAt->toJSON(),
+                11 => $secondAnnouncedAt->toJSON(),
+            ],
+        ],
+    );
+
+    $message = $notification->toSystemNotification(new User(['id' => 7]))['message'];
+
+    expect($message)
+        ->toContain('[*]Ubuntu 1080p (last announce: 2 hours ago on 2026-05-13 10:00:00 UTC)')
+        ->toContain('[*]Ubuntu 2160p (last announce: 30 minutes ago on 2026-05-13 11:30:00 UTC)');
+});


### PR DESCRIPTION
## Summary
- snapshot `history.updated_at` before deleting torrent history rows
- include each recipient’s last announce age and UTC timestamp in single torrent deletion PMs
- include per-torrent last announce details in bulk/similar torrent deletion PMs

Fixes #4432

## Tests
- `docker run --rm -v "$PWD":/app -w /app unit3d-php-test ./vendor/bin/pint --test app/Http/Controllers/TorrentController.php app/Http/Livewire/SimilarTorrent.php app/Notifications/TorrentDeleted.php app/Notifications/TorrentsDeleted.php tests/Unit/Notifications/TorrentDeletedTest.php`
- `git diff --check`
- `php artisan test tests/Unit/Notifications/TorrentDeletedTest.php --stop-on-failure` inside Docker/MySQL: 2 passed, 5 assertions

Note: the focused Laravel test was run with a temporary local-only route shim for the current `Route::livewire(...)` boot failure on `development` (`Attribute [livewire] does not exist`). The shim was reverted before commit.