### PR TITLE
(Update) Only select necessary columns in invite tree

### DIFF
--- a/app/Http/Controllers/User/InviteTreeController.php
+++ b/app/Http/Controllers/User/InviteTreeController.php
@@ -100,6 +100,18 @@ class InviteTreeController extends Controller
             ->addBinding(User::SYSTEM_USER_ID, 'join')
             ->with([
                 'receiver' => fn ($query) => $query
+                    ->select([
+                        'id',
+                        'group_id',
+                        'username',
+                        'uploaded',
+                        'downloaded',
+                        'created_at',
+                        'last_action',
+                        'is_donor',
+                        'icon',
+                        'is_lifetime',
+                    ])
                     ->withTrashed()
                     ->with('group')
                     ->withAvg(['history' => fn ($query) => $query->withTrashed()], 'seedtime')


### PR DESCRIPTION
Reduces memory from 103 MB to 93 MB for an invite tree of ~4100 users. The blade alone used 40 MB of the 103 MB.