### PR TITLE
Add automatic freeleech duration

### DIFF
--- a/app/Helpers/TorrentHelper.php
+++ b/app/Helpers/TorrentHelper.php
@@ -64,6 +64,9 @@ class TorrentHelper
             foreach ($autoFreeleeches as $autoFreeleech) {
                 if ($autoFreeleech->name_regex === null || preg_match($autoFreeleech->name_regex, $torrent->name)) {
                     $torrent->free = $autoFreeleech->freeleech_percentage;
+                    $torrent->fl_until = $autoFreeleech->freeleech_duration === null || $autoFreeleech->freeleech_percentage === 0
+                        ? null
+                        : now()->addDays($autoFreeleech->freeleech_duration);
 
                     break;
                 }

--- a/app/Http/Requests/Staff/StoreAutomaticTorrentFreeleechRequest.php
+++ b/app/Http/Requests/Staff/StoreAutomaticTorrentFreeleechRequest.php
@@ -43,6 +43,7 @@ class StoreAutomaticTorrentFreeleechRequest extends FormRequest
             'type_id'              => ['nullable', 'integer', 'exists:types,id'],
             'resolution_id'        => ['nullable', 'integer', 'exists:resolutions,id'],
             'freeleech_percentage' => ['required', 'integer', 'max:100', 'min:0'],
+            'freeleech_duration'   => ['nullable', 'integer', 'min:1'],
         ];
     }
 }

--- a/app/Http/Requests/Staff/UpdateAutomaticTorrentFreeleechRequest.php
+++ b/app/Http/Requests/Staff/UpdateAutomaticTorrentFreeleechRequest.php
@@ -43,6 +43,7 @@ class UpdateAutomaticTorrentFreeleechRequest extends FormRequest
             'type_id'              => ['nullable', 'integer', 'exists:types,id'],
             'resolution_id'        => ['nullable', 'integer', 'exists:resolutions,id'],
             'freeleech_percentage' => ['required', 'integer', 'max:100', 'min:0'],
+            'freeleech_duration'   => ['nullable', 'integer', 'min:1'],
         ];
     }
 }

--- a/app/Models/AutomaticTorrentFreeleech.php
+++ b/app/Models/AutomaticTorrentFreeleech.php
@@ -29,6 +29,20 @@ final class AutomaticTorrentFreeleech extends Model
     protected $guarded = [];
 
     /**
+     * Get the attributes that should be cast.
+     *
+     * @return array{
+     *     freeleech_duration: 'int',
+     * }
+     */
+    protected function casts(): array
+    {
+        return [
+            'freeleech_duration' => 'int',
+        ];
+    }
+
+    /**
      * Get the category that owns automatic torrent freeleech.
      *
      * @return BelongsTo<Category, $this>

--- a/database/migrations/2026_05_13_000003_add_freeleech_duration_to_automatic_torrent_freeleeches_table.php
+++ b/database/migrations/2026_05_13_000003_add_freeleech_duration_to_automatic_torrent_freeleeches_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('automatic_torrent_freeleeches', function (Blueprint $table): void {
+            $table->unsignedInteger('freeleech_duration')->nullable()->after('freeleech_percentage');
+        });
+    }
+};

--- a/resources/views/Staff/automatic-torrent-freeleech/create.blade.php
+++ b/resources/views/Staff/automatic-torrent-freeleech/create.blade.php
@@ -139,6 +139,21 @@
                     </label>
                 </p>
                 <p class="form__group">
+                    <input
+                        type="text"
+                        name="freeleech_duration"
+                        id="freeleech_duration"
+                        class="form__text"
+                        inputmode="numeric"
+                        pattern="[1-9][0-9]*"
+                        placeholder=" "
+                        value="{{ old('freeleech_duration') }}"
+                    />
+                    <label class="form__label form__label--floating" for="freeleech_duration">
+                        Freeleech duration (days)
+                    </label>
+                </p>
+                <p class="form__group">
                     <button class="form__button form__button--filled">
                         {{ __('common.add') }}
                     </button>
@@ -153,7 +168,7 @@
         <h2 class="panel__heading">{{ __('common.info') }}</h2>
         <div class="panel__body">
             When a torrent is uploaded that meets the given criteria, the specified freeleech
-            percentage will be automatically applied.
+            percentage will be automatically applied. Leave duration empty to apply it indefinitely.
         </div>
     </section>
 @endsection

--- a/resources/views/Staff/automatic-torrent-freeleech/edit.blade.php
+++ b/resources/views/Staff/automatic-torrent-freeleech/edit.blade.php
@@ -145,6 +145,21 @@
                     </label>
                 </p>
                 <p class="form__group">
+                    <input
+                        type="text"
+                        name="freeleech_duration"
+                        id="freeleech_duration"
+                        class="form__text"
+                        inputmode="numeric"
+                        pattern="[1-9][0-9]*"
+                        placeholder=" "
+                        value="{{ $automaticTorrentFreeleech->freeleech_duration }}"
+                    />
+                    <label class="form__label form__label--floating" for="freeleech_duration">
+                        Freeleech duration (days)
+                    </label>
+                </p>
+                <p class="form__group">
                     <button class="form__button form__button--filled">
                         {{ __('common.submit') }}
                     </button>
@@ -159,7 +174,7 @@
         <h2 class="panel__heading">{{ __('common.info') }}</h2>
         <div class="panel__body">
             When a torrent is uploaded that meets the given criteria, the specified freeleech
-            percentage will be automatically applied.
+            percentage will be automatically applied. Leave duration empty to apply it indefinitely.
         </div>
     </section>
 @endsection

--- a/resources/views/Staff/automatic-torrent-freeleech/index.blade.php
+++ b/resources/views/Staff/automatic-torrent-freeleech/index.blade.php
@@ -35,6 +35,7 @@
                         <th>{{ __('common.type') }}</th>
                         <th>{{ __('common.resolution') }}</th>
                         <th>Freeleech percentage</th>
+                        <th>Freeleech duration</th>
                         <th>{{ __('common.created_at') }}</th>
                         <th>{{ __('torrent.updated_at') }}</th>
                         <th>{{ __('common.actions') }}</th>
@@ -52,6 +53,14 @@
                             <td>{{ $automaticTorrentFreeleech->type?->name ?? 'Any' }}</td>
                             <td>{{ $automaticTorrentFreeleech->resolution?->name ?? 'Any' }}</td>
                             <td>{{ $automaticTorrentFreeleech->freeleech_percentage }}</td>
+                            <td>
+                                @if ($automaticTorrentFreeleech->freeleech_duration === null)
+                                    Indefinite
+                                @else
+                                    {{ $automaticTorrentFreeleech->freeleech_duration }}
+                                    {{ Illuminate\Support\Str::plural('day', $automaticTorrentFreeleech->freeleech_duration) }}
+                                @endif
+                            </td>
                             <td>
                                 <time
                                     datetime="{{ $automaticTorrentFreeleech->created_at }}"
@@ -100,7 +109,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="10">No automated torrent freeleeches</td>
+                            <td colspan="11">No automated torrent freeleeches</td>
                         </tr>
                     @endforelse
                 </tbody>
@@ -114,7 +123,7 @@
         <h2 class="panel__heading">{{ __('common.info') }}</h2>
         <div class="panel__body">
             When a torrent is uploaded that meets the given criteria, the specified freeleech
-            percentage will be automatically applied.
+            percentage will be automatically applied. Rules without a duration apply indefinitely.
         </div>
     </section>
 @endsection

--- a/tests/Unit/Helpers/TorrentHelperTest.php
+++ b/tests/Unit/Helpers/TorrentHelperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Helpers\TorrentHelper;
+use App\Models\AutomaticTorrentFreeleech;
+use App\Models\Torrent;
+use Illuminate\Support\Carbon;
+
+test('approve helper applies automatic torrent freeleech duration', function (): void {
+    $this->asAuthenticatedUser();
+
+    $now = now()->startOfSecond();
+    Carbon::setTestNow($now);
+
+    try {
+        AutomaticTorrentFreeleech::query()->create([
+            'position'             => 0,
+            'freeleech_percentage' => 100,
+            'freeleech_duration'   => 3,
+        ]);
+
+        $torrent = Torrent::factory()->create([
+            'anon'     => true,
+            'free'     => 0,
+            'fl_until' => null,
+        ]);
+
+        TorrentHelper::approveHelper($torrent->id);
+
+        $torrent->refresh();
+
+        expect($torrent->free)->toBe(100)
+            ->and($torrent->fl_until?->equalTo($now->copy()->addDays(3)))->toBeTrue();
+    } finally {
+        Carbon::setTestNow();
+    }
+});


### PR DESCRIPTION
Closes #3690.

## Summary
- Add optional duration in days for automatic torrent freeleech rules.
- Set fl_until when a matching rule has a duration; blank keeps existing indefinite behavior.
- Show/edit duration in staff automatic torrent freeleech screens.

## Tests
- git diff --check
- vendor/bin/pint --test app/Helpers/TorrentHelper.php app/Http/Requests/Staff/StoreAutomaticTorrentFreeleechRequest.php app/Http/Requests/Staff/UpdateAutomaticTorrentFreeleechRequest.php app/Models/AutomaticTorrentFreeleech.php database/migrations/2026_05_13_000003_add_freeleech_duration_to_automatic_torrent_freeleeches_table.php tests/Unit/Helpers/TorrentHelperTest.php
- npx prettier --check resources/views/Staff/automatic-torrent-freeleech/create.blade.php resources/views/Staff/automatic-torrent-freeleech/edit.blade.php resources/views/Staff/automatic-torrent-freeleech/index.blade.php
- php -l on changed PHP files
- vendor/bin/pest tests/Unit/Helpers/TorrentHelperTest.php

Note: the focused Pest run needed the existing local test bootstrap workaround of temporarily changing three Route::livewire test routes to Route::get; that temporary shim was reverted before commit.