### PR TITLE
Preserve similar group expansion after bulk delete

### DIFF
--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -188,6 +188,8 @@ class SimilarTorrent extends Component
 
     public bool $selectPage = false;
 
+    public bool $expandGroups = false;
+
     public bool $hideFilledRequests = true;
 
     #[Url(history: true)]
@@ -215,16 +217,22 @@ class SimilarTorrent extends Component
     final public function updating(string $field, mixed &$value): void
     {
         $this->castLivewireProperties($field, $value);
+
+        if (!str_starts_with($field, 'checked') && !\in_array($field, ['selectPage', 'reason'], true)) {
+            $this->expandGroups = false;
+        }
     }
 
     final public function updatedSelectPage(bool $value): void
     {
         $this->checked = $value ? collect($this->torrents)->flatten()->pluck('id')->toArray() : [];
+        $this->expandGroups = $this->checked !== [];
     }
 
     final public function updatedChecked(): void
     {
         $this->selectPage = false;
+        $this->expandGroups = $this->checked !== [];
     }
 
     /**
@@ -483,6 +491,7 @@ class SimilarTorrent extends Component
 
         $this->checked = [];
         $this->selectPage = false;
+        $this->expandGroups = true;
 
         $this->dispatch(
             'swal:modal',

--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -614,7 +614,7 @@
                         @if (array_key_exists('Specials', $similarTorrents))
                             <details
                                 class="torrent-search--grouped__dropdown"
-                                @if ($checked || (! array_key_exists('Complete Pack', $similarTorrents) && ! array_key_exists('Seasons', $similarTorrents)))
+                                @if ($checked || $expandGroups || (! array_key_exists('Complete Pack', $similarTorrents) && ! array_key_exists('Seasons', $similarTorrents)))
                                     open
                                 @endif
                                 wire:ignore.self
@@ -623,7 +623,7 @@
                                 @foreach ($similarTorrents['Specials'] as $specialName => $special)
                                     <details
                                         class="torrent-search--grouped__dropdown"
-                                        @if ($checked || $loop->first)
+                                        @if ($checked || $expandGroups || $loop->first)
                                             open
                                         @endif
                                         wire:ignore.self
@@ -671,7 +671,7 @@
                         @foreach ($similarTorrents['Seasons'] ?? [] as $seasonName => $season)
                             <details
                                 class="torrent-search--grouped__dropdown"
-                                @if ($checked || $loop->first)
+                                @if ($checked || $expandGroups || $loop->first)
                                     open
                                 @endif
                                 wire:ignore.self
@@ -759,7 +759,7 @@
                                 @foreach ($season['Episodes'] ?? [] as $episodeName => $episode)
                                     <details
                                         class="torrent-search--grouped__dropdown"
-                                        @if ($checked || ($loop->first && ! array_key_exists('Season Pack', $season)))
+                                        @if ($checked || $expandGroups || ($loop->first && ! array_key_exists('Season Pack', $season)))
                                             open
                                         @endif
                                         wire:ignore.self

--- a/tests/Feature/Http/Livewire/SimilarTorrentExpansionTest.php
+++ b/tests/Feature/Http/Livewire/SimilarTorrentExpansionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Livewire\SimilarTorrent;
+use App\Models\Category;
+use App\Models\Group;
+use App\Models\TmdbTv;
+use App\Models\Torrent;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+test('bulk delete keeps similar page groups expanded after clearing selection', function (): void {
+    Notification::fake();
+
+    $category = Category::factory()->create([
+        'movie_meta' => false,
+        'tv_meta'    => true,
+        'game_meta'  => false,
+        'music_meta' => false,
+        'no_meta'    => false,
+    ]);
+    $show = TmdbTv::factory()->create([
+        'first_air_date' => '2024-01-01',
+        'last_air_date'  => '2024-01-01',
+    ]);
+    $staff = User::factory()->create([
+        'group_id' => Group::factory()->create([
+            'is_modo' => true,
+        ])->id,
+    ]);
+    $deletedTorrent = Torrent::factory()->create([
+        'category_id'    => $category->id,
+        'tmdb_tv_id'     => $show->id,
+        'tmdb_movie_id'  => null,
+        'igdb'           => null,
+        'season_number'  => 1,
+        'episode_number' => 1,
+    ]);
+    $remainingTorrent = Torrent::factory()->create([
+        'category_id'    => $category->id,
+        'tmdb_tv_id'     => $show->id,
+        'tmdb_movie_id'  => null,
+        'igdb'           => null,
+        'season_number'  => 1,
+        'episode_number' => 2,
+    ]);
+
+    Livewire::actingAs($staff)
+        ->test(SimilarTorrent::class, [
+            'category' => $category,
+            'work'     => $show,
+            'tmdbId'   => $show->id,
+            'igdbId'   => null,
+        ])
+        ->set('checked', [$deletedTorrent->id])
+        ->assertSet('expandGroups', true)
+        ->set('reason', 'Duplicate upload')
+        ->call('deleteRecords')
+        ->assertSet('checked', [])
+        ->assertSet('selectPage', false)
+        ->assertSet('expandGroups', true)
+        ->assertSee($remainingTorrent->name);
+
+    expect(Torrent::query()->whereKey($deletedTorrent->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- keep TV similar-page groupings expanded after a staff bulk delete clears the selected torrents
- reset the preserved expansion state when normal filters/sort inputs change
- add a focused Livewire regression test for the bulk delete state transition

Closes #4363

## Tests
- git diff --check
- ./node_modules/.bin/prettier --check resources/views/livewire/similar-torrent.blade.php
- vendor/bin/pint --test app/Http/Livewire/SimilarTorrent.php tests/Feature/Http/Livewire/SimilarTorrentExpansionTest.php
- php artisan test tests/Feature/Http/Livewire/SimilarTorrentExpansionTest.php --stop-on-failure (Docker/MySQL: 1 passed, 6 assertions)
- php artisan view:cache (Docker; current development required a local-only Livewire route shim, reverted before commit)