### PR TITLE
Add per-user moderation queue override

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -193,7 +193,7 @@ class TorrentController extends BaseController
         }
 
         // check for trusted user & mod queue isn't opted in and update torrent
-        if ($user->group->is_trusted && !$request->boolean('mod_queue_opt_in')) {
+        if ($user->canSkipTorrentModeration($request->boolean('mod_queue_opt_in'))) {
             $user = $torrent->user;
             $username = $user->username;
             $anon = $torrent->anon;

--- a/app/Http/Controllers/Staff/UserController.php
+++ b/app/Http/Controllers/Staff/UserController.php
@@ -93,13 +93,14 @@ class UserController extends Controller
     public function permissions(Request $request, User $user): \Illuminate\Http\RedirectResponse
     {
         $user->update([
-            'can_chat'    => $request->filled('can_chat') ? $request->boolean('can_chat') : null,
-            'can_comment' => $request->filled('can_comment') ? $request->boolean('can_comment') : null,
-            'can_invite'  => $request->filled('can_invite') ? $request->boolean('can_invite') : null,
-            'can_request' => $request->filled('can_request') ? $request->boolean('can_request') : null,
-            'can_upload'  => $request->filled('can_upload') ? $request->boolean('can_upload') : null,
-            'is_donor'    => $request->boolean('is_donor'),
-            'is_lifetime' => $request->boolean('is_lifetime'),
+            'can_chat'        => $request->filled('can_chat') ? $request->boolean('can_chat') : null,
+            'can_comment'     => $request->filled('can_comment') ? $request->boolean('can_comment') : null,
+            'can_invite'      => $request->filled('can_invite') ? $request->boolean('can_invite') : null,
+            'can_request'     => $request->filled('can_request') ? $request->boolean('can_request') : null,
+            'can_upload'      => $request->filled('can_upload') ? $request->boolean('can_upload') : null,
+            'force_mod_queue' => $request->boolean('force_mod_queue'),
+            'is_donor'        => $request->boolean('is_donor'),
+            'is_lifetime'     => $request->boolean('is_lifetime'),
         ]);
 
         cache()->forget('user:'.$user->passkey);

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -633,7 +633,7 @@ class TorrentController extends Controller
         }
 
         // check for trusted user and update torrent
-        if ($user->group->is_trusted && !$request->boolean('mod_queue_opt_in')) {
+        if ($user->canSkipTorrentModeration($request->boolean('mod_queue_opt_in'))) {
             $user = $torrent->user;
             $username = $user->username;
             $anon = $torrent->anon;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,6 +66,7 @@ use AllowDynamicProperties;
  * @property bool                            $can_request
  * @property bool                            $can_invite
  * @property bool                            $can_upload
+ * @property bool                            $force_mod_queue
  * @property bool                            $is_donor
  * @property bool                            $is_lifetime
  * @property string|null                     $remember_token
@@ -129,6 +130,7 @@ final class User extends Authenticatable implements MustVerifyEmail
      *     can_request: 'bool',
      *     can_invite: 'bool',
      *     can_upload: 'bool',
+     *     force_mod_queue: 'bool',
      *     can_chat: 'bool',
      *     seedbonus: 'decimal:2',
      *     is_donor: 'bool',
@@ -148,6 +150,7 @@ final class User extends Authenticatable implements MustVerifyEmail
             'can_request'             => 'bool',
             'can_invite'              => 'bool',
             'can_upload'              => 'bool',
+            'force_mod_queue'         => 'bool',
             'can_chat'                => 'bool',
             'is_donor'                => 'bool',
             'is_lifetime'             => 'bool',
@@ -183,6 +186,11 @@ final class User extends Authenticatable implements MustVerifyEmail
             'can_upload'   => config('user.group.defaults.can_upload'),
             'level'        => config('user.group.defaults.level'),
         ]);
+    }
+
+    public function canSkipTorrentModeration(bool $modQueueOptIn = false): bool
+    {
+        return $this->group->is_trusted && !$this->force_mod_queue && !$modQueueOptIn;
     }
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -63,6 +63,7 @@ class UserFactory extends Factory
             'can_request'       => $this->faker->boolean(),
             'can_invite'        => $this->faker->boolean(),
             'can_upload'        => $this->faker->boolean(),
+            'force_mod_queue'   => false,
             'remember_token'    => Str::random(10),
             'api_token'         => $this->faker->uuid(),
             'last_login'        => $this->faker->dateTime(),

--- a/database/migrations/2026_05_13_000001_add_force_mod_queue_to_users_table.php
+++ b/database/migrations/2026_05_13_000001_add_force_mod_queue_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->boolean('force_mod_queue')->default(false)->after('can_upload');
+        });
+    }
+};

--- a/resources/views/Staff/user/edit.blade.php
+++ b/resources/views/Staff/user/edit.blade.php
@@ -341,6 +341,18 @@
                     </fieldset>
                 </div>
                 <p class="form__group">
+                    <input type="hidden" name="force_mod_queue" value="0" />
+                    <input
+                        type="checkbox"
+                        class="form__checkbox"
+                        id="force_mod_queue"
+                        name="force_mod_queue"
+                        value="1"
+                        @checked($user->force_mod_queue)
+                    />
+                    <label for="force_mod_queue">Force moderation queue?</label>
+                </p>
+                <p class="form__group">
                     <input type="hidden" name="is_donor" value="0" />
                     <input
                         type="checkbox"

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -584,7 +584,7 @@
                     />
                     <label class="form__label" for="personal_release">Personal release?</label>
                 </p>
-                @if ($user->group->is_trusted)
+                @if ($user->group->is_trusted && ! $user->force_mod_queue)
                     <p class="form__group">
                         <input type="hidden" name="mod_queue_opt_in" value="0" />
                         <input

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Models\Group;
+use App\Models\User;
+
+describe('user model', function (): void {
+    it('allows trusted users to skip torrent moderation', function (): void {
+        $group = Group::factory()->create(['is_trusted' => true]);
+        $user = User::factory()->create(['group_id' => $group->id]);
+
+        expect($user->canSkipTorrentModeration())->toBeTrue();
+    });
+
+    it('does not skip torrent moderation when the user is forced through mod queue', function (): void {
+        $group = Group::factory()->create(['is_trusted' => true]);
+        $user = User::factory()->create([
+            'group_id'        => $group->id,
+            'force_mod_queue' => true,
+        ]);
+
+        expect($user->canSkipTorrentModeration())->toBeFalse();
+    });
+
+    it('does not skip torrent moderation when the user opts in', function (): void {
+        $group = Group::factory()->create(['is_trusted' => true]);
+        $user = User::factory()->create(['group_id' => $group->id]);
+
+        expect($user->canSkipTorrentModeration(modQueueOptIn: true))->toBeFalse();
+    });
+
+    it('does not skip torrent moderation for untrusted users', function (): void {
+        $group = Group::factory()->create(['is_trusted' => false]);
+        $user = User::factory()->create(['group_id' => $group->id]);
+
+        expect($user->canSkipTorrentModeration())->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Description
- add a per-user `force_mod_queue` permission flag for staff
- keep upload permission behavior unchanged while preventing trusted users with the flag from auto-approving uploads
- hide the upload form's voluntary moderation queue opt-in when moderation is already forced

Closes HDInnovations/UNIT3D#4080

## Tests
- `docker run --rm -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app unit3d-php-test vendor/bin/pint --test app/Models/User.php app/Http/Controllers/TorrentController.php app/Http/Controllers/API/TorrentController.php app/Http/Controllers/Staff/UserController.php database/factories/UserFactory.php database/migrations/2026_05_13_000001_add_force_mod_queue_to_users_table.php tests/Unit/Models/UserTest.php`
- `npx prettier --check resources/views/Staff/user/edit.blade.php resources/views/torrent/create.blade.php`
- `docker run --rm -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app unit3d-php-test sh -lc 'for f in app/Models/User.php app/Http/Controllers/TorrentController.php app/Http/Controllers/API/TorrentController.php app/Http/Controllers/Staff/UserController.php database/factories/UserFactory.php database/migrations/2026_05_13_000001_add_force_mod_queue_to_users_table.php tests/Unit/Models/UserTest.php; do php -l "" >/dev/null || exit 1; done; printf "%s\n" "syntax ok"'`
- `git diff --check`
- `docker run --rm --network unit3d-test-net -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app ... unit3d-php-test vendor/bin/pest tests/Unit/Models/UserTest.php` (4 passed, 4 assertions; used a temporary local-only `Route::livewire` to `Route::get` shim so current development boots under local Livewire 4, then reverted before commit)