### PR TITLE
Add staff notes to reports

### DIFF
--- a/app/Http/Controllers/Staff/ReportController.php
+++ b/app/Http/Controllers/Staff/ReportController.php
@@ -42,6 +42,8 @@ class ReportController extends Controller
      */
     public function show(Report $report): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
+        $report->load(['notes.user']);
+
         // cspell:ignore punct
         preg_match_all('#\bhttps?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#', (string) $report->message, $match);
 

--- a/app/Http/Controllers/Staff/ReportNoteController.php
+++ b/app/Http/Controllers/Staff/ReportNoteController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Http\Controllers\Staff;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Staff\StoreReportNoteRequest;
+use App\Models\Report;
+use App\Models\ReportNote;
+
+class ReportNoteController extends Controller
+{
+    /**
+     * Store a newly created report staff note.
+     */
+    public function store(StoreReportNoteRequest $request, Report $report): \Illuminate\Http\RedirectResponse
+    {
+        $report->notes()->create([
+            'user_id' => $request->user()->id,
+            'message' => $request->validated('message'),
+        ]);
+
+        return to_route('staff.reports.show', ['report' => $report])
+            ->with('success', 'Report note has been successfully created.');
+    }
+
+    /**
+     * Remove the specified report staff note.
+     */
+    public function destroy(Report $report, ReportNote $reportNote): \Illuminate\Http\RedirectResponse
+    {
+        abort_unless($reportNote->report_id === $report->id, 404);
+
+        $reportNote->delete();
+
+        return to_route('staff.reports.show', ['report' => $report])
+            ->with('success', 'Report note has been successfully deleted.');
+    }
+}

--- a/app/Http/Requests/Staff/StoreReportNoteRequest.php
+++ b/app/Http/Requests/Staff/StoreReportNoteRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Http\Requests\Staff;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreReportNoteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()->group->is_modo;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array<\Illuminate\Contracts\Validation\Rule|string>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'message' => [
+                'required',
+                'string',
+            ],
+        ];
+    }
+}

--- a/app/Models/Report.php
+++ b/app/Models/Report.php
@@ -20,28 +20,30 @@ use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use AllowDynamicProperties;
 
 /**
  * App\Models\Report.
  *
- * @property int                             $id
- * @property string                          $type
- * @property int                             $reporter_id
- * @property int                             $reported_user_id
- * @property int                             $reported_torrent_id
- * @property int                             $reported_request_id
- * @property string                          $title
- * @property string                          $message
- * @property int|null                        $solved_by
- * @property int|null                        $assigned_to
- * @property string|null                     $verdict
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property int|null                        $reported_user
- * @property int|null                        $torrent_id
- * @property int|null                        $request_id
- * @property \Illuminate\Support\Carbon|null $snoozed_until
+ * @property int                                                       $id
+ * @property string                                                    $type
+ * @property int                                                       $reporter_id
+ * @property int                                                       $reported_user_id
+ * @property int                                                       $reported_torrent_id
+ * @property int                                                       $reported_request_id
+ * @property string                                                    $title
+ * @property string                                                    $message
+ * @property int|null                                                  $solved_by
+ * @property int|null                                                  $assigned_to
+ * @property string|null                                               $verdict
+ * @property \Illuminate\Support\Carbon|null                           $created_at
+ * @property \Illuminate\Support\Carbon|null                           $updated_at
+ * @property int|null                                                  $reported_user
+ * @property int|null                                                  $torrent_id
+ * @property int|null                                                  $request_id
+ * @property \Illuminate\Support\Carbon|null                           $snoozed_until
+ * @property \Illuminate\Database\Eloquent\Collection<int, ReportNote> $notes
  */
 #[AllowDynamicProperties]
 final class Report extends Model
@@ -129,5 +131,15 @@ final class Report extends Model
     public function judge(): BelongsTo
     {
         return $this->belongsTo(User::class, 'solved_by')->withTrashed();
+    }
+
+    /**
+     * Get the staff notes for this report.
+     *
+     * @return HasMany<ReportNote, $this>
+     */
+    public function notes(): HasMany
+    {
+        return $this->hasMany(ReportNote::class)->latest();
     }
 }

--- a/app/Models/ReportNote.php
+++ b/app/Models/ReportNote.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use AllowDynamicProperties;
+
+/**
+ * App\Models\ReportNote.
+ *
+ * @property int                             $id
+ * @property int                             $user_id
+ * @property int                             $report_id
+ * @property string                          $message
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+#[AllowDynamicProperties]
+final class ReportNote extends Model
+{
+    /** @use HasFactory<\Database\Factories\ReportNoteFactory> */
+    use HasFactory;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]
+     */
+    protected $guarded = ['id', 'created_at', 'updated_at'];
+
+    /**
+     * Get the user that wrote the note.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class)->withTrashed();
+    }
+
+    /**
+     * Get the report associated with the note.
+     *
+     * @return BelongsTo<Report, $this>
+     */
+    public function report(): BelongsTo
+    {
+        return $this->belongsTo(Report::class);
+    }
+}

--- a/database/factories/ReportNoteFactory.php
+++ b/database/factories/ReportNoteFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace Database\Factories;
+
+use App\Models\Report;
+use App\Models\ReportNote;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<ReportNote> */
+class ReportNoteFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     */
+    protected $model = ReportNote::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'report_id' => Report::factory(),
+            'user_id'   => User::factory(),
+            'message'   => $this->faker->text(),
+        ];
+    }
+}

--- a/database/migrations/2026_05_13_000000_create_report_notes_table.php
+++ b/database/migrations/2026_05_13_000000_create_report_notes_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('report_notes', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedInteger('report_id')->index();
+            $table->unsignedInteger('user_id')->index();
+            $table->text('message');
+            $table->timestamps();
+
+            $table->foreign('report_id')->references('id')->on('reports')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnUpdate();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('report_notes');
+    }
+};

--- a/resources/views/Staff/report/show.blade.php
+++ b/resources/views/Staff/report/show.blade.php
@@ -68,6 +68,82 @@
         </section>
     @endif
 
+    <section class="panelV2">
+        <h2 class="panel__heading">Staff Notes</h2>
+        <div class="panel__body">
+            <button class="form__button form__button--text" popovertarget="report-note-add">
+                <i class="{{ config('other.font-awesome') }} fa-plus"></i>
+                Add staff note
+            </button>
+            <dialog id="report-note-add" class="dialog" popover>
+                <h4 class="dialog__heading">Add staff note</h4>
+                <form
+                    class="form"
+                    method="POST"
+                    action="{{ route('staff.reports.notes.store', ['report' => $report]) }}"
+                >
+                    @csrf
+                    @livewire('bbcode-input', ['name' => 'message', 'label' => __('common.message'), 'required' => true])
+                    <p class="form__group">
+                        <button class="form__button form__button--filled">
+                            {{ __('common.submit') }}
+                        </button>
+                        <button
+                            formmethod="dialog"
+                            formnovalidate
+                            class="form__button form__button--outlined"
+                            popovertarget="report-note-add"
+                        >
+                            {{ __('common.cancel') }}
+                        </button>
+                    </p>
+                </form>
+            </dialog>
+        </div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>{{ __('common.created_at') }}</th>
+                    <th>{{ __('common.user') }}</th>
+                    <th>{{ __('user.note') }}</th>
+                    <th>{{ __('common.actions') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse ($report->notes as $note)
+                    <tr>
+                        <td>
+                            <time datetime="{{ $note->created_at }}" title="{{ $note->created_at }}">
+                                {{ $note->created_at->diffForHumans() }}
+                            </time>
+                        </td>
+                        <td>
+                            <x-user-tag :anon="false" :user="$note->user" />
+                        </td>
+                        {{-- format-ignore-start --}}<td style="white-space: pre-wrap">@linkify($note->message)</td>{{-- format-ignore-end --}}
+                        <td>
+                            <form
+                                method="POST"
+                                action="{{ route('staff.reports.notes.destroy', ['report' => $report, 'reportNote' => $note]) }}"
+                            >
+                                @csrf
+                                @method('DELETE')
+                                <button class="form__button form__button--text">
+                                    <i class="{{ config('other.font-awesome') }} fa-trash"></i>
+                                    {{ __('common.delete') }}
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="4">No notes</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </section>
+
     @if ($report->solved_by !== null)
         <section class="panelV2">
             <h2 class="panel__heading">Verdict</h2>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1015,6 +1015,8 @@ Route::middleware(SetLanguage::class)->group(function (): void {
                 Route::get('/', [App\Http\Controllers\Staff\ReportController::class, 'index'])->name('index');
                 Route::get('/{report}', [App\Http\Controllers\Staff\ReportController::class, 'show'])->name('show');
                 Route::patch('/{report}', [App\Http\Controllers\Staff\ReportController::class, 'update'])->name('update');
+                Route::post('/{report}/notes', [App\Http\Controllers\Staff\ReportNoteController::class, 'store'])->name('notes.store');
+                Route::delete('/{report}/notes/{reportNote}', [App\Http\Controllers\Staff\ReportNoteController::class, 'destroy'])->name('notes.destroy');
                 Route::post('/{report}/assignee', [App\Http\Controllers\Staff\ReportAssigneeController::class, 'store'])->name('assignee.store');
                 Route::delete('/{report}/assignee', [App\Http\Controllers\Staff\ReportAssigneeController::class, 'destroy'])->name('assignee.destroy');
             });

--- a/tests/Feature/Http/Controllers/Staff/ReportNoteControllerTest.php
+++ b/tests/Feature/Http/Controllers/Staff/ReportNoteControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Http\Controllers\Staff\ReportNoteController;
+use App\Http\Middleware\UpdateLastAction;
+use App\Http\Requests\Staff\StoreReportNoteRequest;
+use App\Models\Group;
+use App\Models\Report;
+use App\Models\ReportNote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->withoutMiddleware(UpdateLastAction::class);
+    $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+    $this->withoutVite();
+});
+
+test('store report note validates with a form request', function (): void {
+    $this->assertActionUsesFormRequest(
+        ReportNoteController::class,
+        'store',
+        StoreReportNoteRequest::class
+    );
+});
+
+test('staff can add a note to a report', function (): void {
+    $report = Report::factory()->create();
+    $staff = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => 1])->id,
+    ]);
+
+    $response = $this->actingAs($staff)->post(route('staff.reports.notes.store', ['report' => $report]), [
+        'message' => 'Started checking this report.',
+    ]);
+
+    $response->assertRedirect(route('staff.reports.show', $report));
+
+    $this->assertDatabaseHas('report_notes', [
+        'report_id' => $report->id,
+        'user_id'   => $staff->id,
+        'message'   => 'Started checking this report.',
+    ]);
+});
+
+test('report details show staff notes', function (): void {
+    $report = Report::factory()->create();
+    $staff = User::factory()->create([
+        'username' => 'reportstaff',
+        'group_id' => Group::factory()->create(['is_modo' => 1])->id,
+    ]);
+
+    ReportNote::factory()->create([
+        'report_id' => $report->id,
+        'user_id'   => $staff->id,
+        'message'   => 'Downloaded sample for review.',
+    ]);
+
+    $response = $this->actingAs($staff)->get(route('staff.reports.show', [$report]));
+
+    $response->assertOk()
+        ->assertSee('Staff Notes')
+        ->assertSee('reportstaff')
+        ->assertSee('Downloaded sample for review.');
+});
+
+test('staff can delete a single report note', function (): void {
+    $report = Report::factory()->create();
+    $staff = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => 1])->id,
+    ]);
+    $note = ReportNote::factory()->create([
+        'report_id' => $report->id,
+    ]);
+    $otherNote = ReportNote::factory()->create([
+        'report_id' => $report->id,
+    ]);
+
+    $response = $this->actingAs($staff)->delete(route('staff.reports.notes.destroy', [
+        'report'     => $report,
+        'reportNote' => $note,
+    ]));
+
+    $response->assertRedirect(route('staff.reports.show', $report));
+
+    $this->assertModelMissing($note);
+    $this->assertModelExists($otherNote);
+});


### PR DESCRIPTION
## Summary
- add persistent staff notes for reports with create/delete actions
- show staff notes on the staff report detail page
- add report-note model, factory, migration, relationships, and focused feature coverage

Fixes #3817

## Tests
- `vendor/bin/pint --test app/Http/Controllers/Staff/ReportController.php app/Http/Controllers/Staff/ReportNoteController.php app/Http/Requests/Staff/StoreReportNoteRequest.php app/Models/Report.php app/Models/ReportNote.php database/factories/ReportNoteFactory.php database/migrations/2026_05_13_000000_create_report_notes_table.php routes/web.php tests/Feature/Http/Controllers/Staff/ReportNoteControllerTest.php`
- `git diff --check`
- `php artisan test tests/Feature/Http/Controllers/Staff/ReportNoteControllerTest.php --stop-on-failure` in Docker/MySQL: 4 passed, 14 assertions

Note: the local Docker test run used a temporary, reverted route shim for the current `development` branch `Route::livewire(...)` boot issue before executing the focused test.