### PR TITLE
Add API seedbox management

### DIFF
--- a/app/Http/Controllers/API/SeedboxController.php
+++ b/app/Http/Controllers/API/SeedboxController.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Http\Controllers\API;
+
+use App\Models\Seedbox;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\Rule;
+
+class SeedboxController extends BaseController
+{
+    public function index(Request $request): JsonResponse
+    {
+        return response()->json([
+            'data' => $request->user()
+                ->seedboxes()
+                ->latest()
+                ->get()
+                ->map(fn (Seedbox $seedbox): array => $this->serializeSeedbox($seedbox)),
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $userSeedboxes = Seedbox::query()->where('user_id', '=', $user->id)->get(['ip', 'name']);
+        $seedboxIps = $userSeedboxes->pluck('ip')->filter(fn ($ip) => filter_var($ip, FILTER_VALIDATE_IP) !== false);
+        $seedboxNames = $userSeedboxes->pluck('name');
+
+        $validated = $request->validate(
+            [
+                'name' => [
+                    'required',
+                    'alpha_num',
+                    Rule::notIn($seedboxNames),
+                ],
+                'ip' => [
+                    'bail',
+                    'required',
+                    'ip',
+                    Rule::notIn($seedboxIps),
+                ],
+            ],
+            [
+                'name.not_in' => 'You have already used this seedbox name.',
+                'ip.not_in'   => 'You have already registered this seedbox IP.',
+            ]
+        );
+
+        $seedbox = Seedbox::query()->create([
+            'user_id' => $user->id,
+            'name'    => $validated['name'],
+            'ip'      => $validated['ip'],
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $this->serializeSeedbox($seedbox),
+            'message' => trans('user.seedbox-added-success'),
+        ], 201);
+    }
+
+    public function destroy(Request $request, int $seedbox): JsonResponse
+    {
+        $seedbox = Seedbox::query()->findOrFail($seedbox);
+
+        abort_unless((int) $seedbox->user_id === (int) $request->user()->id, 403);
+
+        $seedbox->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => trans('user.seedbox-deleted-success'),
+        ]);
+    }
+
+    /**
+     * @return array{id: int, name: string, ip: string, created_at: string|null, updated_at: string|null}
+     */
+    private function serializeSeedbox(Seedbox $seedbox): array
+    {
+        return [
+            'id'         => $seedbox->id,
+            'name'       => $seedbox->name,
+            'ip'         => $seedbox->ip,
+            'created_at' => $seedbox->created_at?->toISOString(),
+            'updated_at' => $seedbox->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -58,6 +58,11 @@ Route::middleware([Authenticate::using(AuthGuard::API->value), CheckIfBanned::cl
 
     // User
     Route::get('/user', [App\Http\Controllers\API\UserController::class, 'show']);
+    Route::prefix('user/seedboxes')->group(function (): void {
+        Route::get('/', [App\Http\Controllers\API\SeedboxController::class, 'index']);
+        Route::post('/', [App\Http\Controllers\API\SeedboxController::class, 'store']);
+        Route::delete('/{seedbox}', [App\Http\Controllers\API\SeedboxController::class, 'destroy'])->whereNumber('seedbox');
+    });
 });
 
 // Internal front-end web API routes

--- a/tests/Feature/Http/Controllers/API/SeedboxControllerTest.php
+++ b/tests/Feature/Http/Controllers/API/SeedboxControllerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Enums\AuthGuard;
+use App\Models\Seedbox;
+use App\Models\User;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+
+use function Pest\Laravel\assertDatabaseMissing;
+
+beforeEach(function (): void {
+    $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+});
+
+test('index returns the authenticated users seedboxes', function (): void {
+    $user = User::factory()->create();
+    $seedbox = Seedbox::factory()->create([
+        'ip'      => '203.0.113.10',
+        'name'    => 'HomeSeedbox',
+        'user_id' => $user->id,
+    ]);
+    $otherSeedbox = Seedbox::factory()->create([
+        'ip'   => '203.0.113.11',
+        'name' => 'OtherSeedbox',
+    ]);
+
+    $response = $this->actingAs($user, AuthGuard::API->value)->getJson('/api/user/seedboxes');
+
+    $response->assertOk()
+        ->assertJsonFragment([
+            'id'   => $seedbox->id,
+            'ip'   => '203.0.113.10',
+            'name' => 'HomeSeedbox',
+        ])
+        ->assertJsonMissing([
+            'id'   => $otherSeedbox->id,
+            'ip'   => '203.0.113.11',
+            'name' => 'OtherSeedbox',
+        ]);
+});
+
+test('store creates a seedbox for the authenticated user', function (): void {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user, AuthGuard::API->value)->postJson('/api/user/seedboxes', [
+        'ip'   => '203.0.113.12',
+        'name' => 'WeeklyVpn',
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.ip', '203.0.113.12')
+        ->assertJsonPath('data.name', 'WeeklyVpn');
+
+    $seedbox = Seedbox::query()->where('user_id', '=', $user->id)->sole();
+
+    expect($seedbox->ip)->toBe('203.0.113.12')
+        ->and($seedbox->name)->toBe('WeeklyVpn');
+});
+
+test('store rejects duplicate seedbox names and ips for the authenticated user', function (): void {
+    $user = User::factory()->create();
+    Seedbox::factory()->create([
+        'ip'      => '203.0.113.13',
+        'name'    => 'ExistingSeedbox',
+        'user_id' => $user->id,
+    ]);
+
+    $response = $this->actingAs($user, AuthGuard::API->value)->postJson('/api/user/seedboxes', [
+        'ip'   => '203.0.113.13',
+        'name' => 'ExistingSeedbox',
+    ]);
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['ip', 'name']);
+});
+
+test('destroy rejects seedboxes owned by another user', function (): void {
+    $user = User::factory()->create();
+    $otherSeedbox = Seedbox::factory()->create([
+        'ip'   => '203.0.113.15',
+        'name' => 'OtherVpn',
+    ]);
+
+    $this->actingAs($user, AuthGuard::API->value)
+        ->deleteJson('/api/user/seedboxes/'.$otherSeedbox->id)
+        ->assertForbidden();
+
+    $this->assertModelExists($otherSeedbox);
+});
+
+test('destroy deletes the authenticated users seedbox', function (): void {
+    $user = User::factory()->create();
+    $seedbox = Seedbox::factory()->create([
+        'ip'      => '203.0.113.14',
+        'name'    => 'OldVpn',
+        'user_id' => $user->id,
+    ]);
+
+    $this->actingAs($user, AuthGuard::API->value)
+        ->deleteJson('/api/user/seedboxes/'.$seedbox->id)
+        ->assertOk()
+        ->assertJsonPath('success', true);
+
+    assertDatabaseMissing('seedboxes', [
+        'id' => $seedbox->id,
+    ]);
+});


### PR DESCRIPTION
## Summary
- add authenticated API endpoints to list, create, and delete the current user's registered seedbox IP entries
- reuse the existing per-user duplicate name/IP validation behavior for API creates
- enforce ownership when deleting seedbox records

Closes #3923

## Tests
- git diff --check
- vendor/bin/pint app/Http/Controllers/API/SeedboxController.php routes/api.php tests/Feature/Http/Controllers/API/SeedboxControllerTest.php
- php artisan test tests/Feature/Http/Controllers/API/SeedboxControllerTest.php --stop-on-failure (Docker/MySQL; 5 passed, 22 assertions)

Local note: the focused test disables Redis-backed throttling because the local PHP test image lacks phpredis. Test bootstrap also required the same local-only Livewire route shim on current development; the shim was reverted before commit.