### PR TITLE
Add API endpoint for torrent requests

### DIFF
--- a/app/Http/Controllers/API/TorrentRequestController.php
+++ b/app/Http/Controllers/API/TorrentRequestController.php
@@ -17,12 +17,32 @@ declare(strict_types=1);
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\API\StoreTorrentRequestRequest;
 use App\Http\Resources\TorrentRequestResource;
 use App\Models\TorrentRequest;
+use App\Services\TorrentRequestCreator;
 use Illuminate\Http\Request;
 
 class TorrentRequestController extends Controller
 {
+    public function __construct(private readonly TorrentRequestCreator $torrentRequestCreator)
+    {
+    }
+
+    /**
+     * Store a newly created request.
+     */
+    public function store(StoreTorrentRequestRequest $request): \Illuminate\Http\JsonResponse
+    {
+        $torrentRequest = $this->torrentRequestCreator->create($request->user(), $request->validated())
+            ->load(['user', 'claim.user', 'filler'])
+            ->loadSum('bounties', 'seedbonus');
+
+        return (new TorrentRequestResource($torrentRequest))
+            ->response()
+            ->setStatusCode(201);
+    }
+
     /**
      * Request search filter.
      */

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -22,11 +22,8 @@ use App\Http\Requests\UpdateTorrentRequestRequest;
 use App\Models\Category;
 use App\Models\Resolution;
 use App\Models\TorrentRequest;
-use App\Models\TorrentRequestBounty;
 use App\Models\Type;
-use App\Repositories\ChatRepository;
-use App\Services\Igdb\IgdbScraper;
-use App\Services\Tmdb\TMDBScraper;
+use App\Services\TorrentRequestCreator;
 use Illuminate\Http\Request;
 use Exception;
 
@@ -38,7 +35,7 @@ class RequestController extends Controller
     /**
      * RequestController Constructor.
      */
-    public function __construct(private readonly ChatRepository $chatRepository)
+    public function __construct(private readonly TorrentRequestCreator $torrentRequestCreator)
     {
     }
 
@@ -135,39 +132,7 @@ class RequestController extends Controller
      */
     public function store(StoreTorrentRequestRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $user = $request->user();
-
-        $user->decrement('seedbonus', $request->bounty);
-
-        $torrentRequest = TorrentRequest::query()->create([
-            'user_id'   => $request->user()->id,
-            'bumped_at' => now(),
-        ] + $request->validated());
-
-        TorrentRequestBounty::query()->create([
-            'user_id'     => $user->id,
-            'seedbonus'   => $request->bounty,
-            'requests_id' => $torrentRequest->id,
-            'anon'        => $request->anon,
-        ]);
-
-        // Auto Shout
-        if (!$torrentRequest->anon) {
-            $this->chatRepository->systemMessage(
-                \sprintf('[url=%s]%s[/url] has created a new request [url=%s]%s[/url]', href_profile($user), $user->username, href_request($torrentRequest), $torrentRequest->name)
-            );
-        } else {
-            $this->chatRepository->systemMessage(
-                \sprintf('An anonymous user has created a new request [url=%s]%s[/url]', href_request($torrentRequest), $torrentRequest->name)
-            );
-        }
-
-        match (true) {
-            $torrentRequest->tmdb_tv_id !== null    => new TMDBScraper()->tv($torrentRequest->tmdb_tv_id),
-            $torrentRequest->tmdb_movie_id !== null => new TMDBScraper()->movie($torrentRequest->tmdb_movie_id),
-            $torrentRequest->igdb !== null          => new IgdbScraper()->game($torrentRequest->igdb),
-            default                                 => null,
-        };
+        $this->torrentRequestCreator->create($request->user(), $request->validated());
 
         return to_route('requests.index')
             ->with('success', trans('request.added-request'));

--- a/app/Http/Requests/API/StoreTorrentRequestRequest.php
+++ b/app/Http/Requests/API/StoreTorrentRequestRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Http\Requests\API;
+
+use App\Http\Requests\StoreTorrentRequestRequest as WebStoreTorrentRequestRequest;
+use App\Models\Category;
+
+class StoreTorrentRequestRequest extends WebStoreTorrentRequestRequest
+{
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $category = Category::query()->find($this->integer('category_id'));
+        $tmdb = $this->input('tmdb') ?: null;
+
+        $this->merge([
+            'tmdb_movie_id' => $this->input('tmdb_movie_id') ?: ($category?->movie_meta ? $tmdb : null),
+            'tmdb_tv_id'    => $this->input('tmdb_tv_id') ?: ($category?->tv_meta ? $tmdb : null),
+            'imdb'          => $this->input('imdb') ?: null,
+            'tvdb'          => $this->input('tvdb') ?: null,
+            'mal'           => $this->input('mal') ?: null,
+            'igdb'          => $this->input('igdb') ?: null,
+            'anon'          => $this->input('anon', $this->input('anonymous', false)),
+        ]);
+    }
+}

--- a/app/Services/TorrentRequestCreator.php
+++ b/app/Services/TorrentRequestCreator.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Services;
+
+use App\Models\TorrentRequest;
+use App\Models\TorrentRequestBounty;
+use App\Models\User;
+use App\Repositories\ChatRepository;
+use App\Services\Igdb\IgdbScraper;
+use App\Services\Tmdb\TMDBScraper;
+
+final readonly class TorrentRequestCreator
+{
+    public function __construct(private ChatRepository $chatRepository)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function create(User $user, array $attributes): TorrentRequest
+    {
+        $bounty = $attributes['bounty'];
+        $anon = (bool) $attributes['anon'];
+
+        $user->decrement('seedbonus', $bounty);
+
+        $torrentRequest = TorrentRequest::query()->create([
+            'user_id'   => $user->id,
+            'bumped_at' => now(),
+        ] + $attributes);
+
+        TorrentRequestBounty::query()->create([
+            'user_id'     => $user->id,
+            'seedbonus'   => $bounty,
+            'requests_id' => $torrentRequest->id,
+            'anon'        => $anon,
+        ]);
+
+        if (! $torrentRequest->anon) {
+            $this->chatRepository->systemMessage(
+                \sprintf('[url=%s]%s[/url] has created a new request [url=%s]%s[/url]', href_profile($user), $user->username, href_request($torrentRequest), $torrentRequest->name)
+            );
+        } else {
+            $this->chatRepository->systemMessage(
+                \sprintf('An anonymous user has created a new request [url=%s]%s[/url]', href_request($torrentRequest), $torrentRequest->name)
+            );
+        }
+
+        match (true) {
+            $torrentRequest->tmdb_tv_id !== null    => new TMDBScraper()->tv($torrentRequest->tmdb_tv_id),
+            $torrentRequest->tmdb_movie_id !== null => new TMDBScraper()->movie($torrentRequest->tmdb_movie_id),
+            $torrentRequest->igdb !== null          => new IgdbScraper()->game($torrentRequest->igdb),
+            default                                 => null,
+        };
+
+        return $torrentRequest;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -52,6 +52,7 @@ Route::middleware([Authenticate::using(AuthGuard::API->value), CheckIfBanned::cl
 
     // Requests System
     Route::prefix('requests')->group(function (): void {
+        Route::post('/', [App\Http\Controllers\API\TorrentRequestController::class, 'store']);
         Route::get('/filter', [App\Http\Controllers\API\TorrentRequestController::class, 'filter']);
         Route::get('/{id}', [App\Http\Controllers\API\TorrentRequestController::class, 'show'])->where('id', '[0-9]+');
     });

--- a/tests/Feature/Http/Controllers/API/TorrentRequestControllerTest.php
+++ b/tests/Feature/Http/Controllers/API/TorrentRequestControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Enums\AuthGuard;
+use App\Http\Middleware\UpdateLastAction;
+use App\Models\Category;
+use App\Models\Resolution;
+use App\Models\Type;
+use App\Models\User;
+use App\Repositories\ChatRepository;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+
+use function Pest\Laravel\assertDatabaseCount;
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function (): void {
+    $this->withoutMiddleware([
+        ThrottleRequestsWithRedis::class,
+        UpdateLastAction::class,
+    ]);
+
+    $this->app->instance(ChatRepository::class, new class () extends ChatRepository {
+        public function systemMessage(string $message): void
+        {
+        }
+    });
+});
+
+test('store creates a torrent request from the api', function (): void {
+    $category = Category::factory()->create([
+        'movie_meta' => false,
+        'tv_meta'    => false,
+        'game_meta'  => false,
+        'music_meta' => false,
+        'no_meta'    => true,
+    ]);
+    $type = Type::factory()->create();
+    $resolution = Resolution::factory()->create();
+    $user = User::factory()->create([
+        'can_request' => true,
+        'seedbonus'   => 1000,
+    ]);
+
+    $response = $this->actingAs($user, AuthGuard::API->value)
+        ->postJson('/api/requests', [
+            'name'          => 'API Wanted',
+            'description'   => 'Created from the API.',
+            'category_id'   => $category->id,
+            'type_id'       => $type->id,
+            'resolution_id' => $resolution->id,
+            'bounty'        => 250,
+            'anonymous'     => false,
+        ]);
+
+    $response
+        ->assertCreated()
+        ->assertJsonPath('data.name', 'API Wanted')
+        ->assertJsonPath('data.description', 'Created from the API.')
+        ->assertJsonPath('data.category_id', $category->id)
+        ->assertJsonPath('data.user', $user->username);
+
+    assertDatabaseHas('requests', [
+        'name'          => 'API Wanted',
+        'description'   => 'Created from the API.',
+        'category_id'   => $category->id,
+        'type_id'       => $type->id,
+        'resolution_id' => $resolution->id,
+        'user_id'       => $user->id,
+        'bounty'        => 250,
+        'anon'          => false,
+    ]);
+    assertDatabaseHas('request_bounty', [
+        'user_id'   => $user->id,
+        'seedbonus' => 250,
+        'anon'      => false,
+    ]);
+    assertDatabaseHas('users', [
+        'id'        => $user->id,
+        'seedbonus' => 750,
+    ]);
+});
+
+test('store rejects a torrent request when bounty exceeds user balance', function (): void {
+    $category = Category::factory()->create([
+        'movie_meta' => false,
+        'tv_meta'    => false,
+        'game_meta'  => false,
+        'music_meta' => false,
+        'no_meta'    => true,
+    ]);
+    $user = User::factory()->create([
+        'can_request' => true,
+        'seedbonus'   => 50,
+    ]);
+
+    $this->actingAs($user, AuthGuard::API->value)
+        ->postJson('/api/requests', [
+            'name'        => 'Too Expensive',
+            'description' => 'The bounty is higher than the user balance.',
+            'category_id' => $category->id,
+            'bounty'      => 100,
+            'anon'        => false,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('bounty');
+
+    assertDatabaseCount('requests', 0);
+    assertDatabaseCount('request_bounty', 0);
+});


### PR DESCRIPTION
## Summary
- add an authenticated `POST /api/requests` endpoint for creating torrent requests
- reuse the existing web request creation side effects through a shared creator service
- add API-friendly request validation aliases and focused creation/balance tests

Closes HDInnovations/UNIT3D#3645

## Tests
- vendor/bin/pint --test app/Services/TorrentRequestCreator.php app/Http/Controllers/RequestController.php app/Http/Requests/API/StoreTorrentRequestRequest.php app/Http/Controllers/API/TorrentRequestController.php tests/Feature/Http/Controllers/API/TorrentRequestControllerTest.php routes/api.php
- php artisan test tests/Feature/Http/Controllers/API/TorrentRequestControllerTest.php --stop-on-failure
- git diff --check