### PR TITLE
(Fix) Trending `from` and `until` default values

### DIFF
--- a/app/Http/Livewire/Trending.php
+++ b/app/Http/Livewire/Trending.php
@@ -46,6 +46,12 @@ class Trending extends Component
     #[Validate('sometimes|date_format:Y-m-d')]
     public string $from = '' {
         set(string $value) {
+            if ($value === '') {
+                $this->from = '';
+
+                return;
+            }
+
             try {
                 $this->from = Carbon::parse($value)->format('Y-m-d');
             } catch (Throwable) {
@@ -58,6 +64,12 @@ class Trending extends Component
     #[Validate('sometimes|date_format:Y-m-d')]
     public string $until = '' {
         set(string $value) {
+            if ($value === '') {
+                $this->until = '';
+
+                return;
+            }
+
             try {
                 $this->until = Carbon::parse($value)->format('Y-m-d');
             } catch (Throwable) {


### PR DESCRIPTION
Livewire for whatever reason is setting the values when the page is first loaded, which sets it to the current day in the failed try-catch, instead of keeping them as empty strings until the user chooses to change them. Fix by explicitly checking for the empty string and setting the value before the try-catch.