### PR TITLE
Mention grace period in pre-warning notification

### DIFF
--- a/app/Notifications/UserPreWarning.php
+++ b/app/Notifications/UserPreWarning.php
@@ -23,6 +23,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Str;
 
 class UserPreWarning extends Notification implements ShouldQueue
 {
@@ -71,6 +72,7 @@ class UserPreWarning extends Notification implements ShouldQueue
         return (new MailMessage())
             ->greeting('Hit and run pre-warning')
             ->line('You received a hit and run pre-warning on one or more torrents.')
+            ->line('The current hit and run grace period is '.$this->gracePeriod().' from your last activity.')
             ->action('View unsatisfied torrents and start seeding.', route('users.history.index', ['user' => $this->user]));
     }
 
@@ -83,9 +85,16 @@ class UserPreWarning extends Notification implements ShouldQueue
     {
         return [
             'title' => 'Hit and run pre-warning',
-            'body'  => 'You received a hit and run pre-warning on one or more torrents. View unsatisfied torrents and start seeding.',
+            'body'  => 'You received a hit and run pre-warning on one or more torrents. The current hit and run grace period is '.$this->gracePeriod().' from your last activity. View unsatisfied torrents and start seeding.',
             'url'   => route('users.history.index', ['user' => $this->user]),
         ];
+    }
+
+    private function gracePeriod(): string
+    {
+        $days = (int) config('hitrun.grace');
+
+        return $days.' '.Str::plural('day', $days);
     }
 
     /**

--- a/tests/Unit/Notifications/UserPreWarningTest.php
+++ b/tests/Unit/Notifications/UserPreWarningTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Models\User;
+use App\Notifications\UserPreWarning;
+
+test('pre-warning notification mentions configured grace period', function (): void {
+    config(['hitrun.grace' => 3]);
+
+    $user = User::factory()->create();
+    $notification = new UserPreWarning($user);
+
+    expect(implode(' ', $notification->toMail($user)->introLines))
+        ->toContain('The current hit and run grace period is 3 days from your last activity.');
+
+    expect($notification->toArray($user)['body'])
+        ->toContain('The current hit and run grace period is 3 days from your last activity.');
+});
+
+test('pre-warning notification uses singular day for a one day grace period', function (): void {
+    config(['hitrun.grace' => 1]);
+
+    $user = User::factory()->create();
+    $notification = new UserPreWarning($user);
+
+    expect(implode(' ', $notification->toMail($user)->introLines))
+        ->toContain('The current hit and run grace period is 1 day from your last activity.');
+});


### PR DESCRIPTION
## Summary
- include the configured hit-and-run grace period in pre-warning mail notifications
- include the same grace-period wording in database notification text
- add coverage for plural and singular day wording

Fixes #5134

## Root Cause
The pre-warning notification told users they had one or more hit-and-run candidates, but it did not include the configured grace-period duration, forcing users to find tracker documentation to know the timing.

## Tests
- `vendor/bin/pint --test app/Notifications/UserPreWarning.php tests/Unit/Notifications/UserPreWarningTest.php`
- `git diff --check`
- `php artisan test tests/Unit/Notifications/UserPreWarningTest.php --stop-on-failure` in Docker/MySQL: 2 passed, 3 assertions

Note: the local Docker test run used a temporary, reverted route shim for the current `development` branch `Route::livewire(...)` boot issue before executing the focused test.