### PR TITLE
Add autogroup requirement unit conversion

### DIFF
--- a/app/Http/Controllers/Staff/GroupController.php
+++ b/app/Http/Controllers/Staff/GroupController.php
@@ -60,7 +60,7 @@ class GroupController extends Controller
      */
     public function store(StoreGroupRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $group = Group::query()->create(['slug' => Str::slug($request->validated('group.name'))] + $request->validated('group'));
+        $group = Group::query()->create(['slug' => Str::slug($request->validated('group.name'))] + $request->groupAttributes());
 
         $group->permissions()->upsert($request->validated('permissions'), ['forum_id', 'group_id']);
 
@@ -91,7 +91,7 @@ class GroupController extends Controller
      */
     public function update(UpdateGroupRequest $request, Group $group): \Illuminate\Http\RedirectResponse
     {
-        $group->update(['slug' => Str::slug($request->validated('group.name'))] + $request->validated('group'));
+        $group->update(['slug' => Str::slug($request->validated('group.name'))] + $request->groupAttributes());
 
         $group->permissions()->upsert($request->validated('permissions'), ['forum_id', 'group_id']);
 

--- a/app/Http/Requests/Staff/StoreGroupRequest.php
+++ b/app/Http/Requests/Staff/StoreGroupRequest.php
@@ -16,12 +16,24 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Staff;
 
+use App\Support\AutogroupRequirementUnits;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 
 class StoreGroupRequest extends FormRequest
 {
+    protected function prepareForValidation(): void
+    {
+        $group = $this->input('group');
+
+        if (\is_array($group)) {
+            $this->merge([
+                'group' => AutogroupRequirementUnits::convertGroup($group),
+            ]);
+        }
+    }
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -37,6 +49,8 @@ class StoreGroupRequest extends FormRequest
      */
     public function rules(Request $request): array
     {
+        $autogroup = $request->boolean('group.autogroup');
+
         return [
             'group.name' => [
                 'required',
@@ -140,43 +154,72 @@ class StoreGroupRequest extends FormRequest
                 'boolean',
             ],
             'group.min_uploaded' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
                 ], 'prohibited'),
             ],
+            'group.min_uploaded_unit' => [
+                Rule::when($autogroup, [
+                    'sometimes',
+                    Rule::in(array_keys(AutogroupRequirementUnits::BYTE_UNITS)),
+                ], 'nullable'),
+            ],
             'group.min_ratio' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
                     'min:0',
                     'max:99.99',
                 ], 'prohibited'),
             ],
             'group.min_age' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
                 ], 'prohibited'),
+            ],
+            'group.min_age_unit' => [
+                Rule::when($autogroup, [
+                    'sometimes',
+                    Rule::in(array_keys(AutogroupRequirementUnits::TIME_UNITS)),
+                ], 'nullable'),
             ],
             'group.min_avg_seedtime' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
                 ], 'prohibited'),
+            ],
+            'group.min_avg_seedtime_unit' => [
+                Rule::when($autogroup, [
+                    'sometimes',
+                    Rule::in(array_keys(AutogroupRequirementUnits::TIME_UNITS)),
+                ], 'nullable'),
             ],
             'group.min_seedsize' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
                 ], 'prohibited'),
             ],
-            'group.min_uploads' => [
-                Rule::when($request->boolean('autogroup'), [
+            'group.min_seedsize_unit' => [
+                Rule::when($autogroup, [
                     'sometimes',
+                    Rule::in(array_keys(AutogroupRequirementUnits::BYTE_UNITS)),
+                ], 'nullable'),
+            ],
+            'group.min_uploads' => [
+                Rule::when($autogroup, [
+                    'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
                 ], 'prohibited'),
@@ -206,5 +249,13 @@ class StoreGroupRequest extends FormRequest
                 'boolean',
             ],
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function groupAttributes(): array
+    {
+        return AutogroupRequirementUnits::stripUnitFields($this->validated('group'));
     }
 }

--- a/app/Http/Requests/Staff/UpdateGroupRequest.php
+++ b/app/Http/Requests/Staff/UpdateGroupRequest.php
@@ -17,12 +17,24 @@ declare(strict_types=1);
 namespace App\Http\Requests\Staff;
 
 use App\Models\Group;
+use App\Support\AutogroupRequirementUnits;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 
 class UpdateGroupRequest extends FormRequest
 {
+    protected function prepareForValidation(): void
+    {
+        $group = $this->input('group');
+
+        if (\is_array($group)) {
+            $this->merge([
+                'group' => AutogroupRequirementUnits::convertGroup($group),
+            ]);
+        }
+    }
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -40,6 +52,7 @@ class UpdateGroupRequest extends FormRequest
     {
         /** @var Group $group */
         $group = $request->route('group');
+        $autogroup = $request->boolean('group.autogroup');
 
         return [
             'group.name' => [
@@ -146,43 +159,72 @@ class UpdateGroupRequest extends FormRequest
                 'boolean',
             ],
             'group.min_uploaded' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
                 ], 'nullable'),
             ],
+            'group.min_uploaded_unit' => [
+                Rule::when($autogroup, [
+                    'sometimes',
+                    Rule::in(array_keys(AutogroupRequirementUnits::BYTE_UNITS)),
+                ], 'nullable'),
+            ],
             'group.min_ratio' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
                     'min:0',
                     'max:99.99',
                 ], 'nullable'),
             ],
             'group.min_age' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
+                ], 'nullable'),
+            ],
+            'group.min_age_unit' => [
+                Rule::when($autogroup, [
+                    'sometimes',
+                    Rule::in(array_keys(AutogroupRequirementUnits::TIME_UNITS)),
                 ], 'nullable'),
             ],
             'group.min_avg_seedtime' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
+                ], 'nullable'),
+            ],
+            'group.min_avg_seedtime_unit' => [
+                Rule::when($autogroup, [
+                    'sometimes',
+                    Rule::in(array_keys(AutogroupRequirementUnits::TIME_UNITS)),
                 ], 'nullable'),
             ],
             'group.min_seedsize' => [
-                Rule::when($request->boolean('autogroup'), [
+                Rule::when($autogroup, [
                     'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
                 ], 'nullable'),
             ],
-            'group.min_uploads' => [
-                Rule::when($request->boolean('autogroup'), [
+            'group.min_seedsize_unit' => [
+                Rule::when($autogroup, [
                     'sometimes',
+                    Rule::in(array_keys(AutogroupRequirementUnits::BYTE_UNITS)),
+                ], 'nullable'),
+            ],
+            'group.min_uploads' => [
+                Rule::when($autogroup, [
+                    'sometimes',
+                    'nullable',
                     'integer',
                     'min:0',
                 ], 'nullable'),
@@ -224,5 +266,13 @@ class UpdateGroupRequest extends FormRequest
         return [
             'name.prohibited' => 'You cannot change the name of a system required group.',
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function groupAttributes(): array
+    {
+        return AutogroupRequirementUnits::stripUnitFields($this->validated('group'));
     }
 }

--- a/app/Support/AutogroupRequirementUnits.php
+++ b/app/Support/AutogroupRequirementUnits.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Support;
+
+use Illuminate\Support\Arr;
+
+final class AutogroupRequirementUnits
+{
+    /**
+     * @var array<string, int>
+     */
+    public const array BYTE_UNITS = [
+        'bytes' => 1,
+        'mb'    => 1024 ** 2,
+        'gb'    => 1024 ** 3,
+        'tb'    => 1024 ** 4,
+    ];
+
+    /**
+     * @var array<string, int>
+     */
+    public const array TIME_UNITS = [
+        'seconds' => 1,
+        'days'    => 86400,
+        'weeks'   => 604800,
+        'months'  => 2592000,
+        'years'   => 31536000,
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const array UNIT_FIELDS = [
+        'min_uploaded_unit',
+        'min_seedsize_unit',
+        'min_age_unit',
+        'min_avg_seedtime_unit',
+    ];
+
+    /**
+     * @param  array<string, mixed> $group
+     * @return array<string, mixed>
+     */
+    public static function convertGroup(array $group): array
+    {
+        $group['min_uploaded'] = self::convert($group['min_uploaded'] ?? null, $group['min_uploaded_unit'] ?? 'bytes', self::BYTE_UNITS);
+        $group['min_seedsize'] = self::convert($group['min_seedsize'] ?? null, $group['min_seedsize_unit'] ?? 'bytes', self::BYTE_UNITS);
+        $group['min_age'] = self::convert($group['min_age'] ?? null, $group['min_age_unit'] ?? 'seconds', self::TIME_UNITS);
+        $group['min_avg_seedtime'] = self::convert($group['min_avg_seedtime'] ?? null, $group['min_avg_seedtime_unit'] ?? 'seconds', self::TIME_UNITS);
+
+        return $group;
+    }
+
+    /**
+     * @param  array<string, mixed> $group
+     * @return array<string, mixed>
+     */
+    public static function stripUnitFields(array $group): array
+    {
+        return Arr::except($group, self::UNIT_FIELDS);
+    }
+
+    /**
+     * @return array{value: int|null, unit: string}
+     */
+    public static function displayByte(?int $value): array
+    {
+        return self::display($value, array_reverse(self::BYTE_UNITS, true), 'bytes');
+    }
+
+    /**
+     * @return array{value: int|null, unit: string}
+     */
+    public static function displayTime(?int $value): array
+    {
+        return self::display($value, array_reverse(self::TIME_UNITS, true), 'seconds');
+    }
+
+    /**
+     * @param array<string, int> $units
+     */
+    private static function convert(mixed $value, mixed $unit, array $units): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_INT) === false || ! \is_string($unit) || ! isset($units[$unit])) {
+            return $value;
+        }
+
+        return (int) $value * $units[$unit];
+    }
+
+    /**
+     * @param  array<string, int>                   $units
+     * @return array{value: int|null, unit: string}
+     */
+    private static function display(?int $value, array $units, string $defaultUnit): array
+    {
+        if ($value === null) {
+            return [
+                'value' => null,
+                'unit'  => $defaultUnit,
+            ];
+        }
+
+        foreach ($units as $unit => $multiplier) {
+            if ($multiplier !== 1 && $value >= $multiplier && $value % $multiplier === 0) {
+                return [
+                    'value' => (int) ($value / $multiplier),
+                    'unit'  => $unit,
+                ];
+            }
+        }
+
+        return [
+            'value' => $value,
+            'unit'  => $defaultUnit,
+        ];
+    }
+}

--- a/resources/views/Staff/group/create.blade.php
+++ b/resources/views/Staff/group/create.blade.php
@@ -330,18 +330,36 @@
                     />
                     <label class="form__label" for="autogroup">Autogroup</label>
                 </p>
-                <p class="form__group" x-show="autogroup" x-cloak>
-                    <input
-                        id="min_uploaded"
-                        class="form__text"
-                        type="text"
-                        name="group[min_uploaded]"
-                        placeholder=" "
-                    />
-                    <label class="form__label form__label--floating" for="min_uploaded">
-                        Minimum upload required
-                    </label>
-                </p>
+                <div class="form__group--horizontal" x-show="autogroup" x-cloak>
+                    <p class="form__group">
+                        <select
+                            id="min_uploaded_unit"
+                            class="form__select"
+                            name="group[min_uploaded_unit]"
+                            x-bind:disabled="!autogroup"
+                        >
+                            <option value="bytes">Bytes</option>
+                            <option value="mb">MB</option>
+                            <option value="gb">GB</option>
+                            <option value="tb">TB</option>
+                        </select>
+                        <label class="form__label form__label--floating" for="min_uploaded_unit">
+                            Upload unit
+                        </label>
+                    </p>
+                    <p class="form__group">
+                        <input
+                            id="min_uploaded"
+                            class="form__text"
+                            type="text"
+                            name="group[min_uploaded]"
+                            placeholder=" "
+                        />
+                        <label class="form__label form__label--floating" for="min_uploaded">
+                            Minimum upload required
+                        </label>
+                    </p>
+                </div>
                 <p class="form__group" x-show="autogroup" x-cloak>
                     <input
                         id="min_ratio"
@@ -354,42 +372,101 @@
                         Minimum ratio required
                     </label>
                 </p>
-                <p class="form__group" x-show="autogroup" x-cloak>
-                    <input
-                        id="min_age"
-                        class="form__text"
-                        type="text"
-                        name="group[min_age]"
-                        placeholder=" "
-                    />
-                    <label class="form__label form__label--floating" for="min_age">
-                        Minimum age required
-                    </label>
-                </p>
-                <p class="form__group" x-show="autogroup" x-cloak>
-                    <input
-                        id="min_avg_seedtime"
-                        class="form__text"
-                        type="text"
-                        name="group[min_avg_seedtime]"
-                        placeholder=" "
-                    />
-                    <label class="form__label form__label--floating" for="min_avg_seedtime">
-                        Minimum average seedtime required
-                    </label>
-                </p>
-                <p class="form__group" x-show="autogroup" x-cloak>
-                    <input
-                        id="min_seedsize"
-                        class="form__text"
-                        type="text"
-                        name="group[min_seedsize]"
-                        placeholder=" "
-                    />
-                    <label class="form__label form__label--floating" for="min_seedsize">
-                        Minimum seedsize required
-                    </label>
-                </p>
+                <div class="form__group--horizontal" x-show="autogroup" x-cloak>
+                    <p class="form__group">
+                        <select
+                            id="min_age_unit"
+                            class="form__select"
+                            name="group[min_age_unit]"
+                            x-bind:disabled="!autogroup"
+                        >
+                            <option value="seconds">Seconds</option>
+                            <option value="days">Days</option>
+                            <option value="weeks">Weeks</option>
+                            <option value="months">Months</option>
+                            <option value="years">Years</option>
+                        </select>
+                        <label class="form__label form__label--floating" for="min_age_unit">
+                            Age unit
+                        </label>
+                    </p>
+                    <p class="form__group">
+                        <input
+                            id="min_age"
+                            class="form__text"
+                            type="text"
+                            name="group[min_age]"
+                            placeholder=" "
+                        />
+                        <label class="form__label form__label--floating" for="min_age">
+                            Minimum age required
+                        </label>
+                    </p>
+                </div>
+                <div class="form__group--horizontal" x-show="autogroup" x-cloak>
+                    <p class="form__group">
+                        <select
+                            id="min_avg_seedtime_unit"
+                            class="form__select"
+                            name="group[min_avg_seedtime_unit]"
+                            x-bind:disabled="!autogroup"
+                        >
+                            <option value="seconds">Seconds</option>
+                            <option value="days">Days</option>
+                            <option value="weeks">Weeks</option>
+                            <option value="months">Months</option>
+                            <option value="years">Years</option>
+                        </select>
+                        <label
+                            class="form__label form__label--floating"
+                            for="min_avg_seedtime_unit"
+                        >
+                            Seedtime unit
+                        </label>
+                    </p>
+                    <p class="form__group">
+                        <input
+                            id="min_avg_seedtime"
+                            class="form__text"
+                            type="text"
+                            name="group[min_avg_seedtime]"
+                            placeholder=" "
+                        />
+                        <label class="form__label form__label--floating" for="min_avg_seedtime">
+                            Minimum average seedtime required
+                        </label>
+                    </p>
+                </div>
+                <div class="form__group--horizontal" x-show="autogroup" x-cloak>
+                    <p class="form__group">
+                        <select
+                            id="min_seedsize_unit"
+                            class="form__select"
+                            name="group[min_seedsize_unit]"
+                            x-bind:disabled="!autogroup"
+                        >
+                            <option value="bytes">Bytes</option>
+                            <option value="mb">MB</option>
+                            <option value="gb">GB</option>
+                            <option value="tb">TB</option>
+                        </select>
+                        <label class="form__label form__label--floating" for="min_seedsize_unit">
+                            Seedsize unit
+                        </label>
+                    </p>
+                    <p class="form__group">
+                        <input
+                            id="min_seedsize"
+                            class="form__text"
+                            type="text"
+                            name="group[min_seedsize]"
+                            placeholder=" "
+                        />
+                        <label class="form__label form__label--floating" for="min_seedsize">
+                            Minimum seedsize required
+                        </label>
+                    </p>
+                </div>
                 <p class="form__group" x-show="autogroup" x-cloak>
                     <input
                         id="min_uploads"

--- a/resources/views/Staff/group/edit.blade.php
+++ b/resources/views/Staff/group/edit.blade.php
@@ -25,6 +25,13 @@
     <section class="panelV2" x-data="{ autogroup: {{ Js::from($group->autogroup) }} }">
         <h2 class="panel__heading">Edit group: {{ $group->name }}</h2>
         <div class="panel__body">
+            @php
+                $minUploaded = \App\Support\AutogroupRequirementUnits::displayByte($group->min_uploaded);
+                $minSeedsize = \App\Support\AutogroupRequirementUnits::displayByte($group->min_seedsize);
+                $minAge = \App\Support\AutogroupRequirementUnits::displayTime($group->min_age);
+                $minAverageSeedtime = \App\Support\AutogroupRequirementUnits::displayTime($group->min_avg_seedtime);
+            @endphp
+
             <form
                 class="form"
                 method="POST"
@@ -366,19 +373,51 @@
                 <div class="form__group" x-show="autogroup">
                     <fieldset class="form form__fieldset">
                         <legend class="form__legend">Autogroup requirements</legend>
-                        <p class="form__group">
-                            <input
-                                id="min_uploaded"
-                                class="form__text"
-                                type="text"
-                                name="group[min_uploaded]"
-                                placeholder=" "
-                                value="{{ $group->min_uploaded }}"
-                            />
-                            <label class="form__label form__label--floating" for="min_uploaded">
-                                Minimum upload
-                            </label>
-                        </p>
+                        <div class="form__group--horizontal">
+                            <p class="form__group">
+                                <select
+                                    id="min_uploaded_unit"
+                                    class="form__select"
+                                    name="group[min_uploaded_unit]"
+                                    x-bind:disabled="!autogroup"
+                                >
+                                    <option
+                                        value="bytes"
+                                        @selected($minUploaded['unit'] === 'bytes')
+                                    >
+                                        Bytes
+                                    </option>
+                                    <option value="mb" @selected($minUploaded['unit'] === 'mb')>
+                                        MB
+                                    </option>
+                                    <option value="gb" @selected($minUploaded['unit'] === 'gb')>
+                                        GB
+                                    </option>
+                                    <option value="tb" @selected($minUploaded['unit'] === 'tb')>
+                                        TB
+                                    </option>
+                                </select>
+                                <label
+                                    class="form__label form__label--floating"
+                                    for="min_uploaded_unit"
+                                >
+                                    Upload unit
+                                </label>
+                            </p>
+                            <p class="form__group">
+                                <input
+                                    id="min_uploaded"
+                                    class="form__text"
+                                    type="text"
+                                    name="group[min_uploaded]"
+                                    placeholder=" "
+                                    value="{{ $minUploaded['value'] }}"
+                                />
+                                <label class="form__label form__label--floating" for="min_uploaded">
+                                    Minimum upload
+                                </label>
+                            </p>
+                        </div>
                         <p class="form__group">
                             <input
                                 id="min_ratio"
@@ -392,45 +431,159 @@
                                 Minimum ratio
                             </label>
                         </p>
-                        <p class="form__group">
-                            <input
-                                id="min_age"
-                                class="form__text"
-                                type="text"
-                                name="group[min_age]"
-                                placeholder=" "
-                                value="{{ $group->min_age }}"
-                            />
-                            <label class="form__label form__label--floating" for="min_age">
-                                Minimum age
-                            </label>
-                        </p>
-                        <p class="form__group">
-                            <input
-                                id="min_avg_seedtime"
-                                class="form__text"
-                                type="text"
-                                name="group[min_avg_seedtime]"
-                                placeholder=" "
-                                value="{{ $group->min_avg_seedtime }}"
-                            />
-                            <label class="form__label form__label--floating" for="min_avg_seedtime">
-                                Minimum average seedtime
-                            </label>
-                        </p>
-                        <p class="form__group">
-                            <input
-                                id="min_seedsize"
-                                class="form__text"
-                                type="text"
-                                name="group[min_seedsize]"
-                                placeholder=" "
-                                value="{{ $group->min_seedsize }}"
-                            />
-                            <label class="form__label form__label--floating" for="min_seedsize">
-                                Minimum seedsize
-                            </label>
-                        </p>
+                        <div class="form__group--horizontal">
+                            <p class="form__group">
+                                <select
+                                    id="min_age_unit"
+                                    class="form__select"
+                                    name="group[min_age_unit]"
+                                    x-bind:disabled="!autogroup"
+                                >
+                                    <option
+                                        value="seconds"
+                                        @selected($minAge['unit'] === 'seconds')
+                                    >
+                                        Seconds
+                                    </option>
+                                    <option value="days" @selected($minAge['unit'] === 'days')>
+                                        Days
+                                    </option>
+                                    <option value="weeks" @selected($minAge['unit'] === 'weeks')>
+                                        Weeks
+                                    </option>
+                                    <option value="months" @selected($minAge['unit'] === 'months')>
+                                        Months
+                                    </option>
+                                    <option value="years" @selected($minAge['unit'] === 'years')>
+                                        Years
+                                    </option>
+                                </select>
+                                <label class="form__label form__label--floating" for="min_age_unit">
+                                    Age unit
+                                </label>
+                            </p>
+                            <p class="form__group">
+                                <input
+                                    id="min_age"
+                                    class="form__text"
+                                    type="text"
+                                    name="group[min_age]"
+                                    placeholder=" "
+                                    value="{{ $minAge['value'] }}"
+                                />
+                                <label class="form__label form__label--floating" for="min_age">
+                                    Minimum age
+                                </label>
+                            </p>
+                        </div>
+                        <div class="form__group--horizontal">
+                            <p class="form__group">
+                                <select
+                                    id="min_avg_seedtime_unit"
+                                    class="form__select"
+                                    name="group[min_avg_seedtime_unit]"
+                                    x-bind:disabled="!autogroup"
+                                >
+                                    <option
+                                        value="seconds"
+                                        @selected($minAverageSeedtime['unit'] === 'seconds')
+                                    >
+                                        Seconds
+                                    </option>
+                                    <option
+                                        value="days"
+                                        @selected($minAverageSeedtime['unit'] === 'days')
+                                    >
+                                        Days
+                                    </option>
+                                    <option
+                                        value="weeks"
+                                        @selected($minAverageSeedtime['unit'] === 'weeks')
+                                    >
+                                        Weeks
+                                    </option>
+                                    <option
+                                        value="months"
+                                        @selected($minAverageSeedtime['unit'] === 'months')
+                                    >
+                                        Months
+                                    </option>
+                                    <option
+                                        value="years"
+                                        @selected($minAverageSeedtime['unit'] === 'years')
+                                    >
+                                        Years
+                                    </option>
+                                </select>
+                                <label
+                                    class="form__label form__label--floating"
+                                    for="min_avg_seedtime_unit"
+                                >
+                                    Seedtime unit
+                                </label>
+                            </p>
+                            <p class="form__group">
+                                <input
+                                    id="min_avg_seedtime"
+                                    class="form__text"
+                                    type="text"
+                                    name="group[min_avg_seedtime]"
+                                    placeholder=" "
+                                    value="{{ $minAverageSeedtime['value'] }}"
+                                />
+                                <label
+                                    class="form__label form__label--floating"
+                                    for="min_avg_seedtime"
+                                >
+                                    Minimum average seedtime
+                                </label>
+                            </p>
+                        </div>
+                        <div class="form__group--horizontal">
+                            <p class="form__group">
+                                <select
+                                    id="min_seedsize_unit"
+                                    class="form__select"
+                                    name="group[min_seedsize_unit]"
+                                    x-bind:disabled="!autogroup"
+                                >
+                                    <option
+                                        value="bytes"
+                                        @selected($minSeedsize['unit'] === 'bytes')
+                                    >
+                                        Bytes
+                                    </option>
+                                    <option value="mb" @selected($minSeedsize['unit'] === 'mb')>
+                                        MB
+                                    </option>
+                                    <option value="gb" @selected($minSeedsize['unit'] === 'gb')>
+                                        GB
+                                    </option>
+                                    <option value="tb" @selected($minSeedsize['unit'] === 'tb')>
+                                        TB
+                                    </option>
+                                </select>
+                                <label
+                                    class="form__label form__label--floating"
+                                    for="min_seedsize_unit"
+                                >
+                                    Seedsize unit
+                                </label>
+                            </p>
+                            <p class="form__group">
+                                <input
+                                    id="min_seedsize"
+                                    class="form__text"
+                                    type="text"
+                                    name="group[min_seedsize]"
+                                    placeholder=" "
+                                    value="{{ $minSeedsize['value'] }}"
+                                />
+                                <label class="form__label form__label--floating" for="min_seedsize">
+                                    Minimum seedsize
+                                </label>
+                            </p>
+                        </div>
                         <p class="form__group">
                             <input
                                 id="min_uploads"

--- a/tests/Feature/Http/Controllers/Staff/GroupControllerTest.php
+++ b/tests/Feature/Http/Controllers/Staff/GroupControllerTest.php
@@ -15,12 +15,21 @@ declare(strict_types=1);
  */
 
 use App\Http\Controllers\Staff\GroupController;
+use App\Http\Middleware\UpdateLastAction;
 use App\Http\Requests\Staff\StoreGroupRequest;
 use App\Http\Requests\Staff\UpdateGroupRequest;
 use App\Models\Forum;
 use App\Models\Group;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 
 use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function (): void {
+    $this->withoutMiddleware([
+        ThrottleRequestsWithRedis::class,
+        UpdateLastAction::class,
+    ]);
+});
 
 test('create returns an ok response', function (): void {
     $this->get(route('staff.groups.create'))
@@ -101,6 +110,72 @@ test('store returns an ok response', function (): void {
     assertDatabaseHas('groups', [
         'name'     => $group->name,
         'position' => $group->position,
+    ]);
+});
+
+test('store converts autogroup requirement units', function (): void {
+    $group = Group::factory()->make([
+        'name'      => 'Unit Converted',
+        'autogroup' => true,
+    ]);
+    $forum = Forum::factory()->create();
+
+    $this->post(route('staff.groups.store'), [
+        'group' => [
+            'name'                  => $group->name,
+            'position'              => $group->position,
+            'level'                 => $group->level,
+            'color'                 => $group->color,
+            'icon'                  => $group->icon,
+            'effect'                => $group->effect,
+            'is_uploader'           => $group->is_uploader,
+            'is_internal'           => $group->is_internal,
+            'is_owner'              => $group->is_owner,
+            'is_admin'              => $group->is_admin,
+            'is_modo'               => $group->is_modo,
+            'is_torrent_modo'       => $group->is_torrent_modo,
+            'is_editor'             => $group->is_editor,
+            'is_trusted'            => $group->is_trusted,
+            'is_immune'             => $group->is_immune,
+            'is_freeleech'          => $group->is_freeleech,
+            'is_double_upload'      => $group->is_double_upload,
+            'can_chat'              => $group->can_chat,
+            'can_comment'           => $group->can_comment,
+            'can_invite'            => $group->can_invite,
+            'can_request'           => $group->can_request,
+            'can_upload'            => $group->can_upload,
+            'is_incognito'          => $group->is_incognito,
+            'autogroup'             => true,
+            'min_uploaded'          => 5,
+            'min_uploaded_unit'     => 'gb',
+            'min_seedsize'          => 2,
+            'min_seedsize_unit'     => 'tb',
+            'min_age'               => 3,
+            'min_age_unit'          => 'weeks',
+            'min_avg_seedtime'      => 4,
+            'min_avg_seedtime_unit' => 'days',
+            'min_ratio'             => 1.5,
+            'min_uploads'           => 12,
+        ],
+        'permissions' => [
+            [
+                'forum_id'    => $forum->id,
+                'read_topic'  => true,
+                'start_topic' => true,
+                'reply_topic' => true,
+            ],
+        ],
+    ])
+        ->assertRedirect(route('staff.groups.index'))
+        ->assertSessionHasNoErrors();
+
+    assertDatabaseHas('groups', [
+        'name'             => 'Unit Converted',
+        'min_uploaded'     => 5 * 1024 ** 3,
+        'min_seedsize'     => 2 * 1024 ** 4,
+        'min_age'          => 3 * 604800,
+        'min_avg_seedtime' => 4 * 86400,
+        'min_uploads'      => 12,
     ]);
 });
 


### PR DESCRIPTION
## Summary
- add unit selectors for autogroup upload, seed size, account age, and average seedtime requirements
- convert selected byte/time units back to the existing persisted byte/second values during staff group create/update
- display existing persisted values in the largest clean unit when editing a group
- cover converted autogroup requirements with a staff group feature test

Closes HDInnovations/UNIT3D#3693

## Tests
- vendor/bin/pint --test app/Support/AutogroupRequirementUnits.php app/Http/Requests/Staff/StoreGroupRequest.php app/Http/Requests/Staff/UpdateGroupRequest.php app/Http/Controllers/Staff/GroupController.php tests/Feature/Http/Controllers/Staff/GroupControllerTest.php
- npx prettier --check resources/views/Staff/group/create.blade.php resources/views/Staff/group/edit.blade.php
- php artisan test tests/Feature/Http/Controllers/Staff/GroupControllerTest.php --stop-on-failure