### PR TITLE
Refactor preserved timestamp updates

### DIFF
--- a/app/Console/Commands/AutoCorrectHistory.php
+++ b/app/Console/Commands/AutoCorrectHistory.php
@@ -19,7 +19,6 @@ namespace App\Console\Commands;
 use App\Models\History;
 use Illuminate\Console\Command;
 use Exception;
-use Illuminate\Support\Facades\DB;
 use Throwable;
 
 class AutoCorrectHistory extends Command
@@ -45,14 +44,15 @@ class AutoCorrectHistory extends Command
      */
     final public function handle(): void
     {
-        History::query()
-            ->withTrashed()
-            ->where('active', '=', 1)
-            ->where('updated_at', '<', now()->subHours(2))
-            ->update([
-                'active'     => 0,
-                'updated_at' => DB::raw('updated_at'),
-            ]);
+        History::withoutTimestamps(
+            fn () => History::query()
+                ->withTrashed()
+                ->where('active', '=', 1)
+                ->where('updated_at', '<', now()->subHours(2))
+                ->update([
+                    'active' => 0,
+                ])
+        );
 
         $this->comment('Automated history record correction command complete');
     }

--- a/app/Console/Commands/AutoFlushPeers.php
+++ b/app/Console/Commands/AutoFlushPeers.php
@@ -20,7 +20,6 @@ use App\Models\History;
 use App\Models\Peer;
 use Illuminate\Console\Command;
 use Exception;
-use Illuminate\Support\Facades\DB;
 use Throwable;
 
 class AutoFlushPeers extends Command
@@ -53,22 +52,24 @@ class AutoFlushPeers extends Command
             ->get();
 
         foreach ($peers as $peer) {
-            History::query()
-                ->where('torrent_id', '=', $peer->torrent_id)
-                ->where('user_id', '=', $peer->user_id)
-                ->update([
-                    'active'     => false,
-                    'updated_at' => DB::raw('updated_at')
-                ]);
+            History::withoutTimestamps(
+                fn () => History::query()
+                    ->where('torrent_id', '=', $peer->torrent_id)
+                    ->where('user_id', '=', $peer->user_id)
+                    ->update([
+                        'active' => false,
+                    ])
+            );
 
-            Peer::query()
-                ->where('torrent_id', '=', $peer->torrent_id)
-                ->where('user_id', '=', $peer->user_id)
-                ->where('peer_id', '=', $peer->peer_id)
-                ->update([
-                    'active'     => false,
-                    'updated_at' => DB::raw('updated_at'),
-                ]);
+            Peer::withoutTimestamps(
+                fn () => Peer::query()
+                    ->where('torrent_id', '=', $peer->torrent_id)
+                    ->where('user_id', '=', $peer->user_id)
+                    ->where('peer_id', '=', $peer->peer_id)
+                    ->update([
+                        'active' => false,
+                    ])
+            );
         }
 
         // Keep peers that stopped being announced without a `stopped` event

--- a/app/Console/Commands/AutoHighspeedTag.php
+++ b/app/Console/Commands/AutoHighspeedTag.php
@@ -53,22 +53,23 @@ class AutoHighspeedTag extends Command
             ->filter(fn ($ip) => filter_var($ip, FILTER_VALIDATE_IP) !== false)
             ->map(fn ($ip) => inet_pton($ip));
 
-        Torrent::query()
-            ->withoutGlobalScope(ApprovedScope::class)
-            ->leftJoinSub(
-                Peer::query()
-                    ->where('seeder', '=', 1)
-                    ->where('active', '=', 1)
-                    ->distinct()
-                    ->select('torrent_id')
-                    ->whereIn('ip', $seedboxIps),
-                'highspeed_torrents',
-                fn ($join) => $join->on('torrents.id', '=', 'highspeed_torrents.torrent_id')
-            )
-            ->update([
-                'highspeed'  => DB::raw('CASE WHEN highspeed_torrents.torrent_id IS NOT NULL THEN TRUE ELSE FALSE END'),
-                'updated_at' => DB::raw('updated_at'),
-            ]);
+        Torrent::withoutTimestamps(
+            fn () => Torrent::query()
+                ->withoutGlobalScope(ApprovedScope::class)
+                ->leftJoinSub(
+                    Peer::query()
+                        ->where('seeder', '=', 1)
+                        ->where('active', '=', 1)
+                        ->distinct()
+                        ->select('torrent_id')
+                        ->whereIn('ip', $seedboxIps),
+                    'highspeed_torrents',
+                    fn ($join) => $join->on('torrents.id', '=', 'highspeed_torrents.torrent_id')
+                )
+                ->update([
+                    'highspeed' => DB::raw('CASE WHEN highspeed_torrents.torrent_id IS NOT NULL THEN TRUE ELSE FALSE END'),
+                ])
+        );
 
         $this->comment('Automated high speed torrents command complete');
     }

--- a/app/Console/Commands/AutoPreWarning.php
+++ b/app/Console/Commands/AutoPreWarning.php
@@ -20,7 +20,6 @@ use App\Models\History;
 use App\Notifications\UserPreWarning;
 use Illuminate\Console\Command;
 use Exception;
-use Illuminate\Support\Facades\DB;
 use Throwable;
 
 class AutoPreWarning extends Command
@@ -69,13 +68,14 @@ class AutoPreWarning extends Command
         $usersWithPreWarnings = [];
 
         foreach ($prewarn as $pre) {
-            History::query()
-                ->where('torrent_id', '=', $pre->torrent_id)
-                ->where('user_id', '=', $pre->user_id)
-                ->update([
-                    'prewarned_at' => now(),
-                    'updated_at'   => DB::raw('updated_at'),
-                ]);
+            History::withoutTimestamps(
+                fn () => History::query()
+                    ->where('torrent_id', '=', $pre->torrent_id)
+                    ->where('user_id', '=', $pre->user_id)
+                    ->update([
+                        'prewarned_at' => now(),
+                    ])
+            );
 
             // Add user to usersWithWarnings array
             $usersWithPreWarnings[$pre->user_id] = $pre->user;

--- a/app/Console/Commands/AutoTorrentBalance.php
+++ b/app/Console/Commands/AutoTorrentBalance.php
@@ -47,19 +47,20 @@ class AutoTorrentBalance extends Command
     final public function handle(): void
     {
         DB::transaction(static function (): void {
-            Torrent::query()->withoutGlobalScopes()->joinSub(
-                History::query()
-                    ->withTrashed()
-                    ->select('torrent_id')
-                    ->selectRaw('SUM(actual_uploaded) - SUM(actual_downloaded) AS balance')
-                    ->groupBy('torrent_id'),
-                'balances',
-                static fn ($join) => $join->on('balances.torrent_id', '=', 'torrents.id')
-            )
-                ->update([
-                    'torrents.balance' => DB::raw('balances.balance'),
-                    'updated_at'       => DB::raw('updated_at'),
-                ]);
+            Torrent::withoutTimestamps(
+                fn () => Torrent::query()->withoutGlobalScopes()->joinSub(
+                    History::query()
+                        ->withTrashed()
+                        ->select('torrent_id')
+                        ->selectRaw('SUM(actual_uploaded) - SUM(actual_downloaded) AS balance')
+                        ->groupBy('torrent_id'),
+                    'balances',
+                    static fn ($join) => $join->on('balances.torrent_id', '=', 'torrents.id')
+                )
+                    ->update([
+                        'torrents.balance' => DB::raw('balances.balance'),
+                    ])
+            );
         }, 5);
 
         $this->comment('Torrent balance calculations completed.');

--- a/app/Console/Commands/AutoWarning.php
+++ b/app/Console/Commands/AutoWarning.php
@@ -80,13 +80,14 @@ class AutoWarning extends Command
                 'active'     => true,
             ]);
 
-            History::query()
-                ->where('torrent_id', '=', $hr->torrent_id)
-                ->where('user_id', '=', $hr->user_id)
-                ->update([
-                    'hitrun'     => true,
-                    'updated_at' => DB::raw('updated_at'),
-                ]);
+            History::withoutTimestamps(
+                fn () => History::query()
+                    ->where('torrent_id', '=', $hr->torrent_id)
+                    ->where('user_id', '=', $hr->user_id)
+                    ->update([
+                        'hitrun' => true,
+                    ])
+            );
 
             // Add +1 To Users Warnings Count In Users Table
             $hr->user->increment('hitandruns');

--- a/app/Http/Controllers/Staff/FlushController.php
+++ b/app/Http/Controllers/Staff/FlushController.php
@@ -23,7 +23,6 @@ use App\Models\Message;
 use App\Models\Peer;
 use App\Repositories\ChatRepository;
 use Exception;
-use Illuminate\Support\Facades\DB;
 
 /**
  * @see \Tests\Todo\Feature\Http\Controllers\Staff\FlushControllerTest
@@ -51,13 +50,14 @@ class FlushController extends Controller
         $peers = Peer::query()->select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', now()->subHours(2))->get();
 
         foreach ($peers as $peer) {
-            History::query()
-                ->where('torrent_id', '=', $peer->torrent_id)
-                ->where('user_id', '=', $peer->user_id)
-                ->update([
-                    'active'     => false,
-                    'updated_at' => DB::raw('updated_at'),
-                ]);
+            History::withoutTimestamps(
+                fn () => History::query()
+                    ->where('torrent_id', '=', $peer->torrent_id)
+                    ->where('user_id', '=', $peer->user_id)
+                    ->update([
+                        'active' => false,
+                    ])
+            );
 
             Peer::query()
                 ->where('torrent_id', '=', $peer->torrent_id)

--- a/app/Http/Controllers/User/PeerController.php
+++ b/app/Http/Controllers/User/PeerController.php
@@ -20,7 +20,6 @@ use App\Http\Controllers\Controller;
 use App\Models\History;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class PeerController extends Controller
 {
@@ -68,13 +67,14 @@ class PeerController extends Controller
             ->where('updated_at', '<', $cutoff)
             ->delete();
 
-        $user->history()
-            ->where('active', '=', 1)
-            ->where('updated_at', '<', $cutoff)
-            ->update([
-                'active'     => 0,
-                'updated_at' => DB::raw('updated_at'),
-            ]);
+        History::withoutTimestamps(
+            fn () => $user->history()
+                ->where('active', '=', 1)
+                ->where('updated_at', '<', $cutoff)
+                ->update([
+                    'active' => 0,
+                ])
+        );
 
         $user->decrement('own_flushes');
 


### PR DESCRIPTION
## Description
- replace runtime Eloquent updates that preserved `updated_at` via `DB::raw('updated_at')` with `Model::withoutTimestamps(...)`
- remove no-longer-needed DB facade imports where those raw expressions were the only use
- leave migration/seeder upsert no-ops untouched because they are not equivalent to the requested update refactor

Closes HDInnovations/UNIT3D#4298

## Tests
- `docker run --rm -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app unit3d-php-test vendor/bin/pint --test app/Console/Commands/AutoPreWarning.php app/Console/Commands/AutoHighspeedTag.php app/Console/Commands/AutoWarning.php app/Console/Commands/AutoCorrectHistory.php app/Console/Commands/AutoFlushPeers.php app/Console/Commands/AutoTorrentBalance.php app/Http/Controllers/User/PeerController.php app/Http/Controllers/Staff/FlushController.php`
- `docker run --rm -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app unit3d-php-test sh -lc 'for f in app/Console/Commands/AutoPreWarning.php app/Console/Commands/AutoHighspeedTag.php app/Console/Commands/AutoWarning.php app/Console/Commands/AutoCorrectHistory.php app/Console/Commands/AutoFlushPeers.php app/Console/Commands/AutoTorrentBalance.php app/Http/Controllers/User/PeerController.php app/Http/Controllers/Staff/FlushController.php; do php -l "" >/dev/null || exit 1; done; printf "%s\n" "syntax ok"'`
- `git diff --check`
- `docker run --rm --network unit3d-test-net -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app ... unit3d-php-test vendor/bin/pest tests/Unit/Console/Commands/AutoPreWarningTest.php tests/Unit/Console/Commands/AutoHighspeedTagTest.php tests/Unit/Console/Commands/AutoWarningTest.php tests/Unit/Console/Commands/AutoCorrectHistoryTest.php tests/Unit/Console/Commands/AutoFlushPeersTest.php tests/Unit/Console/Commands/AutoTorrentBalanceTest.php` (6 passed, 6 assertions; used a temporary local-only `Route::livewire` to `Route::get` shim so current development boots under local Livewire 4, then reverted before commit)