### PR TITLE
Add sitewide IP search

### DIFF
--- a/app/Http/Livewire/UserSearch.php
+++ b/app/Http/Livewire/UserSearch.php
@@ -16,10 +16,19 @@ declare(strict_types=1);
 
 namespace App\Http\Livewire;
 
+use App\Models\BlockedIp;
+use App\Models\FailedLoginAttempt;
 use App\Models\Group;
+use App\Models\Note;
+use App\Models\Peer;
+use App\Models\Seedbox;
 use App\Models\User;
 use App\Traits\CastLivewireProperties;
 use App\Traits\LivewireSort;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -60,6 +69,9 @@ class UserSearch extends Component
     public string $passkey = '';
 
     #[Url(history: true)]
+    public string $ipAddress = '';
+
+    #[Url(history: true)]
     public ?int $groupId = null;
 
     #[Url(history: true)]
@@ -69,6 +81,11 @@ class UserSearch extends Component
     public string $sortDirection = 'desc';
 
     final public function updatingShow(): void
+    {
+        $this->resetPage();
+    }
+
+    final public function updatingIpAddress(): void
     {
         $this->resetPage();
     }
@@ -103,17 +120,182 @@ class UserSearch extends Component
     }
 
     /**
-     * @var \Illuminate\Support\Collection<int, Group>
+     * @var Collection<int, Group>
      */
     final protected $groups {
         get => Group::query()->orderBy('position')->get();
     }
 
+    /**
+     * @var Collection<int, array{source: string, user: User|null, fallback_user: string|null, ip_address: string, details: string, matched_at: mixed}>
+     */
+    final protected Collection $ipMatches {
+        get {
+            $ipAddress = trim($this->ipAddress);
+
+            if ($ipAddress === '') {
+                return collect();
+            }
+
+            return collect()
+                ->concat($this->peerIpMatches($ipAddress))
+                ->concat($this->sessionIpMatches($ipAddress))
+                ->concat($this->failedLoginIpMatches($ipAddress))
+                ->concat($this->blockedIpMatches($ipAddress))
+                ->concat($this->seedboxIpMatches($ipAddress))
+                ->concat($this->userNoteIpMatches($ipAddress));
+        }
+    }
+
+    /**
+     * @return Collection<int, array{source: string, user: User|null, fallback_user: string|null, ip_address: string, details: string, matched_at: mixed}>
+     */
+    private function peerIpMatches(string $ipAddress): Collection
+    {
+        return Peer::query()
+            ->select(['peers.user_id'])
+            ->selectRaw('INET6_NTOA(peers.ip) as ip_address')
+            ->selectRaw('COUNT(*) as result_count')
+            ->selectRaw('MAX(peers.updated_at) as latest_activity_at')
+            ->with(['user.group'])
+            ->where(DB::raw('INET6_NTOA(peers.ip)'), 'LIKE', $ipAddress.'%')
+            ->groupBy(['peers.user_id', 'peers.ip'])
+            ->orderByDesc('latest_activity_at')
+            ->limit(50)
+            ->get()
+            ->map(fn (Peer $peer): array => [
+                'source'        => 'Peers',
+                'user'          => $peer->user,
+                'fallback_user' => null,
+                'ip_address'    => $peer->ip_address,
+                'details'       => $peer->result_count.' peer '.Str::plural('record', (int) $peer->result_count),
+                'matched_at'    => $peer->latest_activity_at,
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array{source: string, user: User|null, fallback_user: string|null, ip_address: string, details: string, matched_at: mixed}>
+     */
+    private function sessionIpMatches(string $ipAddress): Collection
+    {
+        $sessions = DB::table('sessions')
+            ->select(['id', 'user_id', 'ip_address', 'user_agent', 'last_activity'])
+            ->where('ip_address', 'LIKE', $ipAddress.'%')
+            ->orderByDesc('last_activity')
+            ->limit(50)
+            ->get();
+
+        $users = User::query()
+            ->with('group')
+            ->whereKey($sessions->pluck('user_id')->filter()->unique())
+            ->get()
+            ->keyBy('id');
+
+        return $sessions->map(fn (object $session): array => [
+            'source'        => 'Sessions',
+            'user'          => $users->get($session->user_id),
+            'fallback_user' => $session->user_id === null ? 'Guest' : null,
+            'ip_address'    => $session->ip_address,
+            'details'       => Str::limit((string) $session->user_agent, 160),
+            'matched_at'    => Carbon::createFromTimestamp((int) $session->last_activity)->toDateTimeString(),
+        ]);
+    }
+
+    /**
+     * @return Collection<int, array{source: string, user: User|null, fallback_user: string|null, ip_address: string, details: string, matched_at: mixed}>
+     */
+    private function failedLoginIpMatches(string $ipAddress): Collection
+    {
+        return FailedLoginAttempt::query()
+            ->select(['user_id', 'username', 'ip_address'])
+            ->selectRaw('COUNT(*) as result_count')
+            ->selectRaw('MAX(created_at) as latest_activity_at')
+            ->with(['user.group'])
+            ->where('ip_address', 'LIKE', $ipAddress.'%')
+            ->groupBy(['user_id', 'username', 'ip_address'])
+            ->orderByDesc('latest_activity_at')
+            ->limit(50)
+            ->get()
+            ->map(fn (FailedLoginAttempt $failedLoginAttempt): array => [
+                'source'        => 'Failed logins',
+                'user'          => $failedLoginAttempt->user,
+                'fallback_user' => $failedLoginAttempt->username,
+                'ip_address'    => $failedLoginAttempt->ip_address,
+                'details'       => $failedLoginAttempt->result_count.' failed login '.Str::plural('attempt', (int) $failedLoginAttempt->result_count),
+                'matched_at'    => $failedLoginAttempt->latest_activity_at,
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array{source: string, user: User|null, fallback_user: string|null, ip_address: string, details: string, matched_at: mixed}>
+     */
+    private function blockedIpMatches(string $ipAddress): Collection
+    {
+        return BlockedIp::query()
+            ->with(['user.group'])
+            ->where('ip_address', 'LIKE', $ipAddress.'%')
+            ->latest()
+            ->limit(50)
+            ->get()
+            ->map(fn (BlockedIp $blockedIp): array => [
+                'source'        => 'Blocked IPs',
+                'user'          => $blockedIp->user,
+                'fallback_user' => null,
+                'ip_address'    => $blockedIp->ip_address,
+                'details'       => Str::limit((string) $blockedIp->reason, 160),
+                'matched_at'    => $blockedIp->created_at,
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array{source: string, user: User|null, fallback_user: string|null, ip_address: string, details: string, matched_at: mixed}>
+     */
+    private function seedboxIpMatches(string $ipAddress): Collection
+    {
+        return Seedbox::query()
+            ->with(['user.group'])
+            ->latest()
+            ->get()
+            ->filter(fn (Seedbox $seedbox): bool => Str::startsWith($seedbox->ip, $ipAddress))
+            ->take(50)
+            ->values()
+            ->map(fn (Seedbox $seedbox): array => [
+                'source'        => 'Seedboxes',
+                'user'          => $seedbox->user,
+                'fallback_user' => null,
+                'ip_address'    => $seedbox->ip,
+                'details'       => $seedbox->name,
+                'matched_at'    => $seedbox->created_at,
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array{source: string, user: User|null, fallback_user: string|null, ip_address: string, details: string, matched_at: mixed}>
+     */
+    private function userNoteIpMatches(string $ipAddress): Collection
+    {
+        return Note::query()
+            ->with(['user.group', 'staff'])
+            ->where('message', 'LIKE', '%'.$ipAddress.'%')
+            ->latest()
+            ->limit(50)
+            ->get()
+            ->map(fn (Note $note): array => [
+                'source'        => 'User notes',
+                'user'          => $note->user,
+                'fallback_user' => null,
+                'ip_address'    => $ipAddress,
+                'details'       => 'By '.$note->staff->username.': '.Str::limit($note->message, 160),
+                'matched_at'    => $note->created_at,
+            ]);
+    }
+
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application
     {
         return view('livewire.user-search', [
-            'users'  => $this->users,
-            'groups' => $this->groups,
+            'users'     => $this->users,
+            'groups'    => $this->groups,
+            'ipMatches' => $this->ipMatches,
         ]);
     }
 }

--- a/resources/views/livewire/user-search.blade.php
+++ b/resources/views/livewire/user-search.blade.php
@@ -91,6 +91,18 @@
                         </label>
                     </p>
                     <p class="form__group">
+                        <input
+                            id="ipAddress"
+                            class="form__text"
+                            type="text"
+                            wire:model.live="ipAddress"
+                            placeholder=" "
+                        />
+                        <label class="form__label form__label--floating" for="ipAddress">
+                            IP address
+                        </label>
+                    </p>
+                    <p class="form__group">
                         <select
                             id="groupId"
                             class="form__select"
@@ -138,6 +150,55 @@
             </form>
         </div>
     </section>
+    @if (filled($ipAddress))
+        <section class="panelV2">
+            <h2 class="panel__heading">IP matches</h2>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <th>Source</th>
+                            <th>{{ __('common.user') }}</th>
+                            <th>IP address</th>
+                            <th>Details</th>
+                            <th>Matched at</th>
+                        </tr>
+                        @forelse ($ipMatches as $match)
+                            <tr>
+                                <td>{{ $match['source'] }}</td>
+                                <td>
+                                    @if ($match['user'] !== null)
+                                        <x-user-tag :anon="false" :user="$match['user']" />
+                                    @else
+                                        {{ $match['fallback_user'] ?? 'Unknown' }}
+                                    @endif
+                                </td>
+                                <td>{{ $match['ip_address'] }}</td>
+                                <td>{{ $match['details'] === '' ? 'N/A' : $match['details'] }}</td>
+                                <td>
+                                    @if ($match['matched_at'] !== null)
+                                        <time
+                                            datetime="{{ $match['matched_at'] }}"
+                                            title="{{ $match['matched_at'] }}"
+                                        >
+                                            {{ $match['matched_at'] }}
+                                        </time>
+                                    @else
+                                        N/A
+                                    @endif
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="5">No IP matches</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    @endif
+
     <div>
         <section class="panelV2">
             <h2 class="panel__heading">{{ __('common.users') }}</h2>

--- a/tests/Feature/Http/Livewire/UserSearchTest.php
+++ b/tests/Feature/Http/Livewire/UserSearchTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Livewire\UserSearch;
+use App\Models\BlockedIp;
+use App\Models\FailedLoginAttempt;
+use App\Models\Note;
+use App\Models\Seedbox;
+use App\Models\Torrent;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+test('user search shows sitewide ip matches', function (): void {
+    $peerUser = User::factory()->create([
+        'username' => 'peeruser3658',
+    ]);
+    $sessionUser = User::factory()->create([
+        'username' => 'sessionuser3658',
+    ]);
+    $failedLoginUser = User::factory()->create([
+        'username' => 'failedloginuser3658',
+    ]);
+    $blockedIpUser = User::factory()->create([
+        'username' => 'blockedipuser3658',
+    ]);
+    $seedboxUser = User::factory()->create([
+        'username' => 'seedboxuser3658',
+    ]);
+    $notedUser = User::factory()->create([
+        'username' => 'noteduser3658',
+    ]);
+    $staffUser = User::factory()->create([
+        'username' => 'staffuser3658',
+    ]);
+    $torrent = Torrent::factory()->create();
+
+    DB::table('peers')->insert([
+        'peer_id'     => str_repeat('a', 20),
+        'ip'          => inet_pton('203.0.113.10'),
+        'port'        => 12345,
+        'agent'       => 'qBittorrent',
+        'uploaded'    => 0,
+        'downloaded'  => 0,
+        'left'        => 0,
+        'seeder'      => true,
+        'created_at'  => now(),
+        'updated_at'  => now(),
+        'torrent_id'  => $torrent->id,
+        'user_id'     => $peerUser->id,
+        'connectable' => true,
+        'active'      => true,
+        'visible'     => true,
+    ]);
+
+    DB::table('sessions')->insert([
+        'id'            => 'sitewide-ip-search-session',
+        'user_id'       => $sessionUser->id,
+        'ip_address'    => '203.0.113.11',
+        'user_agent'    => 'Mozilla test agent',
+        'payload'       => 'payload',
+        'last_activity' => now()->timestamp,
+    ]);
+
+    FailedLoginAttempt::factory()->create([
+        'user_id'    => $failedLoginUser->id,
+        'username'   => $failedLoginUser->username,
+        'ip_address' => '203.0.113.12',
+    ]);
+    BlockedIp::factory()->create([
+        'user_id'    => $blockedIpUser->id,
+        'ip_address' => '203.0.113.13',
+        'reason'     => 'Known proxy',
+    ]);
+    Seedbox::factory()->create([
+        'user_id' => $seedboxUser->id,
+        'name'    => 'Main seedbox',
+        'ip'      => '203.0.113.14',
+    ]);
+    Note::factory()->create([
+        'user_id'  => $notedUser->id,
+        'staff_id' => $staffUser->id,
+        'message'  => 'Reviewed login from 203.0.113.15',
+    ]);
+
+    Livewire::test(UserSearch::class)
+        ->set('ipAddress', '203.0.113')
+        ->assertSee('IP matches')
+        ->assertSee('peeruser3658')
+        ->assertSee('sessionuser3658')
+        ->assertSee('failedloginuser3658')
+        ->assertSee('blockedipuser3658')
+        ->assertSee('seedboxuser3658')
+        ->assertSee('noteduser3658')
+        ->assertSee('203.0.113.10')
+        ->assertSee('203.0.113.11')
+        ->assertSee('203.0.113.12')
+        ->assertSee('203.0.113.13')
+        ->assertSee('203.0.113.14')
+        ->assertSee('203.0.113.15');
+});


### PR DESCRIPTION
## Summary
- add an IP address field to the staff user search page
- show matching IP records from peers, sessions, failed logins, blocked IPs, seedboxes, and user notes
- include a focused Livewire test covering each source

Closes #3658

## Tests
- git diff --check
- ./node_modules/.bin/prettier --check resources/views/livewire/user-search.blade.php
- vendor/bin/pint --test app/Http/Livewire/UserSearch.php tests/Feature/Http/Livewire/UserSearchTest.php
- php artisan test tests/Feature/Http/Livewire/UserSearchTest.php --stop-on-failure (Docker/MySQL: 1 passed, 13 assertions)
- php artisan view:cache (Docker; current development required a local-only Livewire route shim, reverted before commit)