### PR TITLE
Expose effective freeleech in torrent API

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -320,6 +320,7 @@ class TorrentController extends BaseController
         unset($queryParams['api_token']);
         $queryParams['isRegexAllowed'] = $isRegexAllowed;
         $queryParams['isSqlAllowed'] = $isSqlAllowed;
+        $queryParams['isFreeleechUser'] = config('other.freeleech') || $user->group->is_freeleech;
 
         // Sorting query params by key (acts by reference)
         ksort($queryParams);
@@ -329,7 +330,7 @@ class TorrentController extends BaseController
         $cacheKey = $url.'?'.$queryString;
 
         /** @phpstan-ignore method.unresolvableReturnType (phpstan is unable to resolve type because it's returning a phpstan-ignored line) */
-        [$torrents, $hasMore] = cache()->flexible($cacheKey, [60 * 5, 60 * 6], function () use ($request, $isSqlAllowed) {
+        [$torrents, $hasMore] = cache()->flexible($cacheKey, [60 * 5, 60 * 6], function () use ($request, $isSqlAllowed, $user) {
             $eagerLoads = fn (Builder $query) => $query
                 ->with(['user:id,username', 'category', 'type', 'resolution', 'distributor', 'region', 'files'])
                 ->select('*')
@@ -416,6 +417,8 @@ class TorrentController extends BaseController
                 foreach ($results['hits'] ?? [] as $hit) {
                     $meta = $hit['tmdb_movie'] ?? $hit['tmdb_tv'] ?? [];
 
+                    $effectiveFreeleech = config('other.freeleech') || $user->group->is_freeleech ? 100 : (int) $hit['free'];
+
                     /** @see TorrentResource */
                     $torrents->push([
                         'type'       => 'torrent',
@@ -437,7 +440,7 @@ class TorrentController extends BaseController
                             'size'             => $hit['size'],
                             'num_file'         => $hit['num_file'],
                             'files'            => $hit['files'],
-                            'freeleech'        => $hit['free'].'%',
+                            'freeleech'        => $effectiveFreeleech.'%',
                             'double_upload'    => $hit['doubleup'],
                             'refundable'       => $hit['refundable'],
                             'internal'         => $hit['internal'],

--- a/app/Http/Resources/TorrentResource.php
+++ b/app/Http/Resources/TorrentResource.php
@@ -114,7 +114,7 @@ class TorrentResource extends JsonResource
                     'name'  => $file->name,
                     'size'  => $file->size,
                 ]),
-                'freeleech'        => $this->free.'%',
+                'freeleech'        => $this->effectiveFreeleechPercentage($request).'%',
                 'double_upload'    => $this->doubleup,
                 'refundable'       => $this->refundable,
                 'internal'         => $this->internal,
@@ -148,5 +148,24 @@ class TorrentResource extends JsonResource
     public function withResponse(Request $request, JsonResponse $response): void
     {
         $response->setEncodingOptions(JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+    }
+
+    private function effectiveFreeleechPercentage(Request $request): int
+    {
+        $user = $request->user(AuthGuard::API->value);
+
+        if (config('other.freeleech')) {
+            return 100;
+        }
+
+        if ($user !== null) {
+            $user->loadMissing('group');
+
+            if ($user->group->is_freeleech) {
+                return 100;
+            }
+        }
+
+        return (int) $this->free;
     }
 }

--- a/tests/Feature/Http/Controllers/API/TorrentFreeleechResponseTest.php
+++ b/tests/Feature/Http/Controllers/API/TorrentFreeleechResponseTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Enums\AuthGuard;
+use App\Models\Category;
+use App\Models\Group;
+use App\Models\Torrent;
+use App\Models\User;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+
+beforeEach(function (): void {
+    $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+});
+
+test('torrent API shows global freeleech as effective freeleech', function (): void {
+    config(['other.freeleech' => true]);
+
+    $user = User::factory()->create();
+    $torrent = Torrent::factory()->create([
+        'category_id' => Category::factory()->create([
+            'no_meta'    => false,
+            'music_meta' => false,
+            'game_meta'  => false,
+            'tv_meta'    => false,
+            'movie_meta' => false,
+        ])->id,
+        'free' => 0,
+    ]);
+
+    $response = $this->actingAs($user, AuthGuard::API->value)->getJson('api/torrents/'.$torrent->id);
+
+    $response->assertOk()
+        ->assertJsonPath('attributes.freeleech', '100%');
+});
+
+test('torrent API shows group freeleech as effective freeleech', function (): void {
+    config(['other.freeleech' => false]);
+
+    $user = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_freeleech' => true])->id,
+    ]);
+    $torrent = Torrent::factory()->create([
+        'category_id' => Category::factory()->create([
+            'no_meta'    => false,
+            'music_meta' => false,
+            'game_meta'  => false,
+            'tv_meta'    => false,
+            'movie_meta' => false,
+        ])->id,
+        'free' => 0,
+    ]);
+
+    $response = $this->actingAs($user, AuthGuard::API->value)->getJson('api/torrents/'.$torrent->id);
+
+    $response->assertOk()
+        ->assertJsonPath('attributes.freeleech', '100%');
+});
+
+test('torrent API keeps torrent freeleech percentage without global or group freeleech', function (): void {
+    config(['other.freeleech' => false]);
+
+    $user = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_freeleech' => false])->id,
+    ]);
+    $torrent = Torrent::factory()->create([
+        'category_id' => Category::factory()->create([
+            'no_meta'    => false,
+            'music_meta' => false,
+            'game_meta'  => false,
+            'tv_meta'    => false,
+            'movie_meta' => false,
+        ])->id,
+        'free' => 50,
+    ]);
+
+    $response = $this->actingAs($user, AuthGuard::API->value)->getJson('api/torrents/'.$torrent->id);
+
+    $response->assertOk()
+        ->assertJsonPath('attributes.freeleech', '50%');
+});


### PR DESCRIPTION
## Summary
- serialize torrent API `freeleech` as `100%` when global freeleech is enabled
- also account for API users whose group has freeleech enabled
- keep torrent-specific freeleech percentages unchanged otherwise

Fixes #5327

## Root Cause
Torrent API responses used only the torrent row's `free` percentage. During global freeleech, torrents with `free = 0` still appeared as `freeleech: "0%"` to API clients even though downloads are effectively freeleech.

## Tests
- `vendor/bin/pint --test app/Http/Controllers/API/TorrentController.php app/Http/Resources/TorrentResource.php tests/Feature/Http/Controllers/API/TorrentFreeleechResponseTest.php`
- `git diff --check`
- `php artisan test tests/Feature/Http/Controllers/API/TorrentFreeleechResponseTest.php --stop-on-failure` in Docker/MySQL: 3 passed, 6 assertions

Note: the local Docker test run used a temporary, reverted route shim for the current `development` branch `Route::livewire(...)` boot issue before executing the focused test.