### PR TITLE
Add grouped dashboard credential tools

### DIFF
--- a/app/Http/Livewire/ApikeySearch.php
+++ b/app/Http/Livewire/ApikeySearch.php
@@ -19,6 +19,7 @@ namespace App\Http\Livewire;
 use App\Models\Apikey;
 use App\Models\User;
 use App\Traits\LivewireSort;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -37,6 +38,9 @@ class ApikeySearch extends Component
     public string $apikey = '';
 
     #[Url(history: true)]
+    public string $groupBy = 'none';
+
+    #[Url(history: true)]
     public string $sortField = 'created_at';
 
     #[Url(history: true)]
@@ -44,6 +48,22 @@ class ApikeySearch extends Component
 
     #[Url(history: true)]
     public int $perPage = 25;
+
+    final public function mount(): void
+    {
+        $this->sortField = match ($this->groupBy) {
+            'user_id' => 'created_at_max',
+            default   => 'created_at',
+        };
+    }
+
+    final public function updatingGroupBy(string $value): void
+    {
+        $this->sortField = match ($value) {
+            'user_id' => 'created_at_max',
+            default   => 'created_at',
+        };
+    }
 
     /**
      * @var \Illuminate\Pagination\LengthAwarePaginator<int, Apikey>
@@ -55,6 +75,24 @@ class ApikeySearch extends Component
             ])
             ->when($this->username, fn ($query) => $query->whereIn('user_id', User::query()->withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
             ->when($this->apikey, fn ($query) => $query->where('content', 'LIKE', '%'.$this->apikey.'%'))
+            ->when(
+                $this->groupBy === 'user_id',
+                fn ($query) => $query->groupBy('user_id')
+                    ->select([
+                        'user_id',
+                        DB::raw('MIN(created_at) as created_at_min'),
+                        DB::raw('FROM_UNIXTIME(AVG(UNIX_TIMESTAMP(created_at))) as created_at_avg'),
+                        DB::raw('MAX(created_at) as created_at_max'),
+                        DB::raw('COUNT(*) as key_count'),
+                        DB::raw('SUM(deleted_at IS NULL) as active_count'),
+                        DB::raw('SUM(deleted_at IS NOT NULL) as deleted_count'),
+                    ])
+                    ->withCasts([
+                        'created_at_min' => 'datetime',
+                        'created_at_avg' => 'datetime',
+                        'created_at_max' => 'datetime',
+                    ])
+            )
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate(min($this->perPage, 100));
     }

--- a/app/Http/Livewire/EmailUpdateSearch.php
+++ b/app/Http/Livewire/EmailUpdateSearch.php
@@ -18,6 +18,7 @@ namespace App\Http\Livewire;
 
 use App\Models\EmailUpdate;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -34,6 +35,9 @@ class EmailUpdateSearch extends Component
     public string $username = '';
 
     #[Url(history: true)]
+    public string $groupBy = 'none';
+
+    #[Url(history: true)]
     public string $sortField = 'created_at';
 
     #[Url(history: true)]
@@ -41,6 +45,22 @@ class EmailUpdateSearch extends Component
 
     #[Url(history: true)]
     public int $perPage = 25;
+
+    final public function mount(): void
+    {
+        $this->sortField = match ($this->groupBy) {
+            'user_id' => 'created_at_max',
+            default   => 'created_at',
+        };
+    }
+
+    final public function updatingGroupBy(string $value): void
+    {
+        $this->sortField = match ($value) {
+            'user_id' => 'created_at_max',
+            default   => 'created_at',
+        };
+    }
 
     /**
      * @var \Illuminate\Pagination\LengthAwarePaginator<int, EmailUpdate>
@@ -51,6 +71,24 @@ class EmailUpdateSearch extends Component
                 'user' => fn ($query) => $query->withTrashed()->with('group'),
             ])
             ->when($this->username, fn ($query) => $query->whereIn('user_id', User::query()->withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
+            ->when(
+                $this->groupBy === 'user_id',
+                fn ($query) => $query->groupBy('user_id')
+                    ->select([
+                        'user_id',
+                        DB::raw('MIN(created_at) as created_at_min'),
+                        DB::raw('FROM_UNIXTIME(AVG(UNIX_TIMESTAMP(created_at))) as created_at_avg'),
+                        DB::raw('MAX(created_at) as created_at_max'),
+                        DB::raw('COUNT(*) as email_update_count'),
+                        DB::raw('SUM(deleted_at IS NULL) as active_count'),
+                        DB::raw('SUM(deleted_at IS NOT NULL) as deleted_count'),
+                    ])
+                    ->withCasts([
+                        'created_at_min' => 'datetime',
+                        'created_at_avg' => 'datetime',
+                        'created_at_max' => 'datetime',
+                    ])
+            )
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate(min($this->perPage, 100));
     }

--- a/app/Http/Livewire/PasskeySearch.php
+++ b/app/Http/Livewire/PasskeySearch.php
@@ -19,6 +19,7 @@ namespace App\Http\Livewire;
 use App\Models\Passkey;
 use App\Models\User;
 use App\Traits\LivewireSort;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -37,6 +38,9 @@ class PasskeySearch extends Component
     public string $passkey = '';
 
     #[Url(history: true)]
+    public string $groupBy = 'none';
+
+    #[Url(history: true)]
     public string $sortField = 'created_at';
 
     #[Url(history: true)]
@@ -44,6 +48,22 @@ class PasskeySearch extends Component
 
     #[Url(history: true)]
     public int $perPage = 25;
+
+    final public function mount(): void
+    {
+        $this->sortField = match ($this->groupBy) {
+            'user_id' => 'created_at_max',
+            default   => 'created_at',
+        };
+    }
+
+    final public function updatingGroupBy(string $value): void
+    {
+        $this->sortField = match ($value) {
+            'user_id' => 'created_at_max',
+            default   => 'created_at',
+        };
+    }
 
     /**
      * @var \Illuminate\Pagination\LengthAwarePaginator<int, Passkey>
@@ -55,6 +75,24 @@ class PasskeySearch extends Component
             ])
             ->when($this->username, fn ($query) => $query->whereIn('user_id', User::query()->withTrashed()->select('id')->where('username', '=', $this->username)))
             ->when($this->passkey, fn ($query) => $query->where('content', 'LIKE', '%'.$this->passkey.'%'))
+            ->when(
+                $this->groupBy === 'user_id',
+                fn ($query) => $query->groupBy('user_id')
+                    ->select([
+                        'user_id',
+                        DB::raw('MIN(created_at) as created_at_min'),
+                        DB::raw('FROM_UNIXTIME(AVG(UNIX_TIMESTAMP(created_at))) as created_at_avg'),
+                        DB::raw('MAX(created_at) as created_at_max'),
+                        DB::raw('COUNT(*) as key_count'),
+                        DB::raw('SUM(deleted_at IS NULL) as active_count'),
+                        DB::raw('SUM(deleted_at IS NOT NULL) as deleted_count'),
+                    ])
+                    ->withCasts([
+                        'created_at_min' => 'datetime',
+                        'created_at_avg' => 'datetime',
+                        'created_at_max' => 'datetime',
+                    ])
+            )
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate(min($this->perPage, 100));
     }

--- a/app/Http/Livewire/RsskeySearch.php
+++ b/app/Http/Livewire/RsskeySearch.php
@@ -19,6 +19,7 @@ namespace App\Http\Livewire;
 use App\Models\Rsskey;
 use App\Models\User;
 use App\Traits\LivewireSort;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -37,6 +38,9 @@ class RsskeySearch extends Component
     public string $rsskey = '';
 
     #[Url(history: true)]
+    public string $groupBy = 'none';
+
+    #[Url(history: true)]
     public string $sortField = 'created_at';
 
     #[Url(history: true)]
@@ -44,6 +48,22 @@ class RsskeySearch extends Component
 
     #[Url(history: true)]
     public int $perPage = 25;
+
+    final public function mount(): void
+    {
+        $this->sortField = match ($this->groupBy) {
+            'user_id' => 'created_at_max',
+            default   => 'created_at',
+        };
+    }
+
+    final public function updatingGroupBy(string $value): void
+    {
+        $this->sortField = match ($value) {
+            'user_id' => 'created_at_max',
+            default   => 'created_at',
+        };
+    }
 
     /**
      * @var \Illuminate\Pagination\LengthAwarePaginator<int, Rsskey>
@@ -55,6 +75,24 @@ class RsskeySearch extends Component
             ])
             ->when($this->username, fn ($query) => $query->whereIn('user_id', User::query()->withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->username.'%')))
             ->when($this->rsskey, fn ($query) => $query->where('content', 'LIKE', '%'.$this->rsskey.'%'))
+            ->when(
+                $this->groupBy === 'user_id',
+                fn ($query) => $query->groupBy('user_id')
+                    ->select([
+                        'user_id',
+                        DB::raw('MIN(created_at) as created_at_min'),
+                        DB::raw('FROM_UNIXTIME(AVG(UNIX_TIMESTAMP(created_at))) as created_at_avg'),
+                        DB::raw('MAX(created_at) as created_at_max'),
+                        DB::raw('COUNT(*) as key_count'),
+                        DB::raw('SUM(deleted_at IS NULL) as active_count'),
+                        DB::raw('SUM(deleted_at IS NOT NULL) as deleted_count'),
+                    ])
+                    ->withCasts([
+                        'created_at_min' => 'datetime',
+                        'created_at_avg' => 'datetime',
+                        'created_at_max' => 'datetime',
+                    ])
+            )
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate(min($this->perPage, 100));
     }

--- a/resources/views/livewire/apikey-search.blade.php
+++ b/resources/views/livewire/apikey-search.blade.php
@@ -34,6 +34,15 @@
             </div>
             <div class="panel__action">
                 <div class="form__group">
+                    <select id="groupBy" class="form__select" wire:model.live="groupBy">
+                        <option value="none">None</option>
+                        <option value="user_id">{{ __('common.username') }}</option>
+                    </select>
+                    <label class="form__label form__label--floating" for="groupBy">Group by</label>
+                </div>
+            </div>
+            <div class="panel__action">
+                <div class="form__group">
                     <select id="quantity" class="form__select" wire:model.live="perPage" required>
                         <option>25</option>
                         <option>50</option>
@@ -47,56 +56,134 @@
         </div>
     </header>
     <div class="data-table-wrapper">
-        <table class="data-table">
-            <tbody>
-                <tr>
-                    <th wire:click="sortBy('user_id')" role="columnheader button">
-                        {{ __('common.username') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'user_id'])
-                    </th>
-                    <th wire:click="sortBy('content')" role="columnheader button">
-                        {{ __('user.apikey') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'content'])
-                    </th>
-                    <th wire:click="sortBy('created_at')" role="columnheader button">
-                        {{ __('common.created_at') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'created_at'])
-                    </th>
-                    <th wire:click="sortBy('deleted_at')" role="columnheader button">
-                        {{ __('user.deleted-on') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'deleted_at'])
-                    </th>
-                </tr>
-                @forelse ($apikeys as $apikey)
-                    <tr>
-                        <td>
-                            <x-user-tag :user="$apikey->user" :anon="false" />
-                        </td>
-                        <td>{{ $apikey->content }}</td>
-                        <td>
-                            <time
-                                datetime="{{ $apikey->created_at }}"
-                                title="{{ $apikey->created_at }}"
-                            >
-                                {{ $apikey->created_at }}
-                            </time>
-                        </td>
-                        <td>
-                            <time
-                                datetime="{{ $apikey->deleted_at }}"
-                                title="{{ $apikey->deleted_at }}"
-                            >
-                                {{ $apikey->deleted_at ?? 'Currently in use' }}
-                            </time>
-                        </td>
-                    </tr>
-                @empty
-                    <tr>
-                        <td colspan="4">No API keys</td>
-                    </tr>
-                @endforelse
-            </tbody>
-        </table>
+        @switch($groupBy)
+            @case('user_id')
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <th wire:click="sortBy('user_id')" role="columnheader button">
+                                {{ __('common.username') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'user_id'])
+                            </th>
+                            <th wire:click="sortBy('created_at_min')" role="columnheader button">
+                                First created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_min'])
+                            </th>
+                            <th wire:click="sortBy('created_at_avg')" role="columnheader button">
+                                Average created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_avg'])
+                            </th>
+                            <th wire:click="sortBy('created_at_max')" role="columnheader button">
+                                Last created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_max'])
+                            </th>
+                            <th wire:click="sortBy('key_count')" role="columnheader button">
+                                API keys
+                                @include('livewire.includes._sort-icon', ['field' => 'key_count'])
+                            </th>
+                            <th wire:click="sortBy('active_count')" role="columnheader button">
+                                Currently in use
+                                @include('livewire.includes._sort-icon', ['field' => 'active_count'])
+                            </th>
+                            <th wire:click="sortBy('deleted_count')" role="columnheader button">
+                                Deleted
+                                @include('livewire.includes._sort-icon', ['field' => 'deleted_count'])
+                            </th>
+                        </tr>
+                        @forelse ($apikeys as $apikey)
+                            <tr>
+                                <td>
+                                    <x-user-tag :user="$apikey->user" :anon="false" />
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $apikey->created_at_min }}"
+                                        title="{{ $apikey->created_at_min }}"
+                                    >
+                                        {{ $apikey->created_at_min }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $apikey->created_at_avg }}"
+                                        title="{{ $apikey->created_at_avg }}"
+                                    >
+                                        {{ $apikey->created_at_avg }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $apikey->created_at_max }}"
+                                        title="{{ $apikey->created_at_max }}"
+                                    >
+                                        {{ $apikey->created_at_max }}
+                                    </time>
+                                </td>
+                                <td>{{ $apikey->key_count }}</td>
+                                <td>{{ $apikey->active_count }}</td>
+                                <td>{{ $apikey->deleted_count }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7">No API keys</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+
+                @break
+            @default
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <th wire:click="sortBy('user_id')" role="columnheader button">
+                                {{ __('common.username') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'user_id'])
+                            </th>
+                            <th wire:click="sortBy('content')" role="columnheader button">
+                                {{ __('user.apikey') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'content'])
+                            </th>
+                            <th wire:click="sortBy('created_at')" role="columnheader button">
+                                {{ __('common.created_at') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at'])
+                            </th>
+                            <th wire:click="sortBy('deleted_at')" role="columnheader button">
+                                {{ __('user.deleted-on') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'deleted_at'])
+                            </th>
+                        </tr>
+                        @forelse ($apikeys as $apikey)
+                            <tr>
+                                <td>
+                                    <x-user-tag :user="$apikey->user" :anon="false" />
+                                </td>
+                                <td>{{ $apikey->content }}</td>
+                                <td>
+                                    <time
+                                        datetime="{{ $apikey->created_at }}"
+                                        title="{{ $apikey->created_at }}"
+                                    >
+                                        {{ $apikey->created_at }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $apikey->deleted_at }}"
+                                        title="{{ $apikey->deleted_at }}"
+                                    >
+                                        {{ $apikey->deleted_at ?? 'Currently in use' }}
+                                    </time>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="4">No API keys</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+        @endswitch
     </div>
     {{ $apikeys->links('partials.pagination') }}
 </section>

--- a/resources/views/livewire/email-update-search.blade.php
+++ b/resources/views/livewire/email-update-search.blade.php
@@ -19,6 +19,15 @@
             </div>
             <div class="panel__action">
                 <div class="form__group">
+                    <select id="groupBy" class="form__select" wire:model.live="groupBy">
+                        <option value="none">None</option>
+                        <option value="user_id">{{ __('common.username') }}</option>
+                    </select>
+                    <label class="form__label form__label--floating" for="groupBy">Group by</label>
+                </div>
+            </div>
+            <div class="panel__action">
+                <div class="form__group">
                     <select id="quantity" class="form__select" wire:model.live="perPage" required>
                         <option>25</option>
                         <option>50</option>
@@ -32,51 +41,132 @@
         </div>
     </header>
     <div class="data-table-wrapper">
-        <table class="data-table">
-            <tbody>
-                <tr>
-                    <th wire:click="sortBy('user_id')" role="columnheader button">
-                        {{ __('common.username') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'user_id'])
-                    </th>
-                    <th wire:click="sortBy('created_at')" role="columnheader button">
-                        {{ __('common.created_at') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'created_at'])
-                    </th>
-                    <th wire:click="sortBy('deleted_at')" role="columnheader button">
-                        {{ __('user.deleted-on') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'deleted_at'])
-                    </th>
-                </tr>
-                @forelse ($emailUpdates as $emailUpdate)
-                    <tr>
-                        <td>
-                            <x-user-tag :user="$emailUpdate->user" :anon="false" />
-                        </td>
-                        <td>
-                            <time
-                                datetime="{{ $emailUpdate->created_at }}"
-                                title="{{ $emailUpdate->created_at }}"
+        @switch($groupBy)
+            @case('user_id')
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <th wire:click="sortBy('user_id')" role="columnheader button">
+                                {{ __('common.username') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'user_id'])
+                            </th>
+                            <th wire:click="sortBy('created_at_min')" role="columnheader button">
+                                First created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_min'])
+                            </th>
+                            <th wire:click="sortBy('created_at_avg')" role="columnheader button">
+                                Average created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_avg'])
+                            </th>
+                            <th wire:click="sortBy('created_at_max')" role="columnheader button">
+                                Last created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_max'])
+                            </th>
+                            <th
+                                wire:click="sortBy('email_update_count')"
+                                role="columnheader button"
                             >
-                                {{ $emailUpdate->created_at }}
-                            </time>
-                        </td>
-                        <td>
-                            <time
-                                datetime="{{ $emailUpdate->deleted_at }}"
-                                title="{{ $emailUpdate->deleted_at }}"
-                            >
-                                {{ $emailUpdate->deleted_at ?? 'Currently in use' }}
-                            </time>
-                        </td>
-                    </tr>
-                @empty
-                    <tr>
-                        <td colspan="3">No email updates</td>
-                    </tr>
-                @endforelse
-            </tbody>
-        </table>
+                                Email updates
+                                @include('livewire.includes._sort-icon', ['field' => 'email_update_count'])
+                            </th>
+                            <th wire:click="sortBy('active_count')" role="columnheader button">
+                                Currently in use
+                                @include('livewire.includes._sort-icon', ['field' => 'active_count'])
+                            </th>
+                            <th wire:click="sortBy('deleted_count')" role="columnheader button">
+                                Deleted
+                                @include('livewire.includes._sort-icon', ['field' => 'deleted_count'])
+                            </th>
+                        </tr>
+                        @forelse ($emailUpdates as $emailUpdate)
+                            <tr>
+                                <td>
+                                    <x-user-tag :user="$emailUpdate->user" :anon="false" />
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $emailUpdate->created_at_min }}"
+                                        title="{{ $emailUpdate->created_at_min }}"
+                                    >
+                                        {{ $emailUpdate->created_at_min }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $emailUpdate->created_at_avg }}"
+                                        title="{{ $emailUpdate->created_at_avg }}"
+                                    >
+                                        {{ $emailUpdate->created_at_avg }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $emailUpdate->created_at_max }}"
+                                        title="{{ $emailUpdate->created_at_max }}"
+                                    >
+                                        {{ $emailUpdate->created_at_max }}
+                                    </time>
+                                </td>
+                                <td>{{ $emailUpdate->email_update_count }}</td>
+                                <td>{{ $emailUpdate->active_count }}</td>
+                                <td>{{ $emailUpdate->deleted_count }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7">No email updates</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+
+                @break
+            @default
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <th wire:click="sortBy('user_id')" role="columnheader button">
+                                {{ __('common.username') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'user_id'])
+                            </th>
+                            <th wire:click="sortBy('created_at')" role="columnheader button">
+                                {{ __('common.created_at') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at'])
+                            </th>
+                            <th wire:click="sortBy('deleted_at')" role="columnheader button">
+                                {{ __('user.deleted-on') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'deleted_at'])
+                            </th>
+                        </tr>
+                        @forelse ($emailUpdates as $emailUpdate)
+                            <tr>
+                                <td>
+                                    <x-user-tag :user="$emailUpdate->user" :anon="false" />
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $emailUpdate->created_at }}"
+                                        title="{{ $emailUpdate->created_at }}"
+                                    >
+                                        {{ $emailUpdate->created_at }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $emailUpdate->deleted_at }}"
+                                        title="{{ $emailUpdate->deleted_at }}"
+                                    >
+                                        {{ $emailUpdate->deleted_at ?? 'Currently in use' }}
+                                    </time>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3">No email updates</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+        @endswitch
     </div>
     {{ $emailUpdates->links('partials.pagination') }}
 </section>

--- a/resources/views/livewire/passkey-search.blade.php
+++ b/resources/views/livewire/passkey-search.blade.php
@@ -34,6 +34,15 @@
             </div>
             <div class="panel__action">
                 <div class="form__group">
+                    <select id="groupBy" class="form__select" wire:model.live="groupBy">
+                        <option value="none">None</option>
+                        <option value="user_id">{{ __('common.username') }}</option>
+                    </select>
+                    <label class="form__label form__label--floating" for="groupBy">Group by</label>
+                </div>
+            </div>
+            <div class="panel__action">
+                <div class="form__group">
                     <select id="quantity" class="form__select" wire:model.live="perPage" required>
                         <option>25</option>
                         <option>50</option>
@@ -47,56 +56,134 @@
         </div>
     </header>
     <div class="data-table-wrapper">
-        <table class="data-table">
-            <tbody>
-                <tr>
-                    <th wire:click="sortBy('user_id')" role="columnheader button">
-                        {{ __('common.username') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'user_id'])
-                    </th>
-                    <th wire:click="sortBy('content')" role="columnheader button">
-                        {{ __('user.passkey') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'content'])
-                    </th>
-                    <th wire:click="sortBy('created_at')" role="columnheader button">
-                        {{ __('common.created_at') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'created_at'])
-                    </th>
-                    <th wire:click="sortBy('deleted_at')" role="columnheader button">
-                        {{ __('user.deleted-on') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'deleted_at'])
-                    </th>
-                </tr>
-                @forelse ($passkeys as $passkey)
-                    <tr>
-                        <td>
-                            <x-user-tag :user="$passkey->user" :anon="false" />
-                        </td>
-                        <td>{{ $passkey->content }}</td>
-                        <td>
-                            <time
-                                datetime="{{ $passkey->created_at }}"
-                                title="{{ $passkey->created_at }}"
-                            >
-                                {{ $passkey->created_at }}
-                            </time>
-                        </td>
-                        <td>
-                            <time
-                                datetime="{{ $passkey->deleted_at }}"
-                                title="{{ $passkey->deleted_at }}"
-                            >
-                                {{ $passkey->deleted_at ?? 'Currently in use' }}
-                            </time>
-                        </td>
-                    </tr>
-                @empty
-                    <tr>
-                        <td colspan="4">No passkeys</td>
-                    </tr>
-                @endforelse
-            </tbody>
-        </table>
+        @switch($groupBy)
+            @case('user_id')
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <th wire:click="sortBy('user_id')" role="columnheader button">
+                                {{ __('common.username') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'user_id'])
+                            </th>
+                            <th wire:click="sortBy('created_at_min')" role="columnheader button">
+                                First created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_min'])
+                            </th>
+                            <th wire:click="sortBy('created_at_avg')" role="columnheader button">
+                                Average created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_avg'])
+                            </th>
+                            <th wire:click="sortBy('created_at_max')" role="columnheader button">
+                                Last created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_max'])
+                            </th>
+                            <th wire:click="sortBy('key_count')" role="columnheader button">
+                                Passkeys
+                                @include('livewire.includes._sort-icon', ['field' => 'key_count'])
+                            </th>
+                            <th wire:click="sortBy('active_count')" role="columnheader button">
+                                Currently in use
+                                @include('livewire.includes._sort-icon', ['field' => 'active_count'])
+                            </th>
+                            <th wire:click="sortBy('deleted_count')" role="columnheader button">
+                                Deleted
+                                @include('livewire.includes._sort-icon', ['field' => 'deleted_count'])
+                            </th>
+                        </tr>
+                        @forelse ($passkeys as $passkey)
+                            <tr>
+                                <td>
+                                    <x-user-tag :user="$passkey->user" :anon="false" />
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $passkey->created_at_min }}"
+                                        title="{{ $passkey->created_at_min }}"
+                                    >
+                                        {{ $passkey->created_at_min }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $passkey->created_at_avg }}"
+                                        title="{{ $passkey->created_at_avg }}"
+                                    >
+                                        {{ $passkey->created_at_avg }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $passkey->created_at_max }}"
+                                        title="{{ $passkey->created_at_max }}"
+                                    >
+                                        {{ $passkey->created_at_max }}
+                                    </time>
+                                </td>
+                                <td>{{ $passkey->key_count }}</td>
+                                <td>{{ $passkey->active_count }}</td>
+                                <td>{{ $passkey->deleted_count }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7">No passkeys</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+
+                @break
+            @default
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <th wire:click="sortBy('user_id')" role="columnheader button">
+                                {{ __('common.username') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'user_id'])
+                            </th>
+                            <th wire:click="sortBy('content')" role="columnheader button">
+                                {{ __('user.passkey') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'content'])
+                            </th>
+                            <th wire:click="sortBy('created_at')" role="columnheader button">
+                                {{ __('common.created_at') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at'])
+                            </th>
+                            <th wire:click="sortBy('deleted_at')" role="columnheader button">
+                                {{ __('user.deleted-on') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'deleted_at'])
+                            </th>
+                        </tr>
+                        @forelse ($passkeys as $passkey)
+                            <tr>
+                                <td>
+                                    <x-user-tag :user="$passkey->user" :anon="false" />
+                                </td>
+                                <td>{{ $passkey->content }}</td>
+                                <td>
+                                    <time
+                                        datetime="{{ $passkey->created_at }}"
+                                        title="{{ $passkey->created_at }}"
+                                    >
+                                        {{ $passkey->created_at }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $passkey->deleted_at }}"
+                                        title="{{ $passkey->deleted_at }}"
+                                    >
+                                        {{ $passkey->deleted_at ?? 'Currently in use' }}
+                                    </time>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="4">No passkeys</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+        @endswitch
     </div>
     {{ $passkeys->links('partials.pagination') }}
 </section>

--- a/resources/views/livewire/rsskey-search.blade.php
+++ b/resources/views/livewire/rsskey-search.blade.php
@@ -34,6 +34,15 @@
             </div>
             <div class="panel__action">
                 <div class="form__group">
+                    <select id="groupBy" class="form__select" wire:model.live="groupBy">
+                        <option value="none">None</option>
+                        <option value="user_id">{{ __('common.username') }}</option>
+                    </select>
+                    <label class="form__label form__label--floating" for="groupBy">Group by</label>
+                </div>
+            </div>
+            <div class="panel__action">
+                <div class="form__group">
                     <select id="quantity" class="form__select" wire:model.live="perPage" required>
                         <option>25</option>
                         <option>50</option>
@@ -47,56 +56,134 @@
         </div>
     </header>
     <div class="data-table-wrapper">
-        <table class="data-table">
-            <tbody>
-                <tr>
-                    <th wire:click="sortBy('user_id')" role="columnheader button">
-                        {{ __('common.username') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'user_id'])
-                    </th>
-                    <th wire:click="sortBy('content')" role="columnheader button">
-                        {{ __('user.rsskey') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'content'])
-                    </th>
-                    <th wire:click="sortBy('created_at')" role="columnheader button">
-                        {{ __('common.created_at') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'created_at'])
-                    </th>
-                    <th wire:click="sortBy('deleted_at')" role="columnheader button">
-                        {{ __('user.deleted-on') }}
-                        @include('livewire.includes._sort-icon', ['field' => 'deleted_at'])
-                    </th>
-                </tr>
-                @forelse ($rsskeys as $rsskey)
-                    <tr>
-                        <td>
-                            <x-user-tag :user="$rsskey->user" :anon="false" />
-                        </td>
-                        <td>{{ $rsskey->content }}</td>
-                        <td>
-                            <time
-                                datetime="{{ $rsskey->created_at }}"
-                                title="{{ $rsskey->created_at }}"
-                            >
-                                {{ $rsskey->created_at }}
-                            </time>
-                        </td>
-                        <td>
-                            <time
-                                datetime="{{ $rsskey->deleted_at }}"
-                                title="{{ $rsskey->deleted_at }}"
-                            >
-                                {{ $rsskey->deleted_at ?? 'Currently in use' }}
-                            </time>
-                        </td>
-                    </tr>
-                @empty
-                    <tr>
-                        <td colspan="4">No rsskeys</td>
-                    </tr>
-                @endforelse
-            </tbody>
-        </table>
+        @switch($groupBy)
+            @case('user_id')
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <th wire:click="sortBy('user_id')" role="columnheader button">
+                                {{ __('common.username') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'user_id'])
+                            </th>
+                            <th wire:click="sortBy('created_at_min')" role="columnheader button">
+                                First created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_min'])
+                            </th>
+                            <th wire:click="sortBy('created_at_avg')" role="columnheader button">
+                                Average created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_avg'])
+                            </th>
+                            <th wire:click="sortBy('created_at_max')" role="columnheader button">
+                                Last created at
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at_max'])
+                            </th>
+                            <th wire:click="sortBy('key_count')" role="columnheader button">
+                                RSS keys
+                                @include('livewire.includes._sort-icon', ['field' => 'key_count'])
+                            </th>
+                            <th wire:click="sortBy('active_count')" role="columnheader button">
+                                Currently in use
+                                @include('livewire.includes._sort-icon', ['field' => 'active_count'])
+                            </th>
+                            <th wire:click="sortBy('deleted_count')" role="columnheader button">
+                                Deleted
+                                @include('livewire.includes._sort-icon', ['field' => 'deleted_count'])
+                            </th>
+                        </tr>
+                        @forelse ($rsskeys as $rsskey)
+                            <tr>
+                                <td>
+                                    <x-user-tag :user="$rsskey->user" :anon="false" />
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $rsskey->created_at_min }}"
+                                        title="{{ $rsskey->created_at_min }}"
+                                    >
+                                        {{ $rsskey->created_at_min }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $rsskey->created_at_avg }}"
+                                        title="{{ $rsskey->created_at_avg }}"
+                                    >
+                                        {{ $rsskey->created_at_avg }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $rsskey->created_at_max }}"
+                                        title="{{ $rsskey->created_at_max }}"
+                                    >
+                                        {{ $rsskey->created_at_max }}
+                                    </time>
+                                </td>
+                                <td>{{ $rsskey->key_count }}</td>
+                                <td>{{ $rsskey->active_count }}</td>
+                                <td>{{ $rsskey->deleted_count }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7">No rsskeys</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+
+                @break
+            @default
+                <table class="data-table">
+                    <tbody>
+                        <tr>
+                            <th wire:click="sortBy('user_id')" role="columnheader button">
+                                {{ __('common.username') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'user_id'])
+                            </th>
+                            <th wire:click="sortBy('content')" role="columnheader button">
+                                {{ __('user.rsskey') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'content'])
+                            </th>
+                            <th wire:click="sortBy('created_at')" role="columnheader button">
+                                {{ __('common.created_at') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at'])
+                            </th>
+                            <th wire:click="sortBy('deleted_at')" role="columnheader button">
+                                {{ __('user.deleted-on') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'deleted_at'])
+                            </th>
+                        </tr>
+                        @forelse ($rsskeys as $rsskey)
+                            <tr>
+                                <td>
+                                    <x-user-tag :user="$rsskey->user" :anon="false" />
+                                </td>
+                                <td>{{ $rsskey->content }}</td>
+                                <td>
+                                    <time
+                                        datetime="{{ $rsskey->created_at }}"
+                                        title="{{ $rsskey->created_at }}"
+                                    >
+                                        {{ $rsskey->created_at }}
+                                    </time>
+                                </td>
+                                <td>
+                                    <time
+                                        datetime="{{ $rsskey->deleted_at }}"
+                                        title="{{ $rsskey->deleted_at }}"
+                                    >
+                                        {{ $rsskey->deleted_at ?? 'Currently in use' }}
+                                    </time>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="4">No rsskeys</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+        @endswitch
     </div>
     {{ $rsskeys->links('partials.pagination') }}
 </section>

--- a/tests/Feature/Http/Livewire/DashboardCredentialGroupByTest.php
+++ b/tests/Feature/Http/Livewire/DashboardCredentialGroupByTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Livewire\ApikeySearch;
+use App\Http\Livewire\EmailUpdateSearch;
+use App\Http\Livewire\PasskeySearch;
+use App\Http\Livewire\RsskeySearch;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+test('staff credential searches can group keys by user', function (string $component, string $table, string $contentPrefix, string $heading): void {
+    $staff = User::factory()->create();
+    $user = User::factory()->create(['username' => $contentPrefix.'-owner']);
+
+    DB::table($table)->insert([
+        [
+            'user_id'    => $user->id,
+            'content'    => $contentPrefix.'-active',
+            'created_at' => now()->subDays(2),
+            'deleted_at' => null,
+        ],
+        [
+            'user_id'    => $user->id,
+            'content'    => $contentPrefix.'-deleted',
+            'created_at' => now()->subDay(),
+            'deleted_at' => now(),
+        ],
+    ]);
+
+    Livewire::actingAs($staff)
+        ->test($component)
+        ->set('groupBy', 'user_id')
+        ->assertSet('sortField', 'created_at_max')
+        ->assertSee($contentPrefix.'-owner')
+        ->assertSee($heading)
+        ->assertSeeHtml('<td>2</td>')
+        ->assertSeeHtml('<td>1</td>')
+        ->assertDontSee($contentPrefix.'-active')
+        ->assertDontSee($contentPrefix.'-deleted');
+})->with([
+    'api keys' => [ApikeySearch::class, 'apikeys', 'api-key', 'API keys'],
+    'rss keys' => [RsskeySearch::class, 'rsskeys', 'rss-key', 'RSS keys'],
+    'passkeys' => [PasskeySearch::class, 'passkeys', 'pass-key', 'Passkeys'],
+]);
+
+test('staff email update search can group rows by user', function (): void {
+    $staff = User::factory()->create();
+    $user = User::factory()->create(['username' => 'email-update-owner']);
+
+    DB::table('email_updates')->insert([
+        [
+            'user_id'    => $user->id,
+            'created_at' => now()->subDays(2),
+            'deleted_at' => null,
+        ],
+        [
+            'user_id'    => $user->id,
+            'created_at' => now()->subDay(),
+            'deleted_at' => now(),
+        ],
+    ]);
+
+    Livewire::actingAs($staff)
+        ->test(EmailUpdateSearch::class)
+        ->set('groupBy', 'user_id')
+        ->assertSet('sortField', 'created_at_max')
+        ->assertSee('email-update-owner')
+        ->assertSee('Email updates')
+        ->assertSeeHtml('<td>2</td>')
+        ->assertSeeHtml('<td>1</td>');
+});


### PR DESCRIPTION
## Summary
- add `groupBy=user_id` controls to API key, RSS key, passkey, and email update staff searches
- aggregate grouped rows by user with first, average, and latest timestamps plus total/current/deleted counts
- add Livewire regression coverage for grouped dashboard credential tools

Closes #3678

## Tests
- `git diff --check`
- `./node_modules/.bin/prettier --check resources/views/livewire/apikey-search.blade.php resources/views/livewire/rsskey-search.blade.php resources/views/livewire/passkey-search.blade.php resources/views/livewire/email-update-search.blade.php`
- `vendor/bin/pint --test app/Http/Livewire/ApikeySearch.php app/Http/Livewire/RsskeySearch.php app/Http/Livewire/PasskeySearch.php app/Http/Livewire/EmailUpdateSearch.php tests/Feature/Http/Livewire/DashboardCredentialGroupByTest.php`
- `php artisan test tests/Feature/Http/Livewire/DashboardCredentialGroupByTest.php --stop-on-failure` (Docker/MySQL: 4 passed, 26 assertions)
- `php artisan view:cache` (Docker; current development required a local-only Livewire route shim, reverted before commit)