### PR TITLE
(Remove) gitattributes for bun binary lock file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.lockb binary diff=lockb


### PR DESCRIPTION
We no longer have this file format after bun transitioned to a text-based lock file.