### PR TITLE
Add poster view to top torrents

### DIFF
--- a/app/Http/Livewire/TopTorrents.php
+++ b/app/Http/Livewire/TopTorrents.php
@@ -99,7 +99,7 @@ class TopTorrents extends Component
                                 )
                         )
                 )
-                ->take(5)
+                ->take($this->tab === 'newest' ? 15 : 5)
                 ->get();
 
             // See app/Traits/TorrentMeta.php

--- a/resources/views/components/torrent/poster.blade.php
+++ b/resources/views/components/torrent/poster.blade.php
@@ -1,0 +1,43 @@
+@props([
+    'torrent',
+    'meta',
+])
+
+@php
+    $poster = match (true) {
+        $torrent->category->movie_meta, $torrent->category->tv_meta => isset($meta->poster) ? tmdb_image('poster_mid', $meta->poster) : 'https://via.placeholder.com/160x240',
+        $torrent->category->game_meta && isset($meta->cover_image_id) => 'https://images.igdb.com/igdb/image/upload/t_cover_big/' . $meta->cover_image_id . '.jpg',
+        $torrent->category->no_meta && Storage::disk('torrent-covers')->exists("torrent-cover_$torrent->id.jpg") => route('authenticated_images.torrent_cover', ['id' => $torrent->id]),
+        default => 'https://via.placeholder.com/160x240',
+    };
+    $title = match (true) {
+        $torrent->category->movie_meta => $meta->title ?? $torrent->name,
+        $torrent->category->tv_meta, $torrent->category->game_meta => $meta->name ?? $torrent->name,
+        default => $torrent->name,
+    };
+    $year = match (true) {
+        $torrent->category->movie_meta => substr((string) ($meta->release_date ?? ''), 0, 4),
+        $torrent->category->tv_meta => substr((string) ($meta->first_air_date ?? ''), 0, 4),
+        $torrent->category->game_meta => substr((string) ($meta->first_release_date ?? ''), 0, 4),
+        default => '',
+    };
+@endphp
+
+<article class="torrent-search--poster__result">
+    <figure>
+        <a
+            href="{{ route('torrents.show', ['id' => $torrent->id]) }}"
+            class="torrent-search--poster__poster"
+        >
+            <img src="{{ $poster }}" alt="{{ $title }}" loading="lazy" />
+        </a>
+        <figcaption class="torrent-search--poster__caption">
+            <h2 class="torrent-search--poster__title">
+                {{ $title }}
+            </h2>
+            <h3 class="torrent-search--poster__release-date">
+                {{ $year ?: $torrent->created_at->diffForHumans() }}
+            </h3>
+        </figcaption>
+    </figure>
+</article>

--- a/resources/views/livewire/top-torrents.blade.php
+++ b/resources/views/livewire/top-torrents.blade.php
@@ -29,17 +29,27 @@
             {{ __('torrent.dead-torrents') }}
         </li>
     </menu>
-    <div class="data-table-wrapper">
-        <table class="data-table">
-            <tbody>
-                @foreach ($torrents as $torrent)
-                    <x-torrent.row
-                        :$torrent
-                        :meta="$torrent->meta"
-                        :personalFreeleech="$personal_freeleech"
-                    />
-                @endforeach
-            </tbody>
-        </table>
-    </div>
+    @if ($tab === 'newest')
+        <div class="panel__body torrent-search--poster__results">
+            @forelse ($torrents as $torrent)
+                <x-torrent.poster :$torrent :meta="$torrent->meta" />
+            @empty
+                {{ __('common.no-result') }}
+            @endforelse
+        </div>
+    @else
+        <div class="data-table-wrapper">
+            <table class="data-table">
+                <tbody>
+                    @foreach ($torrents as $torrent)
+                        <x-torrent.row
+                            :$torrent
+                            :meta="$torrent->meta"
+                            :personalFreeleech="$personal_freeleech"
+                        />
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
 </section>

--- a/tests/Feature/Http/Livewire/TopTorrentsTest.php
+++ b/tests/Feature/Http/Livewire/TopTorrentsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Http\Livewire\TopTorrents;
+use App\Models\Category;
+use App\Models\Resolution;
+use App\Models\Torrent;
+use App\Models\Type;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('newest top torrents render as a larger poster grid', function (): void {
+    $user = User::factory()->create();
+    $category = Category::factory()->create([
+        'no_meta'    => true,
+        'music_meta' => false,
+        'game_meta'  => false,
+        'tv_meta'    => false,
+        'movie_meta' => false,
+    ]);
+    $type = Type::factory()->create();
+    $resolution = Resolution::factory()->create();
+
+    for ($i = 1; $i <= 16; $i++) {
+        Torrent::factory()->create([
+            'name'          => \sprintf('Newest %02d', $i),
+            'category_id'   => $category->id,
+            'type_id'       => $type->id,
+            'resolution_id' => $resolution->id,
+        ]);
+    }
+
+    Livewire::actingAs($user)
+        ->test(TopTorrents::class)
+        ->assertSet('tab', 'newest')
+        ->assertSee('torrent-search--poster__results', false)
+        ->assertSee('Newest 16')
+        ->assertSee('Newest 02')
+        ->assertDontSee('Newest 01');
+});
+
+test('non-newest top torrent tabs keep the compact row table', function (): void {
+    $user = User::factory()->create();
+
+    Torrent::factory()->count(6)->create([
+        'seeders' => 10,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(TopTorrents::class)
+        ->set('tab', 'seeded')
+        ->assertSee('data-table-wrapper', false)
+        ->assertDontSee('torrent-search--poster__results', false);
+});


### PR DESCRIPTION
## Summary
- render the New Torrents tab in the top-torrents block as a poster grid
- expand the New Torrents tab from 5 rows to 15 poster entries for a quicker glance
- keep the seeded, leeched, dying, and dead tabs on the existing compact row table
- add a reusable torrent poster component and Livewire regression coverage

Closes #3674

## Tests
- `git diff --check`
- `./node_modules/.bin/prettier --check resources/views/livewire/top-torrents.blade.php resources/views/components/torrent/poster.blade.php`
- `vendor/bin/pint --test app/Http/Livewire/TopTorrents.php tests/Feature/Http/Livewire/TopTorrentsTest.php`
- `php artisan test tests/Feature/Http/Livewire/TopTorrentsTest.php --stop-on-failure` (Docker/MySQL: 2 passed, 7 assertions)
- `php artisan view:cache` (Docker; current development required a local-only Livewire route shim, reverted before commit)