### PR TITLE
Add BDInfo advanced search filter

### DIFF
--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -32,6 +32,7 @@ readonly class TorrentSearchFiltersDTO
         private string $name = '',
         private string $description = '',
         private string $mediainfo = '',
+        private string $bdinfo = '',
         private string $uploader = '',
         /** @var array<mixed> */
         private array $keywords = [],
@@ -127,6 +128,15 @@ readonly class TorrentSearchFiltersDTO
                         $isRegex($this->mediainfo),
                         fn ($query) => $query->where('mediainfo', 'REGEXP', substr($this->mediainfo, 1, -1)),
                         fn ($query) => $query->where('mediainfo', 'LIKE', '%'.$this->mediainfo.'%')
+                    )
+            )
+            ->when(
+                $this->bdinfo !== '',
+                fn ($query) => $query
+                    ->when(
+                        $isRegex($this->bdinfo),
+                        fn ($query) => $query->where('bdinfo', 'REGEXP', substr($this->bdinfo, 1, -1)),
+                        fn ($query) => $query->where('bdinfo', 'LIKE', '%'.$this->bdinfo.'%')
                     )
             )
             ->when(

--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -66,6 +66,9 @@ class SimilarTorrent extends Component
     public string $mediainfo = '';
 
     #[Url(history: true)]
+    public string $bdinfo = '';
+
+    #[Url(history: true)]
     public string $uploader = '';
 
     #[Url(history: true)]
@@ -295,6 +298,7 @@ class SimilarTorrent extends Component
                     name: $this->name,
                     description: $this->description,
                     mediainfo: $this->mediainfo,
+                    bdinfo: $this->bdinfo,
                     keywords: $this->keywords ? array_map(trim(...), explode(',', $this->keywords)) : [],
                     uploader: $this->uploader,
                     episodeNumber: $this->episodeNumber,

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -58,6 +58,9 @@ class TorrentSearch extends Component
     public string $mediainfo = '';
 
     #[Url(history: true)]
+    public string $bdinfo = '';
+
+    #[Url(history: true)]
     public string $uploader = '';
 
     #[Url(history: true)]
@@ -366,6 +369,7 @@ class TorrentSearch extends Component
             name: $this->name,
             description: $this->description,
             mediainfo: $this->mediainfo,
+            bdinfo: $this->bdinfo,
             uploader: $this->uploader,
             keywords: $this->keywords ? array_map(trim(...), explode(',', $this->keywords)) : [],
             startYear: $this->startYear,
@@ -449,7 +453,7 @@ class TorrentSearch extends Component
                 $this->reset('sortField');
             }
 
-            $isSqlAllowed = (($user->group->is_modo || $user->group->is_torrent_modo || $user->group->is_editor) && $this->driver === 'sql') || $this->description || $this->mediainfo;
+            $isSqlAllowed = (($user->group->is_modo || $user->group->is_torrent_modo || $user->group->is_editor) && $this->driver === 'sql') || $this->description || $this->mediainfo || $this->bdinfo;
 
             $eagerLoads = fn (Builder $query) => $query
                 ->with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
@@ -541,7 +545,7 @@ class TorrentSearch extends Component
                 $this->reset('sortField');
             }
 
-            $isSqlAllowed = (($user->group->is_modo || $user->group->is_torrent_modo || $user->group->is_editor) && $this->driver === 'sql') || $this->description || $this->mediainfo;
+            $isSqlAllowed = (($user->group->is_modo || $user->group->is_torrent_modo || $user->group->is_editor) && $this->driver === 'sql') || $this->description || $this->mediainfo || $this->bdinfo;
 
             $groupQuery = Torrent::query()
                 ->select('tmdb_movie_id', 'tmdb_tv_id')

--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -52,6 +52,17 @@
                     </p>
                     <p class="form__group">
                         <input
+                            id="bdinfo"
+                            wire:model.live="bdinfo"
+                            class="form__text"
+                            type="search"
+                            autocomplete="off"
+                            placeholder=" "
+                        />
+                        <label class="form__label form__label--floating" for="bdinfo">BDInfo</label>
+                    </p>
+                    <p class="form__group">
+                        <input
                             id="keywords"
                             wire:model.live="keywords"
                             class="form__text"

--- a/resources/views/livewire/torrent-search.blade.php
+++ b/resources/views/livewire/torrent-search.blade.php
@@ -47,6 +47,15 @@
                 </p>
                 <p class="form__group">
                     <input
+                        id="bdinfo"
+                        wire:model.live="bdinfo"
+                        class="form__text"
+                        placeholder=" "
+                    />
+                    <label class="form__label form__label--floating" for="bdinfo">BDInfo</label>
+                </p>
+                <p class="form__group">
+                    <input
                         id="keywords"
                         wire:model.live="keywords"
                         class="form__text"

--- a/tests/Unit/DTO/TorrentSearchFiltersDTOTest.php
+++ b/tests/Unit/DTO/TorrentSearchFiltersDTOTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use App\DTO\TorrentSearchFiltersDTO;
+use App\Enums\UserGroup;
+use App\Models\Torrent;
+use App\Models\User;
+
+test('it filters torrents by bdinfo text', function (): void {
+    $this->actingAs(User::factory()->create([
+        'group_id' => UserGroup::USER->value,
+    ]));
+
+    $matching = Torrent::factory()->create([
+        'bdinfo' => 'Audio: French DTS-HD Master Audio',
+    ]);
+
+    Torrent::factory()->create([
+        'bdinfo' => 'Audio: English Dolby TrueHD',
+    ]);
+
+    $torrentIds = Torrent::query()
+        ->where((new TorrentSearchFiltersDTO(bdinfo: 'French DTS-HD'))->toSqlQueryBuilder())
+        ->pluck('id')
+        ->all();
+
+    expect($torrentIds)->toBe([$matching->id]);
+});


### PR DESCRIPTION
## Summary
- add a URL-backed BDInfo field to torrent advanced search
- apply BDInfo text/regex matching in the shared SQL torrent search filters
- expose the same BDInfo field beside MediaInfo in similar torrent filters

Closes #5273.

## Tests
- `git diff --check`
- `./node_modules/.bin/prettier --check resources/views/livewire/torrent-search.blade.php resources/views/livewire/similar-torrent.blade.php`
- `docker run --rm -v "$PWD":/app -w /app unit3d-php-test ./vendor/bin/pint app/DTO/TorrentSearchFiltersDTO.php app/Http/Livewire/TorrentSearch.php app/Http/Livewire/SimilarTorrent.php tests/Unit/DTO/TorrentSearchFiltersDTOTest.php`
- `docker run --rm --network unit3d-test-net -v "$PWD":/app -v /tmp/unit3d-test.env:/app/.env:ro -w /app unit3d-php-test sh -lc 'set -a; . ./.env; set +a; APP_ENV=testing APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_CONNECTION=mysql DB_HOST=unit3d-test-mysql DB_PORT=3306 DB_DATABASE=unit3d_test DB_USERNAME=unit3d DB_PASSWORD=secret CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync SCOUT_DRIVER=null php artisan test tests/Unit/DTO/TorrentSearchFiltersDTOTest.php --stop-on-failure'`
- `docker run --rm -v "$PWD":/app -v /tmp/unit3d-view.env:/app/.env:ro -w /app unit3d-php-test sh -lc 'set -a; . ./.env; set +a; APP_ENV=testing APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync SCOUT_DRIVER=null php artisan view:clear && php artisan view:cache'`

Note: the Laravel test and Blade cache check required a local-only route shim from `Route::livewire(...)` to `Route::get(...)` for the current Livewire 4 route boot issue. The shim was reverted before committing.
