### PR TITLE
Notify uploaders when torrents are featured

### DIFF
--- a/app/Http/Controllers/TorrentBuffController.php
+++ b/app/Http/Controllers/TorrentBuffController.php
@@ -21,6 +21,7 @@ use App\Models\FeaturedTorrent;
 use App\Models\FreeleechToken;
 use App\Models\Scopes\ApprovedScope;
 use App\Models\Torrent;
+use App\Notifications\TorrentFeatured;
 use App\Repositories\ChatRepository;
 use App\Services\Unit3dAnnounce;
 use Illuminate\Http\Request;
@@ -155,6 +156,8 @@ class TorrentBuffController extends Controller
             $this->chatRepository->systemMessage(
                 \sprintf('Ladies and Gents, [url=%s]%s[/url] has been added to the Featured Torrents Slider by [url=%s]%s[/url]! Grab It While You Can!', $torrentUrl, $torrent->name, $profileUrl, $user->username)
             );
+
+            $torrent->user->notify(new TorrentFeatured($torrent, $user));
 
             return to_route('torrents.show', ['id' => $torrent->id])
                 ->with('success', 'Torrent is now featured!');

--- a/app/Notifications/TorrentFeatured.php
+++ b/app/Notifications/TorrentFeatured.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Notifications;
+
+use App\Models\Torrent;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class TorrentFeatured extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * TorrentFeatured Constructor.
+     */
+    public function __construct(public Torrent $torrent, public User $featuredBy)
+    {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'title' => 'Your torrent has been featured',
+            'body'  => $this->featuredBy->username.' featured your uploaded torrent: '.$this->torrent->name,
+            'url'   => route('torrents.show', ['id' => $this->torrent->id], false),
+        ];
+    }
+}

--- a/tests/Feature/Http/Controllers/TorrentFeatureNotificationTest.php
+++ b/tests/Feature/Http/Controllers/TorrentFeatureNotificationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Http\Middleware\BlockIpAddress;
+use App\Http\Middleware\UpdateLastAction;
+use App\Models\Bot;
+use App\Models\Group;
+use App\Models\Torrent;
+use App\Models\User;
+use App\Notifications\TorrentFeatured;
+use Database\Seeders\UserSeeder;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+
+test('granting featured status notifies the torrent uploader', function (): void {
+    $this->withoutExceptionHandling();
+    $this->withoutMiddleware([
+        BlockIpAddress::class,
+        ThrottleRequestsWithRedis::class,
+        UpdateLastAction::class,
+    ]);
+
+    $this->seed(UserSeeder::class);
+
+    Bot::factory()->create([
+        'command' => 'systembot',
+    ]);
+
+    Event::fake();
+    Notification::fake();
+
+    $staff = User::factory()->create([
+        'group_id' => Group::factory()->owner(),
+    ]);
+
+    $uploader = User::factory()->create();
+    $torrent = Torrent::factory()->for($uploader)->create([
+        'name' => 'Featured Release',
+    ]);
+
+    $response = $this->actingAs($staff)->post(route('torrent_feature', ['id' => $torrent->id]));
+
+    $response->assertRedirect(route('torrents.show', ['id' => $torrent->id]));
+
+    $this->assertDatabaseHas('featured_torrents', [
+        'torrent_id' => $torrent->id,
+        'user_id'    => $staff->id,
+    ]);
+
+    Notification::assertSentTo(
+        $uploader,
+        TorrentFeatured::class,
+        fn (TorrentFeatured $notification): bool => $notification->torrent->is($torrent)
+            && $notification->featuredBy->is($staff)
+            && $notification->toArray($uploader) === [
+                'title' => 'Your torrent has been featured',
+                'body'  => $staff->username.' featured your uploaded torrent: Featured Release',
+                'url'   => route('torrents.show', ['id' => $torrent->id], false),
+            ],
+    );
+});


### PR DESCRIPTION
Closes #3750.

## Summary
- add a queued database notification for torrent uploaders when staff feature their torrent
- send the notification from the existing staff feature action after the feature record is created
- add a focused feature test covering the notification payload and featured torrent record

## Tests
- `vendor/bin/pint --test app/Http/Controllers/TorrentBuffController.php app/Notifications/TorrentFeatured.php tests/Feature/Http/Controllers/TorrentFeatureNotificationTest.php` in Docker
- `git diff --check`
- Docker/MySQL: `php artisan test tests/Feature/Http/Controllers/TorrentFeatureNotificationTest.php --stop-on-failure` (`1 passed, 4 assertions`; local test disables Redis-backed middleware because the PHP image lacks `phpredis`)

Note: the focused test used the existing local-only `Route::livewire` -> `Route::get` shim for `/laravel-log`, `/torrent-downloads`, and `/torrent-trump-search` so current `development` could boot under Livewire 4. The shim was reverted before commit.