### PR TITLE
Add notes to similar pages

### DIFF
--- a/app/Http/Controllers/SimilarTorrentController.php
+++ b/app/Http/Controllers/SimilarTorrentController.php
@@ -26,6 +26,8 @@ use App\Models\TorrentRequest;
 use App\Models\TmdbTv;
 use App\Services\Igdb\IgdbScraper;
 use App\Services\Tmdb\TMDBScraper;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class SimilarTorrentController extends Controller
@@ -105,8 +107,26 @@ class SimilarTorrentController extends Controller
         ]);
     }
 
-    public function update(Request $request, Category $category, int $metaId): \Illuminate\Http\RedirectResponse
+    public function update(Request $request, Category $category, int $metaId): RedirectResponse
     {
+        if ($request->has('note')) {
+            abort_unless($request->user()->group->is_modo || $request->user()->group->is_torrent_modo, 403);
+
+            $validated = $request->validate([
+                'note' => [
+                    'nullable',
+                    'string',
+                    'max:65535',
+                ],
+            ]);
+
+            $this->meta($category, $metaId)->update([
+                'note' => blank($validated['note'] ?? null) ? null : $validated['note'],
+            ]);
+
+            return back()->with('success', 'Similar page note updated successfully.');
+        }
+
         if (!($category->movie_meta || $category->tv_meta || $category->game_meta)) {
             return to_route('torrents.similar', ['category_id' => $category->id, 'tmdb' => $metaId])
                 ->withErrors('This meta type can not be updated.');
@@ -142,5 +162,15 @@ class SimilarTorrentController extends Controller
         };
 
         return back()->with('success', 'Metadata update queued successfully.');
+    }
+
+    private function meta(Category $category, int $metaId): Model
+    {
+        return match (true) {
+            $category->movie_meta => TmdbMovie::query()->findOrFail($metaId),
+            $category->tv_meta    => TmdbTv::query()->findOrFail($metaId),
+            $category->game_meta  => IgdbGame::query()->findOrFail($metaId),
+            default               => abort(404, 'No Similar Torrents Found'),
+        };
     }
 }

--- a/app/Models/IgdbGame.php
+++ b/app/Models/IgdbGame.php
@@ -34,6 +34,7 @@ use AllowDynamicProperties;
  * @property ?float                      $rating
  * @property ?int                        $rating_count
  * @property ?string                     $first_video_video_id
+ * @property ?string                     $note
  * @property ?\Illuminate\Support\Carbon $created_at
  * @property ?\Illuminate\Support\Carbon $updated_at
  */

--- a/app/Models/TmdbMovie.php
+++ b/app/Models/TmdbMovie.php
@@ -51,6 +51,7 @@ use AllowDynamicProperties;
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property string|null                     $trailer
+ * @property string|null                     $note
  */
 #[AllowDynamicProperties]
 final class TmdbMovie extends Model

--- a/app/Models/TmdbTv.php
+++ b/app/Models/TmdbTv.php
@@ -58,6 +58,7 @@ use AllowDynamicProperties;
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property string|null                     $trailer
+ * @property string|null                     $note
  */
 #[AllowDynamicProperties]
 final class TmdbTv extends Model

--- a/database/migrations/2026_05_13_050000_add_note_to_metadata_tables.php
+++ b/database/migrations/2026_05_13_050000_add_note_to_metadata_tables.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tmdb_movies', function (Blueprint $table): void {
+            $table->text('note')->nullable()->after('trailer');
+        });
+
+        Schema::table('tmdb_tv', function (Blueprint $table): void {
+            $table->text('note')->nullable()->after('trailer');
+        });
+
+        Schema::table('igdb_games', function (Blueprint $table): void {
+            $table->text('note')->nullable()->after('first_video_video_id');
+        });
+    }
+};

--- a/resources/views/torrent/partials/similar-note.blade.php
+++ b/resources/views/torrent/partials/similar-note.blade.php
@@ -1,0 +1,73 @@
+@php
+    $canEditSimilarNote = auth()->user()->group->is_modo || auth()->user()->group->is_torrent_modo;
+@endphp
+
+@if (filled($meta->note) || $canEditSimilarNote)
+    <section class="panelV2">
+        <header class="panel__header">
+            <h2 class="panel__heading">
+                <i class="{{ config('other.font-awesome') }} fa-sticky-note"></i>
+                Similar page note
+            </h2>
+            @if ($canEditSimilarNote)
+                <div class="panel__actions">
+                    <div class="panel__action">
+                        <button
+                            class="form__button form__button--text"
+                            popovertarget="similar-note-edit"
+                        >
+                            {{ filled($meta->note) ? __('common.edit') : __('common.add') }}
+                        </button>
+                    </div>
+                </div>
+            @endif
+        </header>
+        @if (filled($meta->note))
+            <div class="panel__body bbcode-rendered">
+                @bbcode($meta->note)
+            </div>
+        @elseif ($canEditSimilarNote)
+            <div class="panel__body">No note has been set.</div>
+        @endif
+
+        @if ($canEditSimilarNote)
+            <dialog id="similar-note-edit" class="dialog" popover>
+                <h4 class="dialog__heading">Edit similar page note</h4>
+                <form
+                    class="form"
+                    action="{{ route('torrents.similar.update', ['category' => $category, 'metaId' => $meta->id]) }}"
+                    method="post"
+                >
+                    @csrf
+                    @method('PATCH')
+                    <p class="form__group">
+                        {{-- format-ignore-start --}}
+                        <textarea
+                            class="form__textarea"
+                            id="similar-page-note"
+                            maxlength="65535"
+                            name="note"
+                            rows="6"
+                        >{{ old('note', $meta->note) }}</textarea>
+                        {{-- format-ignore-end --}}
+                        <label class="form__label form__label--floating" for="similar-page-note">
+                            Similar page note
+                        </label>
+                    </p>
+                    <p class="form__group">
+                        <button class="form__button form__button--filled" type="submit">
+                            {{ __('common.save') }}
+                        </button>
+                        <button
+                            class="form__button form__button--outlined"
+                            popovertarget="similar-note-edit"
+                            type="button"
+                        >
+                            {{ __('common.cancel') }}
+                        </button>
+                    </p>
+                </form>
+            </dialog>
+        @endif
+    </section>
+@endif

--- a/resources/views/torrent/similar.blade.php
+++ b/resources/views/torrent/similar.blade.php
@@ -48,6 +48,7 @@
 
             @break
     @endswitch
+    @include('torrent.partials.similar-note')
     @livewire('similar-torrent', ['category' => $category, 'tmdbId' => $tmdb, 'igdbId' => $igdb, 'work' => $meta])
     <livewire:comments :model="$meta" :category="$category" />
 @endsection

--- a/tests/Feature/Http/Controllers/SimilarTorrentNoteControllerTest.php
+++ b/tests/Feature/Http/Controllers/SimilarTorrentNoteControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\UpdateLastAction;
+use App\Models\Category;
+use App\Models\Group;
+use App\Models\TmdbMovie;
+use App\Models\Torrent;
+use App\Models\User;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+
+beforeEach(function (): void {
+    $this->withoutMiddleware([
+        ThrottleRequestsWithRedis::class,
+        UpdateLastAction::class,
+    ]);
+});
+
+test('similar page shows metadata note', function (): void {
+    $category = Category::factory()->create([
+        'movie_meta' => true,
+        'tv_meta'    => false,
+        'game_meta'  => false,
+        'music_meta' => false,
+        'no_meta'    => false,
+    ]);
+    $movie = TmdbMovie::factory()->create([
+        'note'         => 'Watch this in production order.',
+        'runtime'      => '120',
+        'vote_average' => '8.2',
+    ]);
+    $torrent = Torrent::factory()->create([
+        'category_id'   => $category->id,
+        'tmdb_movie_id' => $movie->id,
+        'tmdb_tv_id'    => null,
+        'igdb'          => null,
+    ]);
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('torrents.similar', [
+        'category_id' => $category->id,
+        'tmdb'        => $movie->id,
+    ]));
+
+    $response->assertOk();
+    $response->assertSee('Watch this in production order.');
+    $response->assertSee($torrent->name);
+});
+
+test('torrent staff can update similar page note', function (): void {
+    $category = Category::factory()->create([
+        'movie_meta' => true,
+        'tv_meta'    => false,
+        'game_meta'  => false,
+        'music_meta' => false,
+        'no_meta'    => false,
+    ]);
+    $movie = TmdbMovie::factory()->create();
+    Torrent::factory()->create([
+        'category_id'   => $category->id,
+        'tmdb_movie_id' => $movie->id,
+        'tmdb_tv_id'    => null,
+        'igdb'          => null,
+    ]);
+    $staff = User::factory()->create([
+        'group_id' => Group::factory()->create([
+            'is_torrent_modo' => true,
+        ])->id,
+    ]);
+
+    $response = $this->actingAs($staff)->patch(route('torrents.similar.update', [
+        'category' => $category,
+        'metaId'   => $movie->id,
+    ]), [
+        'note' => 'Use the DVD order for season one.',
+    ]);
+
+    $response->assertRedirect();
+    expect($movie->fresh()->note)->toBe('Use the DVD order for season one.');
+});
+
+test('regular users cannot update similar page note', function (): void {
+    $category = Category::factory()->create([
+        'movie_meta' => true,
+        'tv_meta'    => false,
+        'game_meta'  => false,
+        'music_meta' => false,
+        'no_meta'    => false,
+    ]);
+    $movie = TmdbMovie::factory()->create([
+        'note' => 'Original note.',
+    ]);
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->patch(route('torrents.similar.update', [
+        'category' => $category,
+        'metaId'   => $movie->id,
+    ]), [
+        'note' => 'Changed note.',
+    ]);
+
+    $response->assertForbidden();
+    expect($movie->fresh()->note)->toBe('Original note.');
+});


### PR DESCRIPTION
## Summary
- add an optional note field to movie, TV, and game metadata records
- show the note near the top of similar pages before the torrent list
- let torrent staff add, update, or clear the note from the similar page

Closes #4386

## Tests
- git diff --check
- ./node_modules/.bin/prettier --check resources/views/torrent/similar.blade.php resources/views/torrent/partials/similar-note.blade.php
- vendor/bin/pint --test app/Http/Controllers/SimilarTorrentController.php app/Models/TmdbMovie.php app/Models/TmdbTv.php app/Models/IgdbGame.php database/migrations/2026_05_13_050000_add_note_to_metadata_tables.php tests/Feature/Http/Controllers/SimilarTorrentNoteControllerTest.php
- php artisan test tests/Feature/Http/Controllers/SimilarTorrentNoteControllerTest.php --stop-on-failure (Docker/MySQL: 3 passed, 7 assertions)
- php artisan view:cache (Docker; current development required a local-only Livewire route shim, reverted before commit)