### PR TITLE
Add inactive ticket auto-close workflow

### DIFF
--- a/app/Console/Commands/AutoCloseInactiveTickets.php
+++ b/app/Console/Commands/AutoCloseInactiveTickets.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Console\Commands;
+
+use App\Models\Ticket;
+use App\Notifications\TicketAutoCloseReminder;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+class AutoCloseInactiveTickets extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auto:close_inactive_tickets';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remind users about stale helpdesk tickets and close them if they remain inactive.';
+
+    final public function handle(): void
+    {
+        $now = now();
+        $reminderDays = max(1, (int) config('ticket.auto_close_reminder_days', 3));
+        $graceHours = max(1, (int) config('ticket.auto_close_grace_hours', 24));
+        $closed = 0;
+        $reminded = 0;
+
+        $this->ticketsWithLatestStaffReply($now)
+            ->where('reminded_at', '<=', $now->copy()->subHours($graceHours))
+            ->chunkById(100, function ($tickets) use (&$closed, $now): void {
+                foreach ($tickets as $ticket) {
+                    $ticket->update([
+                        'closed_at' => $now,
+                    ]);
+
+                    ++$closed;
+                }
+            });
+
+        $this->ticketsWithLatestStaffReply($now->copy()->subDays($reminderDays))
+            ->whereNull('reminded_at')
+            ->with('user')
+            ->chunkById(100, function ($tickets) use (&$reminded, $graceHours, $now): void {
+                foreach ($tickets as $ticket) {
+                    $ticket->update([
+                        'reminded_at' => $now,
+                        'user_read'   => false,
+                    ]);
+
+                    $ticket->user->notify(new TicketAutoCloseReminder($ticket, $graceHours));
+
+                    ++$reminded;
+                }
+            });
+
+        $this->comment("Automated inactive ticket command complete: {$reminded} reminded, {$closed} closed.");
+    }
+
+    /**
+     * @return Builder<Ticket>
+     */
+    private function ticketsWithLatestStaffReply(Carbon $latestCommentCutoff): Builder
+    {
+        return Ticket::query()
+            ->whereNull('closed_at')
+            ->whereHas(
+                'latestComment',
+                fn (Builder $query) => $query->where('created_at', '<=', $latestCommentCutoff)
+            )
+            ->whereHas(
+                'latestComment.user.group',
+                fn (Builder $query) => $query->where('is_modo', '=', true)
+            );
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,6 +19,7 @@ namespace App\Console;
 use App\Console\Commands\AutoBonAllocation;
 use App\Console\Commands\AutoCacheRandomMediaIds;
 use App\Console\Commands\AutoCacheUserLeechCounts;
+use App\Console\Commands\AutoCloseInactiveTickets;
 use App\Console\Commands\AutoCorrectHistory;
 use App\Console\Commands\AutoDeactivateWarning;
 use App\Console\Commands\AutoDeleteStoppedPeers;
@@ -98,6 +99,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(AutoRecycleFailedLogins::class)->daily();
         $schedule->command(AutoDisableInactiveUsers::class)->daily();
         $schedule->command(AutoSoftDeleteDisabledUsers::class)->daily();
+        $schedule->command(AutoCloseInactiveTickets::class)->hourly();
         $schedule->command(AutoRecycleClaimedTorrentRequests::class)->daily();
         $schedule->command(DeleteUnparticipatedConversations::class)->daily();
         $schedule->command(AutoCorrectHistory::class)->daily();

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -118,7 +118,8 @@ class TicketController extends Controller
         abort_unless($request->user()->group->is_modo || $request->user()->id === $ticket->user_id, 403);
 
         $ticket->update([
-            'closed_at' => null,
+            'closed_at'   => null,
+            'reminded_at' => null,
         ]);
 
         return to_route('tickets.show', ['ticket' => $ticket])

--- a/app/Http/Livewire/Comment.php
+++ b/app/Http/Livewire/Comment.php
@@ -162,6 +162,12 @@ class Comment extends Component
             case Ticket::class:
                 $ticket = $this->model;
 
+                if ($this->user->id === $ticket->user_id) {
+                    $ticket->update([
+                        'reminded_at' => null,
+                    ]);
+                }
+
                 if ($this->user->id !== $ticket->staff_id && $ticket->staff_id !== null) {
                     User::query()->find($ticket->staff_id)->notify(new NewComment($this->model, $reply));
                     $this->model->update(['staff_read' => false]);

--- a/app/Http/Livewire/Comments.php
+++ b/app/Http/Livewire/Comments.php
@@ -134,6 +134,12 @@ class Comments extends Component
         // New Comment Notification
         switch ($this->model::class) {
             case Ticket::class:
+                if ($this->user->id === $this->model->user_id) {
+                    $this->model->update([
+                        'reminded_at' => null,
+                    ]);
+                }
+
                 // Notify assigned staff if needed
                 User::query()->find($this->model->staff_id)?->notify(new NewComment($this->model, $comment));
 

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use AllowDynamicProperties;
 
 /**
@@ -128,6 +129,16 @@ final class Ticket extends Model
     public function comments(): MorphMany
     {
         return $this->morphMany(Comment::class, 'commentable');
+    }
+
+    /**
+     * Get the latest comment for the ticket.
+     *
+     * @return MorphOne<Comment, $this>
+     */
+    public function latestComment(): MorphOne
+    {
+        return $this->morphOne(Comment::class, 'commentable')->latestOfMany('created_at');
     }
 
     /**

--- a/app/Notifications/TicketAutoCloseReminder.php
+++ b/app/Notifications/TicketAutoCloseReminder.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Notifications;
+
+use App\Models\Ticket;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class TicketAutoCloseReminder extends Notification
+{
+    use Queueable;
+
+    public function __construct(public Ticket $ticket, public int $graceHours)
+    {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, string>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'title' => 'Ticket response needed',
+            'body'  => 'Ticket '.$this->ticket->subject.' will close automatically if you do not reply within '.$this->graceHours.' hours.',
+            'url'   => '/tickets/'.$this->ticket->id,
+        ];
+    }
+}

--- a/config/ticket.php
+++ b/config/ticket.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'auto_close_reminder_days' => env('TICKET_AUTO_CLOSE_REMINDER_DAYS', 3),
+    'auto_close_grace_hours'   => env('TICKET_AUTO_CLOSE_GRACE_HOURS', 24),
+];

--- a/tests/Feature/Console/Commands/AutoCloseInactiveTicketsTest.php
+++ b/tests/Feature/Console/Commands/AutoCloseInactiveTicketsTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Models\Group;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Notifications\TicketAutoCloseReminder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+
+uses(RefreshDatabase::class);
+
+test('it reminds the ticket creator after a stale staff reply', function (): void {
+    Notification::fake();
+
+    config([
+        'ticket.auto_close_reminder_days' => 3,
+        'ticket.auto_close_grace_hours'   => 24,
+    ]);
+
+    $user = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => false])->id,
+    ]);
+    $staff = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => true])->id,
+    ]);
+    $ticket = Ticket::factory()->create([
+        'user_id'     => $user->id,
+        'staff_id'    => $staff->id,
+        'user_read'   => true,
+        'closed_at'   => null,
+        'reminded_at' => null,
+        'deleted_at'  => null,
+    ]);
+    $ticket->comments()->create([
+        'content'    => 'Can you confirm this is still an issue?',
+        'user_id'    => $staff->id,
+        'anon'       => false,
+        'created_at' => now()->subDays(4),
+        'updated_at' => now()->subDays(4),
+    ]);
+
+    $this->artisan('auto:close_inactive_tickets')
+        ->assertExitCode(0)
+        ->run();
+
+    $ticket->refresh();
+
+    expect($ticket->closed_at)->toBeNull()
+        ->and($ticket->reminded_at)->not->toBeNull()
+        ->and($ticket->user_read)->toBeFalse();
+
+    Notification::assertSentTo(
+        $user,
+        TicketAutoCloseReminder::class,
+        fn (TicketAutoCloseReminder $notification) => $notification->ticket->is($ticket) && $notification->graceHours === 24
+    );
+});
+
+test('it closes reminded tickets after the grace window when the latest reply is still staff', function (): void {
+    Notification::fake();
+
+    config([
+        'ticket.auto_close_reminder_days' => 3,
+        'ticket.auto_close_grace_hours'   => 24,
+    ]);
+
+    $user = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => false])->id,
+    ]);
+    $staff = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => true])->id,
+    ]);
+    $ticket = Ticket::factory()->create([
+        'user_id'     => $user->id,
+        'staff_id'    => $staff->id,
+        'closed_at'   => null,
+        'reminded_at' => now()->subHours(25),
+        'deleted_at'  => null,
+    ]);
+    $ticket->comments()->create([
+        'content'    => 'Following up before closure.',
+        'user_id'    => $staff->id,
+        'anon'       => false,
+        'created_at' => now()->subDays(4),
+        'updated_at' => now()->subDays(4),
+    ]);
+
+    $this->artisan('auto:close_inactive_tickets')
+        ->assertExitCode(0)
+        ->run();
+
+    expect($ticket->refresh()->closed_at)->not->toBeNull();
+
+    Notification::assertNothingSent();
+});
+
+test('it does not close a reminded ticket after the user replies', function (): void {
+    config([
+        'ticket.auto_close_reminder_days' => 3,
+        'ticket.auto_close_grace_hours'   => 24,
+    ]);
+
+    $user = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => false])->id,
+    ]);
+    $staff = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => true])->id,
+    ]);
+    $ticket = Ticket::factory()->create([
+        'user_id'     => $user->id,
+        'staff_id'    => $staff->id,
+        'closed_at'   => null,
+        'reminded_at' => now()->subHours(25),
+        'deleted_at'  => null,
+    ]);
+    $ticket->comments()->create([
+        'content'    => 'Following up before closure.',
+        'user_id'    => $staff->id,
+        'anon'       => false,
+        'created_at' => now()->subDays(4),
+        'updated_at' => now()->subDays(4),
+    ]);
+    $ticket->comments()->create([
+        'content'    => 'I still need help.',
+        'user_id'    => $user->id,
+        'anon'       => false,
+        'created_at' => now()->subHours(2),
+        'updated_at' => now()->subHours(2),
+    ]);
+
+    $this->artisan('auto:close_inactive_tickets')
+        ->assertExitCode(0)
+        ->run();
+
+    expect($ticket->refresh()->closed_at)->toBeNull();
+});

--- a/tests/Feature/Notifications/NewCommentTicketNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentTicketNotificationTest.php
@@ -63,8 +63,9 @@ test('user comments own ticket does not create a notification for self but assig
     ]);
 
     $ticket = Ticket::factory()->create([
-        'user_id'  => $user->id,
-        'staff_id' => $staff->id,
+        'user_id'     => $user->id,
+        'staff_id'    => $staff->id,
+        'reminded_at' => now()->subHour(),
     ]);
 
     $commentText = 'This is a test comment';
@@ -76,6 +77,7 @@ test('user comments own ticket does not create a notification for self but assig
         ->call('postComment');
 
     $this->assertEquals(1, Comment::query()->count());
+    $this->assertNull($ticket->refresh()->reminded_at);
 
     Notification::assertSentTo(
         [$staff],


### PR DESCRIPTION
## Summary
- add an hourly helpdesk command that reminds ticket creators after a stale staff reply and auto-closes tickets after the grace window
- use the existing `tickets.reminded_at` column plus configurable reminder/grace intervals
- clear pending auto-close reminders when the ticket creator replies or a ticket is reopened

Closes HDInnovations/UNIT3D#4377

## Tests
- `docker run --rm -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app unit3d-php-test vendor/bin/pint --test app/Console/Commands/AutoCloseInactiveTickets.php app/Console/Kernel.php app/Http/Controllers/TicketController.php app/Http/Livewire/Comment.php app/Http/Livewire/Comments.php app/Models/Ticket.php app/Notifications/TicketAutoCloseReminder.php config/ticket.php tests/Feature/Console/Commands/AutoCloseInactiveTicketsTest.php`
- `docker run --rm -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app unit3d-php-test vendor/bin/pint --test tests/Feature/Notifications/NewCommentTicketNotificationTest.php`
- `docker run --rm -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app unit3d-php-test sh -lc 'for f in app/Console/Commands/AutoCloseInactiveTickets.php app/Console/Kernel.php app/Http/Controllers/TicketController.php app/Http/Livewire/Comment.php app/Http/Livewire/Comments.php app/Models/Ticket.php app/Notifications/TicketAutoCloseReminder.php config/ticket.php tests/Feature/Console/Commands/AutoCloseInactiveTicketsTest.php; do php -l "$f" >/dev/null || exit 1; done; printf "%s\n" "syntax ok"'`
- `git diff --check`
- `docker run --rm --network unit3d-test-net -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app ... unit3d-php-test vendor/bin/pest tests/Feature/Console/Commands/AutoCloseInactiveTicketsTest.php` (3 passed, 10 assertions)
- `docker run --rm --network unit3d-test-net -v "/home/ahmad/Desktop/money/repos/UNIT3D":/app -w /app ... unit3d-php-test vendor/bin/pest tests/Feature/Console/Commands/AutoCloseInactiveTicketsTest.php tests/Feature/Notifications/NewCommentTicketNotificationTest.php tests/Feature/Notifications/NewCommentTicketTagNotificationTest.php tests/Feature/Http/Controllers/TicketControllerTest.php` (10 passed, 30 assertions; 9 existing generated controller tests incomplete; used a temporary local-only `Route::livewire` to `Route::get` shim so current development boots under local Livewire 4, then reverted before commit)