### PR TITLE
Improve TMDB trailer selection

### DIFF
--- a/app/Services/Tmdb/Client/Movie.php
+++ b/app/Services/Tmdb/Client/Movie.php
@@ -337,7 +337,7 @@ class Movie
                 'title_sort'        => $titleSort,
                 'vote_average'      => $this->data['vote_average'] ?? null,
                 'vote_count'        => $this->data['vote_count'] ?? null,
-                'trailer'           => $this->data['videos']['results'][0]['key'] ?? null,
+                'trailer'           => $this->tmdb->trailer($this->data),
             ];
         }
 

--- a/app/Services/Tmdb/Client/TV.php
+++ b/app/Services/Tmdb/Client/TV.php
@@ -388,7 +388,7 @@ class TV
                 'status'             => $this->data['status'] ?? null,
                 'vote_average'       => $this->data['vote_average'] ?? null,
                 'vote_count'         => $this->data['vote_count'] ?? null,
-                'trailer'            => $this->data['videos']['results'][0]['key'] ?? null,
+                'trailer'            => $this->tmdb->trailer($this->data),
             ];
         }
 

--- a/app/Services/Tmdb/TMDB.php
+++ b/app/Services/Tmdb/TMDB.php
@@ -35,11 +35,43 @@ class TMDB
      */
     public function trailer(array $array): ?string
     {
-        if (isset($array['videos']['results'])) {
-            return 'https://www.youtube.com/embed/'.$array['videos']['results'][0]['key'];
+        foreach ($array['videos']['results'] ?? [] as $video) {
+            if (!\is_array($video) || strcasecmp((string) ($video['type'] ?? ''), 'Trailer') !== 0) {
+                continue;
+            }
+
+            $key = $video['key'] ?? null;
+            $site = strtolower((string) ($video['site'] ?? ''));
+
+            if (!\is_string($key) || $key === '' || !\in_array($site, ['youtube', 'vimeo'], true)) {
+                continue;
+            }
+
+            return $site.':'.$key;
         }
 
         return null;
+    }
+
+    public function trailerEmbedUrl(?string $trailer): ?string
+    {
+        if ($trailer === null || $trailer === '') {
+            return null;
+        }
+
+        [$site, $key] = str_contains($trailer, ':')
+            ? explode(':', $trailer, 2)
+            : ['youtube', $trailer];
+
+        if ($key === '') {
+            return null;
+        }
+
+        return match (strtolower($site)) {
+            'youtube' => 'https://www.youtube-nocookie.com/embed/'.$key,
+            'vimeo'   => 'https://player.vimeo.com/video/'.$key,
+            default   => null,
+        };
     }
 
     /**

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -478,7 +478,8 @@ return [
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src
         'child-src' => [
             'allow' => [
-                'https://www.youtube-nocookie.com/embed/'
+                'https://www.youtube-nocookie.com/embed/',
+                'https://player.vimeo.com/video/',
             ],
         ],
 
@@ -553,6 +554,7 @@ return [
 
             'allow' => [
                 'https://www.youtube-nocookie.com/embed/',
+                'https://player.vimeo.com/video/',
             ],
         ],
 

--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -1,3 +1,4 @@
+@php($trailerEmbedUrl = (new \App\Services\Tmdb\TMDB())->trailerEmbedUrl($meta?->trailer))
 <section class="meta">
     @if ($meta?->backdrop)
         <img class="meta__backdrop" src="{{ tmdb_image('back_big', $meta->backdrop) }}" alt="" />
@@ -132,7 +133,7 @@
                 {{ round(($meta->vote_average ?? 0) * 10) }}%
             </span>
         </li>
-        @if ($meta?->trailer)
+        @if ($trailerEmbedUrl)
             <li class="work__trailer show-trailer">
                 <a class="work__trailer-link" href="#">
                     {{ __('torrent.view-trailer') }}
@@ -400,7 +401,7 @@
     </div>
 </section>
 
-@if ($meta?->trailer)
+@if ($trailerEmbedUrl)
     <script nonce="{{ HDVinnie\SecureHeaders\SecureHeaders::nonce() }}">
         document.getElementsByClassName('show-trailer')[0].addEventListener('click', (e) => {
             e.preventDefault();
@@ -409,7 +410,7 @@
                 showCloseButton: true,
                 background: 'rgb(35,35,35)',
                 width: 970,
-                html: '<iframe width="930" height="523" src="https://www.youtube-nocookie.com/embed/{{ $meta->trailer }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
+                html: '<iframe width="930" height="523" src="{{ $trailerEmbedUrl }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
                 title: '<i style="color: #a5a5a5;">{{ $meta->title }} trailer</i>',
                 text: '',
             });

--- a/resources/views/torrent/partials/tv-meta.blade.php
+++ b/resources/views/torrent/partials/tv-meta.blade.php
@@ -1,3 +1,4 @@
+@php($trailerEmbedUrl = (new \App\Services\Tmdb\TMDB())->trailerEmbedUrl($meta?->trailer))
 <section class="meta">
     @if ($meta?->backdrop)
         <img class="meta__backdrop" src="{{ tmdb_image('back_big', $meta->backdrop) }}" alt="" />
@@ -131,7 +132,7 @@
                 {{ round(($meta->vote_average ?? 0) * 10) }}%
             </span>
         </li>
-        @if ($meta?->trailer)
+        @if ($trailerEmbedUrl)
             <li class="work__trailer show-trailer">
                 <a class="work__trailer-link" href="#">
                     {{ __('torrent.view-trailer') }}
@@ -340,7 +341,7 @@
     </div>
 </section>
 
-@if ($meta?->trailer)
+@if ($trailerEmbedUrl)
     <script nonce="{{ HDVinnie\SecureHeaders\SecureHeaders::nonce() }}">
         document.getElementsByClassName('show-trailer')[0].addEventListener('click', (e) => {
             e.preventDefault();
@@ -349,7 +350,7 @@
                 showCloseButton: true,
                 background: 'rgb(35,35,35)',
                 width: 970,
-                html: '<iframe width="930" height="523" src="https://www.youtube-nocookie.com/embed/{{ $meta->trailer }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
+                html: '<iframe width="930" height="523" src="{{ $trailerEmbedUrl }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
                 title: '<i style="color: #a5a5a5;">{{ $meta->name }} trailer</i>',
                 text: '',
             });

--- a/tests/Unit/Services/Tmdb/TMDBTest.php
+++ b/tests/Unit/Services/Tmdb/TMDBTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Tmdb\TMDB;
+
+test('it selects the first supported trailer video', function (): void {
+    $tmdb = new TMDB();
+
+    $trailer = $tmdb->trailer([
+        'videos' => [
+            'results' => [
+                [
+                    'key'  => 'teaser-key',
+                    'site' => 'YouTube',
+                    'type' => 'Teaser',
+                ],
+                [
+                    'key'  => 'vimeo-key',
+                    'site' => 'Vimeo',
+                    'type' => 'Trailer',
+                ],
+            ],
+        ],
+    ]);
+
+    expect($trailer)->toBe('vimeo:vimeo-key');
+});
+
+test('it builds trailer embed urls for supported providers and legacy youtube keys', function (): void {
+    $tmdb = new TMDB();
+
+    expect($tmdb->trailerEmbedUrl('youtube:youtube-key'))->toBe('https://www.youtube-nocookie.com/embed/youtube-key')
+        ->and($tmdb->trailerEmbedUrl('vimeo:vimeo-key'))->toBe('https://player.vimeo.com/video/vimeo-key')
+        ->and($tmdb->trailerEmbedUrl('legacy-youtube-key'))->toBe('https://www.youtube-nocookie.com/embed/legacy-youtube-key')
+        ->and($tmdb->trailerEmbedUrl('vimeo:'))->toBeNull()
+        ->and($tmdb->trailerEmbedUrl('dailymotion:unsupported-key'))->toBeNull();
+});


### PR DESCRIPTION
## Summary
- filter TMDB videos to supported Trailer entries instead of blindly using the first video
- store provider-prefixed trailer keys for YouTube and Vimeo, while keeping legacy YouTube keys renderable
- render provider-specific embed URLs and allow Vimeo player embeds in CSP

Closes #5309

## Tests
- git diff --check
- ./node_modules/.bin/prettier --check resources/views/torrent/partials/movie-meta.blade.php resources/views/torrent/partials/tv-meta.blade.php config/secure-headers.php
- vendor/bin/pint app/Services/Tmdb/TMDB.php app/Services/Tmdb/Client/Movie.php app/Services/Tmdb/Client/TV.php tests/Unit/Services/Tmdb/TMDBTest.php
- php artisan test tests/Unit/Services/Tmdb/TMDBTest.php --stop-on-failure (Docker/MySQL)
- php artisan view:clear && php artisan view:cache (Docker; local-only Livewire route shim used for the current route boot issue and reverted before commit)