### PR TITLE
Link invite forum access to invite privileges

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -32,6 +32,11 @@ class ForumController extends Controller
      */
     public function index(Request $request): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
+        $canAccessInviteForums = $request->user()->canAccessInviteForums();
+        $forumCountCacheKey = 'forum-count:by-group-id:'.$request->user()->group_id.':invite-forums:'.(int) $canAccessInviteForums;
+        $postCountCacheKey = 'post-count:by-group-id:'.$request->user()->group_id.':invite-forums:'.(int) $canAccessInviteForums;
+        $topicCountCacheKey = 'topic-count:by-group-id:'.$request->user()->group_id.':invite-forums:'.(int) $canAccessInviteForums;
+
         return view('forum.index', [
             'categories' => ForumCategory::query()
                 ->with([
@@ -43,17 +48,17 @@ class ForumController extends Controller
                 ->get()
                 ->filter(fn ($category) => $category->forums->isNotEmpty()),
             'num_posts' => cache()->remember(
-                'post-count:by-group-id:'.$request->user()->group_id,
+                $postCountCacheKey,
                 3600,
                 fn () => Post::query()->authorized(canReadTopic: true)->count()
             ),
             'num_forums' => cache()->remember(
-                'forum-count:by-group-id:'.$request->user()->group_id,
+                $forumCountCacheKey,
                 3600,
                 fn () => Forum::query()->authorized(canReadTopic: true)->count()
             ),
             'num_topics' => cache()->remember(
-                'topic-count:by-group-id:'.$request->user()->group_id,
+                $topicCountCacheKey,
                 3600,
                 fn () => Topic::query()->authorized(canReadTopic: true)->count()
             ),

--- a/app/Http/Requests/Staff/StoreForumRequest.php
+++ b/app/Http/Requests/Staff/StoreForumRequest.php
@@ -59,6 +59,10 @@ class StoreForumRequest extends FormRequest
                 'nullable',
                 Rule::in(['close', 'open', null]),
             ],
+            'forum.is_invite_forum' => [
+                'sometimes',
+                'boolean',
+            ],
             'permissions' => [
                 'required',
                 'array',

--- a/app/Http/Requests/Staff/UpdateForumRequest.php
+++ b/app/Http/Requests/Staff/UpdateForumRequest.php
@@ -59,6 +59,10 @@ class UpdateForumRequest extends FormRequest
                 'nullable',
                 Rule::in(['close', 'open', null]),
             ],
+            'forum.is_invite_forum' => [
+                'sometimes',
+                'boolean',
+            ],
             'permissions' => [
                 'required',
                 'array',

--- a/app/Models/Forum.php
+++ b/app/Models/Forum.php
@@ -41,6 +41,7 @@ use AllowDynamicProperties;
  * @property string|null                     $slug
  * @property string|null                     $description
  * @property int                             $forum_category_id
+ * @property bool                            $is_invite_forum
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  */
@@ -58,6 +59,18 @@ final class Forum extends Model
      * @var string[]
      */
     protected $guarded = ['id', 'created_at'];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array{is_invite_forum: 'bool'}
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_invite_forum' => 'bool',
+        ];
+    }
 
     /**
      * Get the topics for the forum.
@@ -161,14 +174,17 @@ final class Forum extends Model
         ?bool $canReplyTopic = null,
         ?bool $canStartTopic = null,
     ): \Illuminate\Database\Eloquent\Builder {
+        $user = auth()->user();
+
         return $query
             ->whereRelation(
                 'permissions',
                 fn ($query) => $query
-                    ->where('group_id', '=', auth()->user()->group_id)
+                    ->where('group_id', '=', $user->group_id)
                     ->when($canReadTopic !== null, fn ($query) => $query->where('read_topic', '=', $canReadTopic))
                     ->when($canReplyTopic !== null, fn ($query) => $query->where('reply_topic', '=', $canReplyTopic))
                     ->when($canStartTopic !== null, fn ($query) => $query->where('start_topic', '=', $canStartTopic))
-            );
+            )
+            ->when(! $user->canAccessInviteForums(), fn ($query) => $query->where('is_invite_forum', '=', false));
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -154,23 +154,35 @@ final class Post extends Model
         ?bool $canReplyTopic = null,
         ?bool $canStartTopic = null,
     ): \Illuminate\Database\Eloquent\Builder {
-        return $query->whereNotIn(
-            'topic_id',
-            Topic::query()
-                ->whereRelation(
-                    'forumPermissions',
-                    fn ($query) => $query
-                        ->where('group_id', '=', auth()->user()->group_id)
-                        ->where(
-                            fn ($query) => $query
-                                ->whereRaw('1 = 0')
-                                ->when($canReadTopic !== null, fn ($query) => $query->orWhere('read_topic', '!=', $canReadTopic))
-                                ->when($canReplyTopic !== null, fn ($query) => $query->orWhere('reply_topic', '!=', $canReplyTopic))
-                                ->when($canStartTopic !== null, fn ($query) => $query->orWhere('start_topic', '!=', $canStartTopic))
-                        )
+        $user = auth()->user();
+
+        return $query
+            ->whereNotIn(
+                'topic_id',
+                Topic::query()
+                    ->whereRelation(
+                        'forumPermissions',
+                        fn ($query) => $query
+                            ->where('group_id', '=', $user->group_id)
+                            ->where(
+                                fn ($query) => $query
+                                    ->whereRaw('1 = 0')
+                                    ->when($canReadTopic !== null, fn ($query) => $query->orWhere('read_topic', '!=', $canReadTopic))
+                                    ->when($canReplyTopic !== null, fn ($query) => $query->orWhere('reply_topic', '!=', $canReplyTopic))
+                                    ->when($canStartTopic !== null, fn ($query) => $query->orWhere('start_topic', '!=', $canStartTopic))
+                            )
+                    )
+                    ->when($canReplyTopic && ! $user->group->is_modo, fn ($query) => $query->where('state', '=', 'open'))
+                    ->select('id')
+            )
+            ->when(
+                ! $user->canAccessInviteForums(),
+                fn ($query) => $query->whereNotIn(
+                    'topic_id',
+                    Topic::query()
+                        ->whereRelation('forum', 'is_invite_forum', '=', true)
+                        ->select('id')
                 )
-                ->when($canReplyTopic && !auth()->user()->group->is_modo, fn ($query) => $query->where('state', '=', 'open'))
-                ->select('id')
-        );
+            );
     }
 }

--- a/app/Models/Topic.php
+++ b/app/Models/Topic.php
@@ -191,15 +191,18 @@ final class Topic extends Model
         ?bool $canReplyTopic = null,
         ?bool $canStartTopic = null,
     ): \Illuminate\Database\Eloquent\Builder {
+        $user = auth()->user();
+
         return $query
             ->whereRelation(
                 'forumPermissions',
                 fn ($query) => $query
-                    ->where('group_id', '=', auth()->user()->group_id)
+                    ->where('group_id', '=', $user->group_id)
                     ->when($canReadTopic !== null, fn ($query) => $query->where('read_topic', '=', $canReadTopic))
                     ->when($canReplyTopic !== null, fn ($query) => $query->where('reply_topic', '=', $canReplyTopic))
                     ->when($canStartTopic !== null, fn ($query) => $query->where('start_topic', '=', $canStartTopic))
             )
-            ->when($canReplyTopic && !auth()->user()->group->is_modo, fn ($query) => $query->where('state', '=', 'open'));
+            ->when(! $user->canAccessInviteForums(), fn ($query) => $query->whereRelation('forum', 'is_invite_forum', '=', false))
+            ->when($canReplyTopic && ! $user->group->is_modo, fn ($query) => $query->where('state', '=', 'open'));
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -186,6 +186,14 @@ final class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
+     * Determine whether the user may access invite-only forum areas.
+     */
+    public function canAccessInviteForums(): bool
+    {
+        return (bool) ($this->can_invite ?? $this->group->can_invite);
+    }
+
+    /**
      * Get the internal groups that the user belongs to.
      *
      * @return BelongsToMany<Internal, $this, InternalUser>

--- a/database/factories/ForumFactory.php
+++ b/database/factories/ForumFactory.php
@@ -45,6 +45,7 @@ class ForumFactory extends Factory
             'slug'                 => $this->faker->slug(),
             'description'          => $this->faker->text(),
             'forum_category_id'    => ForumCategory::factory(),
+            'is_invite_forum'      => false,
         ];
     }
 }

--- a/database/migrations/2026_05_13_061500_add_is_invite_forum_to_forums_table.php
+++ b/database/migrations/2026_05_13_061500_add_is_invite_forum_to_forums_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('forums', function (Blueprint $table): void {
+            $table->boolean('is_invite_forum')->default(false)->after('default_topic_state_filter');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('forums', function (Blueprint $table): void {
+            $table->dropColumn('is_invite_forum');
+        });
+    }
+};

--- a/resources/views/Staff/forum/create.blade.php
+++ b/resources/views/Staff/forum/create.blade.php
@@ -100,6 +100,17 @@
                         Default topic state filter
                     </label>
                 </p>
+                <p class="form__group">
+                    <input name="forum[is_invite_forum]" type="hidden" value="0" />
+                    <input
+                        id="is_invite_forum"
+                        class="form__checkbox"
+                        name="forum[is_invite_forum]"
+                        type="checkbox"
+                        value="1"
+                    />
+                    <label class="form__label" for="is_invite_forum">Invite forum</label>
+                </p>
                 <div class="form__group">
                     <h3>Permissions</h3>
                     <div class="data-table-wrapper" x-data="checkboxGrid">

--- a/resources/views/Staff/forum/edit.blade.php
+++ b/resources/views/Staff/forum/edit.blade.php
@@ -140,6 +140,18 @@
                         Topic state filter
                     </label>
                 </p>
+                <p class="form__group">
+                    <input name="forum[is_invite_forum]" type="hidden" value="0" />
+                    <input
+                        id="is_invite_forum"
+                        class="form__checkbox"
+                        name="forum[is_invite_forum]"
+                        type="checkbox"
+                        value="1"
+                        @checked($forum->is_invite_forum)
+                    />
+                    <label class="form__label" for="is_invite_forum">Invite forum</label>
+                </p>
                 <div class="form__group">
                     <label class="form__label">Permissions</label>
                     <div class="data-table-wrapper">

--- a/tests/Feature/Http/Controllers/ForumControllerTest.php
+++ b/tests/Feature/Http/Controllers/ForumControllerTest.php
@@ -14,11 +14,21 @@ declare(strict_types=1);
  * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
  */
 
+use App\Http\Middleware\UpdateLastAction;
 use App\Models\Forum;
 use App\Models\ForumPermission;
+use App\Models\Group;
+use App\Models\Post;
+use App\Models\Topic;
 use App\Models\User;
 use Database\Seeders\GroupSeeder;
 use Database\Seeders\UserSeeder;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+
+beforeEach(function (): void {
+    $this->withoutMiddleware(UpdateLastAction::class);
+    $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+});
 
 test('index returns an ok response', function (): void {
     $user = User::factory()->create();
@@ -51,4 +61,83 @@ test('show returns an ok response', function (): void {
 
     $response = $this->actingAs($user)->get(route('forums.show', ['id' => $forum->id]));
     $response->assertViewIs('forum.forum-topic.index');
+});
+
+test('invite forums are hidden when invite privileges are revoked', function (): void {
+    $group = Group::factory()->create(['can_invite' => true]);
+    $user = User::factory()->create([
+        'group_id'   => $group->id,
+        'can_invite' => false,
+    ]);
+
+    $forum = Forum::factory()->create([
+        'is_invite_forum' => true,
+        'name'            => 'Invite Offers',
+    ]);
+
+    ForumPermission::factory()->create([
+        'group_id'   => $user->group_id,
+        'forum_id'   => $forum->id,
+        'read_topic' => true,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('forums.index'))
+        ->assertOk()
+        ->assertDontSee('Invite Offers');
+
+    $this->actingAs($user)
+        ->get(route('forums.show', ['id' => $forum->id]))
+        ->assertNotFound();
+});
+
+test('invite forums remain visible when invite privileges are allowed', function (): void {
+    $group = Group::factory()->create(['can_invite' => true]);
+    $user = User::factory()->create([
+        'group_id'   => $group->id,
+        'can_invite' => null,
+    ]);
+
+    $forum = Forum::factory()->create(['is_invite_forum' => true]);
+
+    ForumPermission::factory()->create([
+        'group_id'   => $user->group_id,
+        'forum_id'   => $forum->id,
+        'read_topic' => true,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('forums.show', ['id' => $forum->id]))
+        ->assertOk()
+        ->assertViewIs('forum.forum-topic.index');
+});
+
+test('invite forum topics and posts are hidden when invite privileges are revoked', function (): void {
+    $group = Group::factory()->create(['can_invite' => true]);
+    $user = User::factory()->create([
+        'group_id'   => $group->id,
+        'can_invite' => false,
+    ]);
+
+    $forum = Forum::factory()->create(['is_invite_forum' => true]);
+    $topic = Topic::factory()->create([
+        'forum_id' => $forum->id,
+        'state'    => 'open',
+    ]);
+    $post = Post::factory()->create(['topic_id' => $topic->id]);
+
+    ForumPermission::factory()->create([
+        'group_id'    => $user->group_id,
+        'forum_id'    => $forum->id,
+        'read_topic'  => true,
+        'reply_topic' => true,
+        'start_topic' => true,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('topics.show', ['id' => $topic->id]))
+        ->assertNotFound();
+
+    expect(Post::query()->authorized(canReadTopic: true)->pluck('id')->all())
+        ->not->toContain($post->id);
 });

--- a/tests/Unit/Http/Requests/Staff/StoreForumRequestTest.php
+++ b/tests/Unit/Http/Requests/Staff/StoreForumRequestTest.php
@@ -52,6 +52,10 @@ test('rules', function (): void {
             'nullable',
             Rule::in(['close', 'open', null]),
         ],
+        'forum.is_invite_forum' => [
+            'sometimes',
+            'boolean',
+        ],
         'permissions' => [
             'required',
             'array',

--- a/tests/Unit/Http/Requests/Staff/UpdateForumRequestTest.php
+++ b/tests/Unit/Http/Requests/Staff/UpdateForumRequestTest.php
@@ -52,6 +52,10 @@ test('rules', function (): void {
             'nullable',
             Rule::in(['close', 'open', null]),
         ],
+        'forum.is_invite_forum' => [
+            'sometimes',
+            'boolean',
+        ],
         'permissions' => [
             'required',
             'array',


### PR DESCRIPTION
## Summary
- add an invite-forum flag to staff forum create/edit forms
- hide invite-marked forums, topics, and posts when a user's effective invite privilege is false
- keep forum count caches split by effective invite-forum access and add regression coverage

Closes #4041

## Tests
- git diff --check
- ./node_modules/.bin/prettier --check resources/views/Staff/forum/create.blade.php resources/views/Staff/forum/edit.blade.php
- vendor/bin/pint --test app/Http/Controllers/ForumController.php app/Http/Requests/Staff/StoreForumRequest.php app/Http/Requests/Staff/UpdateForumRequest.php app/Models/Forum.php app/Models/Post.php app/Models/Topic.php app/Models/User.php database/factories/ForumFactory.php database/migrations/2026_05_13_061500_add_is_invite_forum_to_forums_table.php tests/Feature/Http/Controllers/ForumControllerTest.php tests/Unit/Http/Requests/Staff/StoreForumRequestTest.php tests/Unit/Http/Requests/Staff/UpdateForumRequestTest.php
- php artisan test tests/Feature/Http/Controllers/ForumControllerTest.php tests/Unit/Http/Requests/Staff/StoreForumRequestTest.php tests/Unit/Http/Requests/Staff/UpdateForumRequestTest.php --stop-on-failure (Docker/MySQL: 9 passed, 18 assertions)
- php artisan view:cache (Docker; current development required a local-only Livewire route shim, reverted before commit)