### PR TITLE
Add info hash filter to torrent API

### DIFF
--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -77,6 +77,7 @@ readonly class TorrentSearchFiltersDTO
         private bool $dying = false,
         private bool $dead = false,
         private string $filename = '',
+        private string $hash = '',
         private bool $graveyard = false,
         private bool $userBookmarked = false,
         private bool $userWished = false,
@@ -325,6 +326,7 @@ readonly class TorrentSearchFiltersDTO
                     )
             )
             ->when($this->filename !== '', fn ($query) => $query->whereRelation('files', 'name', '=', $this->filename))
+            ->when($this->hash !== '', fn ($query) => $query->whereRaw('LOWER(HEX(info_hash)) = ?', [$this->hash]))
             ->when(
                 $this->adult === true,
                 fn ($query) => $query
@@ -691,6 +693,10 @@ readonly class TorrentSearchFiltersDTO
 
         if ($this->filename !== '') {
             $filters[] = 'files.name = '.json_encode($this->filename);
+        }
+
+        if ($this->hash !== '') {
+            $filters[] = 'info_hash = '.json_encode($this->hash);
         }
 
         if ($this->graveyard) {

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -309,7 +309,13 @@ class TorrentController extends BaseController
                 'nullable',
                 'sometimes',
                 'in:asc,desc'
-            ]
+            ],
+            'hash' => [
+                'nullable',
+                'sometimes',
+                'string',
+                'regex:/\A[0-9a-fA-F]{40}\z/',
+            ],
         ]);
 
         // Caching
@@ -374,6 +380,7 @@ class TorrentController extends BaseController
                 dying: $request->filled('dying'),
                 dead: $request->filled('dead'),
                 filename: $request->filled('file_name') ? $request->string('file_name')->toString() : '',
+                hash: $request->filled('hash') ? strtolower($request->string('hash')->toString()) : '',
                 seasonNumber: $request->filled('seasonNumber') ? $request->integer('seasonNumber') : null,
                 episodeNumber: $request->filled('episodeNumber') ? $request->integer('episodeNumber') : null,
             );

--- a/tests/Feature/Http/Controllers/API/TorrentHashFilterTest.php
+++ b/tests/Feature/Http/Controllers/API/TorrentHashFilterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Enums\AuthGuard;
+use App\Models\Category;
+use App\Models\Group;
+use App\Models\Torrent;
+use App\Models\User;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+
+beforeEach(function (): void {
+    $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+});
+
+test('torrent API filter can search by info hash', function (): void {
+    $user = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => true])->id,
+    ]);
+    $category = Category::factory()->create([
+        'no_meta'    => false,
+        'music_meta' => false,
+        'game_meta'  => false,
+        'tv_meta'    => false,
+        'movie_meta' => false,
+    ]);
+    $matchingTorrent = Torrent::factory()->create([
+        'category_id' => $category->id,
+        'info_hash'   => '12345678901234567890',
+    ]);
+    Torrent::factory()->create([
+        'category_id' => $category->id,
+        'info_hash'   => 'abcdefghijklmnopqrst',
+    ]);
+
+    $response = $this->actingAs($user, AuthGuard::API->value)->getJson(
+        'api/torrents/filter?driver=sql&hash='.bin2hex($matchingTorrent->info_hash)
+    );
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', (string) $matchingTorrent->id);
+});
+
+test('torrent API filter validates info hash format', function (): void {
+    $user = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => true])->id,
+    ]);
+
+    $response = $this->actingAs($user, AuthGuard::API->value)->getJson(
+        'api/torrents/filter?driver=sql&hash=not-a-valid-info-hash'
+    );
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['hash']);
+});


### PR DESCRIPTION
## Summary
- add a validated `hash` query parameter to `/api/torrents/filter`
- filter SQL searches with an exact `info_hash` match
- pass the same exact `info_hash` filter through the Meilisearch filter builder

Fixes #4018

## Root Cause
The torrent API already had `info_hash` in the search index/filter data, but `TorrentSearchFiltersDTO` had no request field for exact info-hash lookups. Upload automation therefore could not query `/api/torrents/filter` by a known torrent hash.

## Tests
- `vendor/bin/pint --test app/DTO/TorrentSearchFiltersDTO.php app/Http/Controllers/API/TorrentController.php tests/Feature/Http/Controllers/API/TorrentHashFilterTest.php`
- `git diff --check`
- `php artisan test tests/Feature/Http/Controllers/API/TorrentHashFilterTest.php --stop-on-failure` in Docker/MySQL: 2 passed, 6 assertions

Note: the local Docker test run used a temporary, reverted route shim for the current `development` branch `Route::livewire(...)` boot issue before executing the focused test.