### PR TITLE
Add RSS feed for articles

### DIFF
--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\DTO\TorrentSearchFiltersDTO;
+use App\Models\Article;
 use App\Models\Category;
 use App\Models\TmdbGenre;
 use App\Models\Group;
@@ -33,6 +34,22 @@ use Meilisearch\Endpoints\Indexes;
  */
 class RssController extends Controller
 {
+    /**
+     * Display an RSS feed of latest articles.
+     */
+    public function articles(Request $request): \Illuminate\Http\Response
+    {
+        return response()->view('rss.articles', [
+            'articles' => Article::query()
+                ->with('user')
+                ->latest()
+                ->take(50)
+                ->get(),
+            'user' => $request->user(),
+        ])
+            ->header('Content-Type', 'text/xml');
+    }
+
     /**
      * Display a listing of the RSS resource.
      */

--- a/resources/views/rss/articles.blade.php
+++ b/resources/views/rss/articles.blade.php
@@ -1,0 +1,37 @@
+@php
+    echo '<?xml version="1.0" encoding="UTF-8" ?>';
+@endphp
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>{{ config('other.title') }}: {{ __('common.news') }}</title>
+        <link>{{ route('articles.index') }}</link>
+        <description>{{ __('articles.meta-articles') }}</description>
+        <atom:link href="{{ route('rss.articles.rsskey', ['rsskey' => $user->rsskey]) }}"
+                   type="application/rss+xml" rel="self"></atom:link>
+        <copyright>{{ config('other.title') }} {{ now()->year }}</copyright>
+        <language>en-us</language>
+        <lastBuildDate>{{ $articles->first()?->created_at?->toRssString() ?? now()->toRssString() }}</lastBuildDate>
+        <ttl>5</ttl>
+        @foreach ($articles as $article)
+            @php
+                $description = preg_replace('#\[[^\]]+\]#', '', Str::limit(strip_tags($article->content), 500, '...'));
+                $description = str_replace(']]>', ']]&gt;', $description ?? '');
+                $content = (new \hdvinnie\LaravelJoyPixels\LaravelJoyPixels())
+                    ->toImage((new \App\Helpers\Linkify())->linky((new \App\Helpers\Bbcode())->parse($article->content)));
+                $content = str_replace(']]>', ']]&gt;', $content);
+            @endphp
+            <item>
+                <title>{{ $article->title }}</title>
+                <link>{{ route('articles.show', ['article' => $article]) }}</link>
+                <guid isPermaLink="false">article-{{ $article->id }}</guid>
+                <description><![CDATA[{!! $description !!}]]></description>
+                <content:encoded><![CDATA[{!! $content !!}]]></content:encoded>
+                <dc:creator>{{ $article->user->username }}</dc:creator>
+                <pubDate>{{ $article->created_at->toRssString() }}</pubDate>
+            </item>
+        @endforeach
+    </channel>
+</rss>

--- a/resources/views/rss/index.blade.php
+++ b/resources/views/rss/index.blade.php
@@ -37,6 +37,32 @@
 @section('page', 'page__rss--index')
 
 @section('main')
+    <section class="panelV2" id="news">
+        <h2 class="panel__heading">{{ __('common.news') }}</h2>
+        <div class="data-table-wrapper">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>{{ __('common.name') }}</th>
+                        <th>{{ __('rss.type') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            <a
+                                href="{{ route('rss.articles.rsskey', ['rsskey' => auth()->user()->rsskey]) }}"
+                                target="_blank"
+                            >
+                                {{ __('common.news') }}
+                            </a>
+                        </td>
+                        <td>{{ __('rss.rss-feed') }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
     <section class="panelV2" id="public">
         <h2 class="panel__heading">{{ __('rss.public') }}</h2>
         <div class="data-table-wrapper">

--- a/routes/rss.php
+++ b/routes/rss.php
@@ -30,6 +30,7 @@ if (config('unit3d.root_url_override')) {
 
 Route::middleware([Authenticate::using('rss'), CheckIfBanned::class, EnsureEmailIsVerified::class])->group(function (): void {
     // RSS (RSS Key Auth)
+    Route::get('/rss/articles.{rsskey}', [App\Http\Controllers\RssController::class, 'articles'])->name('rss.articles.rsskey');
     Route::get('/rss/{id}.{rsskey}', [App\Http\Controllers\RssController::class, 'show'])->name('rss.show.rsskey');
     Route::get('/torrent/download/{id}.{rsskey}', [App\Http\Controllers\TorrentDownloadController::class, 'store'])->name('torrent.download.rsskey');
 });

--- a/tests/Feature/Http/Controllers/ArticleRssControllerTest.php
+++ b/tests/Feature/Http/Controllers/ArticleRssControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserGroup;
+use App\Models\Article;
+use App\Models\User;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+
+test('articles rss feed returns the latest articles', function (): void {
+    $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+
+    $user = User::factory()->create([
+        'group_id' => UserGroup::USER->value,
+    ]);
+
+    $olderArticle = Article::factory()->create([
+        'title'      => 'Older tracker announcement',
+        'content'    => 'Older update',
+        'created_at' => now()->subDay(),
+        'updated_at' => now()->subDay(),
+    ]);
+
+    $latestArticle = Article::factory()->create([
+        'title'      => 'Latest tracker announcement',
+        'content'    => '[b]Important[/b] tracker update',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $response = $this->get(route('rss.articles.rsskey', ['rsskey' => $user->rsskey]));
+
+    $response->assertOk();
+    $response->assertSee('<rss version="2.0"', false);
+    $response->assertSee(route('articles.show', ['article' => $latestArticle]), false);
+    $response->assertSee(route('articles.show', ['article' => $olderArticle]), false);
+    $response->assertSeeInOrder([
+        'Latest tracker announcement',
+        'Older tracker announcement',
+    ]);
+});


### PR DESCRIPTION
## Summary
- add an RSS-key authenticated `/rss/articles.{rsskey}` feed for the latest articles/news
- expose the news feed URL on the existing RSS page
- include article links, authors, publication dates, summaries, and rendered article content in the feed

Closes #4827.

## Tests
- `git diff --check`
- `./node_modules/.bin/prettier --check resources/views/rss/index.blade.php`
- `docker run --rm -v "$PWD":/app -w /app unit3d-php-test ./vendor/bin/pint routes/rss.php app/Http/Controllers/RssController.php tests/Feature/Http/Controllers/ArticleRssControllerTest.php`
- `docker run --rm --network unit3d-test-net -v "$PWD":/app -v /tmp/unit3d-test.env:/app/.env:ro -w /app unit3d-php-test sh -lc 'set -a; . ./.env; set +a; APP_ENV=testing APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= DB_CONNECTION=mysql DB_HOST=unit3d-test-mysql DB_PORT=3306 DB_DATABASE=unit3d_test DB_USERNAME=unit3d DB_PASSWORD=secret CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync SCOUT_DRIVER=null php artisan test tests/Feature/Http/Controllers/ArticleRssControllerTest.php --stop-on-failure'`
- `docker run --rm -v "$PWD":/app -v /tmp/unit3d-view.env:/app/.env:ro -w /app unit3d-php-test sh -lc 'set -a; . ./.env; set +a; APP_ENV=testing APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync SCOUT_DRIVER=null php artisan view:clear && php artisan view:cache'`

Note: the Laravel test and Blade cache check required a local-only route shim from `Route::livewire(...)` to `Route::get(...)` for the current Livewire 4 route boot issue. The shim was reverted before committing. The focused RSS test disables Redis-backed throttling because the local PHP image lacks `phpredis`.
