### PR TITLE
(Enhancement) Improve three-dot action touch targets

### DIFF
--- a/resources/sass/components/_meta.scss
+++ b/resources/sass/components/_meta.scss
@@ -113,7 +113,7 @@
     display: none;
     position: absolute;
     z-index: 5;
-    top: 40px;
+    top: 48px;
     right: 0;
     list-style-type: none;
     border-radius: 8px;
@@ -135,8 +135,8 @@
     content: '';
     display: block;
     position: absolute;
-    top: -40px;
-    height: 40px;
+    top: -48px;
+    height: 48px;
     width: 100%;
 }
 
@@ -144,9 +144,11 @@
     color: var(--meta-dropdown-fg);
     display: grid;
     place-items: center;
-    width: 40px;
-    height: 40px;
-    border-radius: 20px;
+    width: 48px;
+    height: 48px;
+    border-radius: 24px;
+    font-size: 18px;
+    touch-action: manipulation;
 }
 
 .meta__actions:hover .meta__dropdown-button,

--- a/resources/sass/components/forum/_post.scss
+++ b/resources/sass/components/forum/_post.scss
@@ -295,8 +295,18 @@
 
 .post__toolbar-overflow {
     display: none;
+    place-items: center;
+    min-width: 44px;
+    min-height: 44px;
+    border: 0;
+    background: transparent;
     color: var(--post-head-fg);
     cursor: pointer;
+    font-family: inherit;
+    font-size: 18px;
+    line-height: 1;
+    padding: 0;
+    touch-action: manipulation;
 }
 
 @media screen and (max-width: 576px) {
@@ -343,9 +353,9 @@
 
     .post__toolbar-overflow {
         grid-area: overflow;
-        display: block;
-        padding: 4px 8px;
-        text-align: right;
+        display: grid;
+        justify-self: end;
+        padding: 0;
     }
 
     .post__toolbar {

--- a/resources/views/components/forum/post.blade.php
+++ b/resources/views/components/forum/post.blade.php
@@ -41,9 +41,14 @@
             </dl>
         @endif
 
-        <a class="post__toolbar-overflow" tabindex="0">
+        <button
+            class="post__toolbar-overflow"
+            type="button"
+            aria-label="{{ __('common.actions') }}"
+            title="{{ __('common.actions') }}"
+        >
             <i class="fa fas fa-ellipsis"></i>
-        </a>
+        </button>
         <menu class="post__toolbar">
             <li class="post__toolbar-item">
                 <form

--- a/resources/views/torrent/partials/game-meta.blade.php
+++ b/resources/views/torrent/partials/game-meta.blade.php
@@ -26,7 +26,12 @@
         />
     </a>
     <div class="meta__actions">
-        <a class="meta__dropdown-button" href="#">
+        <a
+            class="meta__dropdown-button"
+            href="#"
+            aria-label="{{ __('common.actions') }}"
+            title="{{ __('common.actions') }}"
+        >
             <i class="{{ config('other.font-awesome') }} fa-ellipsis-v"></i>
         </a>
         <ul class="meta__dropdown">

--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -22,7 +22,12 @@
         />
     </a>
     <div class="meta__actions">
-        <a class="meta__dropdown-button" href="#">
+        <a
+            class="meta__dropdown-button"
+            href="#"
+            aria-label="{{ __('common.actions') }}"
+            title="{{ __('common.actions') }}"
+        >
             <i class="{{ config('other.font-awesome') }} fa-ellipsis-v"></i>
         </a>
         <ul class="meta__dropdown">

--- a/resources/views/torrent/partials/no-meta.blade.php
+++ b/resources/views/torrent/partials/no-meta.blade.php
@@ -14,7 +14,12 @@
         />
     </span>
     <div class="meta__actions">
-        <a class="meta__dropdown-button" href="#">
+        <a
+            class="meta__dropdown-button"
+            href="#"
+            aria-label="{{ __('common.actions') }}"
+            title="{{ __('common.actions') }}"
+        >
             <i class="{{ config('other.font-awesome') }} fa-ellipsis-v"></i>
         </a>
         <ul class="meta__dropdown">

--- a/resources/views/torrent/partials/tv-meta.blade.php
+++ b/resources/views/torrent/partials/tv-meta.blade.php
@@ -22,7 +22,12 @@
         />
     </a>
     <div class="meta__actions">
-        <a class="meta__dropdown-button" href="#">
+        <a
+            class="meta__dropdown-button"
+            href="#"
+            aria-label="{{ __('common.actions') }}"
+            title="{{ __('common.actions') }}"
+        >
             <i class="{{ config('other.font-awesome') }} fa-ellipsis-v"></i>
         </a>
         <ul class="meta__dropdown">


### PR DESCRIPTION
Closes #4639.

## Summary
- enlarge the mobile forum post overflow control to a 44px touch target
- enlarge torrent metadata action dropdown buttons to 48px and keep their hover gap aligned
- add accessible action labels/titles to the three-dot controls

## Tests
- `./node_modules/.bin/prettier --check resources/views/components/forum/post.blade.php resources/views/torrent/partials/game-meta.blade.php resources/views/torrent/partials/movie-meta.blade.php resources/views/torrent/partials/no-meta.blade.php resources/views/torrent/partials/tv-meta.blade.php resources/sass/components/_meta.scss resources/sass/components/forum/_post.scss`
- `./node_modules/.bin/sass --load-path=node_modules resources/sass/main.scss /tmp/unit3d-main.css`
- `npm run build` (local npm-only setup required `npm install --legacy-peer-deps --no-package-lock --no-save date-fns@4.1.0`; `bun.lock` already includes `date-fns@4.1.0`)
- Docker/PHP: `php artisan view:clear && php artisan view:cache` (with the existing local-only `Route::livewire` -> `Route::get` shim for `/laravel-log`, `/torrent-downloads`, and `/torrent-trump-search`, reverted before commit)