### PR TITLE
Create reseed requests from dead torrent downloads

### DIFF
--- a/app/Enums/TorrentReseedRequestResult.php
+++ b/app/Enums/TorrentReseedRequestResult.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum TorrentReseedRequestResult
+{
+    case AlreadyRequested;
+    case Counted;
+    case Created;
+    case Ineligible;
+}

--- a/app/Http/Controllers/TorrentDownloadController.php
+++ b/app/Http/Controllers/TorrentDownloadController.php
@@ -23,12 +23,17 @@ use App\Models\Torrent;
 use App\Models\TorrentDownload;
 use App\Models\User;
 use App\Models\FreeleechToken;
+use App\Services\TorrentReseedService;
 use App\Services\Unit3dAnnounce;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
 class TorrentDownloadController extends Controller
 {
+    public function __construct(private readonly TorrentReseedService $torrentReseedService)
+    {
+    }
+
     /**
      * Download Check.
      */
@@ -110,6 +115,8 @@ class TorrentDownloadController extends Controller
 
             $torrent->searchable();
         }
+
+        $this->torrentReseedService->request($torrent, $user);
 
         return response()->streamDownload(
             function () use ($id, $user, $torrent): void {

--- a/app/Http/Controllers/TorrentReseedController.php
+++ b/app/Http/Controllers/TorrentReseedController.php
@@ -16,12 +16,9 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Models\History;
+use App\Enums\TorrentReseedRequestResult;
 use App\Models\Torrent;
-use App\Models\TorrentReseed;
-use App\Models\User;
-use App\Notifications\NewReseedRequest;
-use App\Repositories\ChatRepository;
+use App\Services\TorrentReseedService;
 use Illuminate\Http\Request;
 
 class TorrentReseedController extends Controller
@@ -29,7 +26,7 @@ class TorrentReseedController extends Controller
     /**
      * TorrentReseedController Constructor.
      */
-    public function __construct(private readonly ChatRepository $chatRepository)
+    public function __construct(private readonly TorrentReseedService $torrentReseedService)
     {
     }
 
@@ -47,54 +44,17 @@ class TorrentReseedController extends Controller
     public function store(Request $request, int $id): \Illuminate\Http\RedirectResponse
     {
         $torrent = Torrent::query()->findOrFail($id);
-        $userId = $request->user()->id;
+        $result = $this->torrentReseedService->request($torrent, $request->user());
 
-        // Check if this user has already made a reseed request for this torrent
-        $existingUserReseed = TorrentReseed::query()
-            ->where('torrent_id', '=', $torrent->id)
-            ->where('user_id', '=', $userId)
-            ->first();
-
-        if ($existingUserReseed) {
-            return to_route('torrents.show', ['id' => $torrent->id])
-                ->withErrors('You have already made a reseed request for this torrent.');
-        }
-
-        // Check seeders condition and if a request already exists for this torrent
-        $existingReseed = TorrentReseed::query()->where('torrent_id', '=', $torrent->id)->first();
-
-        if ($torrent->seeders <= 2) {
-            if ($existingReseed) {
-                $existingReseed->increment('requests_count');
-                $existingReseed->save();
-
-                return to_route('torrents.show', ['id' => $torrent->id])
-                    ->with('success', 'A reseed request already exists. Your request has been counted.');
-            }
-            TorrentReseed::query()->create([
-                'torrent_id'     => $torrent->id,
-                'user_id'        => $userId,
-                'requests_count' => 1,
-            ]);
-
-            // Send notifications
-            $potentialReseeds = History::query()->where('torrent_id', '=', $torrent->id)->where('active', '=', 0)->get();
-
-            foreach ($potentialReseeds as $potentialReseed) {
-                User::query()->find($potentialReseed->user_id)->notify(new NewReseedRequest($torrent));
-            }
-
-            $torrentUrl = href_torrent($torrent);
-
-            $this->chatRepository->systemMessage(
-                \sprintf('Ladies and Gents, a reseed request was just placed on [url=%s]%s[/url] can you help out?', $torrentUrl, $torrent->name)
-            );
-
-            return to_route('torrents.show', ['id' => $torrent->id])
-                ->with('success', 'A notification has been sent to all users that downloaded this torrent along with original uploader!');
-        }
-
-        return to_route('torrents.show', ['id' => $torrent->id])
-            ->withErrors('This torrent doesn\'t meet the rules for a reseed request.');
+        return match ($result) {
+            TorrentReseedRequestResult::AlreadyRequested => to_route('torrents.show', ['id' => $torrent->id])
+                ->withErrors('You have already made a reseed request for this torrent.'),
+            TorrentReseedRequestResult::Counted => to_route('torrents.show', ['id' => $torrent->id])
+                ->with('success', 'A reseed request already exists. Your request has been counted.'),
+            TorrentReseedRequestResult::Created => to_route('torrents.show', ['id' => $torrent->id])
+                ->with('success', 'A notification has been sent to all users that downloaded this torrent along with original uploader!'),
+            TorrentReseedRequestResult::Ineligible => to_route('torrents.show', ['id' => $torrent->id])
+                ->withErrors('This torrent doesn\'t meet the rules for a reseed request.'),
+        };
     }
 }

--- a/app/Services/TorrentReseedService.php
+++ b/app/Services/TorrentReseedService.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\TorrentReseedRequestResult;
+use App\Models\History;
+use App\Models\Torrent;
+use App\Models\TorrentReseed;
+use App\Models\User;
+use App\Notifications\NewReseedRequest;
+use App\Repositories\ChatRepository;
+
+final readonly class TorrentReseedService
+{
+    public function __construct(private ChatRepository $chatRepository)
+    {
+    }
+
+    public function request(Torrent $torrent, User $user): TorrentReseedRequestResult
+    {
+        $existingUserReseed = TorrentReseed::query()
+            ->where('torrent_id', '=', $torrent->id)
+            ->where('user_id', '=', $user->id)
+            ->first();
+
+        if ($existingUserReseed) {
+            return TorrentReseedRequestResult::AlreadyRequested;
+        }
+
+        if ($torrent->seeders > 2) {
+            return TorrentReseedRequestResult::Ineligible;
+        }
+
+        $existingReseed = TorrentReseed::query()->where('torrent_id', '=', $torrent->id)->first();
+
+        if ($existingReseed) {
+            $existingReseed->increment('requests_count');
+
+            return TorrentReseedRequestResult::Counted;
+        }
+
+        TorrentReseed::query()->create([
+            'torrent_id'     => $torrent->id,
+            'user_id'        => $user->id,
+            'requests_count' => 1,
+        ]);
+
+        $potentialReseeds = History::query()
+            ->where('torrent_id', '=', $torrent->id)
+            ->where('active', '=', 0)
+            ->get();
+
+        foreach ($potentialReseeds as $potentialReseed) {
+            User::query()->find($potentialReseed->user_id)?->notify(new NewReseedRequest($torrent));
+        }
+
+        $torrentUrl = href_torrent($torrent);
+
+        $this->chatRepository->systemMessage(
+            \sprintf('Ladies and Gents, a reseed request was just placed on [url=%s]%s[/url] can you help out?', $torrentUrl, $torrent->name)
+        );
+
+        return TorrentReseedRequestResult::Created;
+    }
+}

--- a/tests/Feature/Http/Controllers/TorrentDownloadAutoReseedTest.php
+++ b/tests/Feature/Http/Controllers/TorrentDownloadAutoReseedTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+declare(strict_types=1);
+
+use App\Helpers\Bencode;
+use App\Models\History;
+use App\Models\Torrent;
+use App\Models\TorrentReseed;
+use App\Models\User;
+use App\Notifications\NewReseedRequest;
+use App\Repositories\ChatRepository;
+use App\Http\Middleware\UpdateLastAction;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+
+beforeEach(function (): void {
+    $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+    $this->withoutMiddleware(UpdateLastAction::class);
+
+    Storage::fake('torrent-files');
+    Notification::fake();
+});
+
+function storeDownloadableTorrentFile(Torrent $torrent): void
+{
+    Storage::disk('torrent-files')->put($torrent->file_name, Bencode::bencode([
+        'announce' => 'https://tracker.example/announce',
+        'info'     => [
+            'length'       => 1,
+            'name'         => $torrent->name,
+            'piece length' => 16_384,
+            'pieces'       => str_repeat('a', 20),
+        ],
+    ]));
+}
+
+test('rss torrent download creates a reseed request for a dead torrent', function (): void {
+    $requester = User::factory()->create([
+        'can_download' => true,
+        'downloaded'   => 1,
+        'uploaded'     => 10_000,
+    ]);
+    $previousDownloader = User::factory()->create();
+    $torrent = Torrent::factory()->create([
+        'seeders' => 0,
+    ]);
+    History::factory()->create([
+        'active'     => false,
+        'torrent_id' => $torrent->id,
+        'user_id'    => $previousDownloader->id,
+    ]);
+    storeDownloadableTorrentFile($torrent);
+
+    $this->mock(ChatRepository::class, function ($mock): void {
+        $mock->shouldReceive('systemMessage')->once();
+    });
+
+    $response = $this->get(route('torrent.download.rsskey', [
+        'id'     => $torrent->id,
+        'rsskey' => $requester->rsskey,
+    ]));
+
+    $response->assertOk();
+
+    assertDatabaseHas('torrent_downloads', [
+        'torrent_id' => $torrent->id,
+        'user_id'    => $requester->id,
+    ]);
+    assertDatabaseHas('torrent_reseeds', [
+        'requests_count' => 1,
+        'torrent_id'     => $torrent->id,
+        'user_id'        => $requester->id,
+    ]);
+    Notification::assertSentTo($previousDownloader, NewReseedRequest::class);
+});
+
+test('site torrent download does not create a reseed request for a healthy torrent', function (): void {
+    $requester = User::factory()->create([
+        'can_download' => true,
+        'downloaded'   => 1,
+        'uploaded'     => 10_000,
+    ]);
+    $torrent = Torrent::factory()->create([
+        'seeders' => 3,
+    ]);
+    storeDownloadableTorrentFile($torrent);
+
+    $this->mock(ChatRepository::class, function ($mock): void {
+        $mock->shouldReceive('systemMessage')->never();
+    });
+
+    $response = $this->actingAs($requester)->get(route('download', ['id' => $torrent->id]));
+
+    $response->assertOk();
+
+    assertDatabaseHas('torrent_downloads', [
+        'torrent_id' => $torrent->id,
+        'user_id'    => $requester->id,
+    ]);
+    assertDatabaseMissing('torrent_reseeds', [
+        'torrent_id' => $torrent->id,
+    ]);
+    expect(TorrentReseed::query()->where('torrent_id', '=', $torrent->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- extract reseed request creation/counting into a shared service while preserving the manual reseed button responses
- call the shared reseed service after valid site, RSS, or API torrent downloads start
- add coverage for RSS auto-reseed creation on dead torrents and no-op behavior for healthy torrents

Closes #5423

## Tests
- git diff --check
- vendor/bin/pint app/Enums/TorrentReseedRequestResult.php app/Services/TorrentReseedService.php app/Http/Controllers/TorrentDownloadController.php app/Http/Controllers/TorrentReseedController.php tests/Feature/Http/Controllers/TorrentDownloadAutoReseedTest.php
- php artisan test tests/Feature/Http/Controllers/TorrentDownloadAutoReseedTest.php --stop-on-failure (Docker/MySQL; 2 passed, 10 assertions)

Local note: the focused test disables Redis-backed throttle/last-action middleware because the local PHP test image lacks phpredis. Test bootstrap also required the same local-only Livewire route shim on current development; the shim was reverted before commit.