### PR TITLE
(Refactor) Link to fortify controllers directly

### DIFF
--- a/app/Enums/GlobalRateLimit.php
+++ b/app/Enums/GlobalRateLimit.php
@@ -25,6 +25,8 @@ enum GlobalRateLimit: string
     case EMAIL_VERIFICATION = 'email-verification';
     case FORGOT_PASSWORD = 'forgot-password';
     case IGDB = 'igdb';
+    case LOGIN = 'login';
+    case TWO_FACTOR = 'two-factor';
     case REGISTER = 'register';
     case RESET_PASSWORD = 'reset-password';
     case RSS = 'rss';

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -22,11 +22,9 @@ use App\Models\Group;
 use App\Models\User;
 use App\Notifications\FailedLogin;
 use App\Services\Unit3dAnnounce;
-use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
@@ -42,6 +40,8 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        Fortify::ignoreRoutes();
+
         // Handle redirects after successful login
         $this->app->instance(LoginResponse::class, new class () implements LoginResponse {
             public function toResponse($request): \Illuminate\Http\RedirectResponse
@@ -93,10 +93,6 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        RateLimiter::for('login', fn (Request $request) => Limit::perMinute(5)->by('fortify-login'.$request->ip()));
-        RateLimiter::for('fortify-login-get', fn (Request $request) => Limit::perMinute(5)->by('fortify-login'.$request->ip()));
-        RateLimiter::for('two-factor', fn (Request $request) => Limit::perMinute(5)->by('fortify-two-factor'.$request->session()->get('login.id')));
-
         Fortify::loginView(fn () => view('auth.login'));
         Fortify::twoFactorChallengeView(fn () => view('auth.two-factor-challenge'));
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -100,6 +100,8 @@ class RouteServiceProvider extends ServiceProvider
         RateLimiter::for(GlobalRateLimit::RESET_PASSWORD, fn (Request $request) => Limit::perMinute(5)->by('reset-password'.$request->ip()));
         RateLimiter::for(GlobalRateLimit::REGISTER, fn (Request $request) => Limit::perMinute(5)->by('register'.$request->ip()));
         RateLimiter::for(GlobalRateLimit::EMAIL_VERIFICATION, fn (Request $request) => Limit::perMinute(5)->by('email-verification'.$request->user()->id));
+        RateLimiter::for(GlobalRateLimit::LOGIN, fn (Request $request) => Limit::perMinute(5)->by('login'.$request->ip()));
+        RateLimiter::for(GlobalRateLimit::TWO_FACTOR, fn (Request $request) => Limit::perMinute(5)->by('two-factor'.$request->session()->get('login.id')));
     }
 
     protected function removeIndexPhpFromUrl(): void

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -107,9 +107,7 @@ return [
     */
 
     'limiters' => [
-        'login'             => 'login',
-        'two-factor'        => 'two-factor',
-        'fortify-login-get' => 'fortify-login-get',
+        'login' => null,
     ],
 
     /*

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -21,7 +21,7 @@
                 <form
                     class="auth-form__form"
                     method="POST"
-                    action="{{ route('two-factor.login') }}"
+                    action="{{ route('two-factor.login.store') }}"
                 >
                     @csrf
                     <a class="auth-form__branding" href="{{ route('home.index') }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,8 +27,6 @@ use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Illuminate\Routing\Middleware\ValidateSignature;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
-use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
-use Laravel\Fortify\RoutePath;
 
 /*
 |--------------------------------------------------------------------------
@@ -50,19 +48,6 @@ if (config('unit3d.root_url_override')) {
 Route::middleware(SetLanguage::class)->group(function (): void {
     /*
     |---------------------------------------------------------------------------------
-    | Laravel Fortify Route Overrides
-    | Don't update Fortify without first making sure this override works.
-    |---------------------------------------------------------------------------------
-    */
-
-    Route::middleware(RedirectIfAuthenticated::class.':'.config('fortify.guard'))->group(function (): void {
-        Route::get(RoutePath::for('login', '/login'), [AuthenticatedSessionController::class, 'create'])
-            ->middleware(ThrottleRequestsWithRedis::using(config('fortify.limiters.fortify-login-get')))
-            ->name('login');
-    });
-
-    /*
-    |---------------------------------------------------------------------------------
     | Website (Not Authorized) (Alpha Ordered)
     |---------------------------------------------------------------------------------
     */
@@ -77,6 +62,14 @@ Route::middleware(SetLanguage::class)->group(function (): void {
         Route::get('/reset-password/{token}', [App\Http\Controllers\Auth\NewPasswordController::class, 'create'])->name('password.reset');
         Route::post('/reset-password', [App\Http\Controllers\Auth\NewPasswordController::class, 'store'])->middleware(ThrottleRequestsWithRedis::using(GlobalRateLimit::RESET_PASSWORD))->name('password.update');
 
+        // Login
+        Route::get('/login', [Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::class, 'create'])->name('login');
+        Route::post('/login', [Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::class, 'store'])->name('login.store')->middleware(ThrottleRequestsWithRedis::using(GlobalRateLimit::LOGIN));
+
+        // Two factor
+        Route::get('/two-factor-challenge', [Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::class, 'create'])->name('two-factor.login');
+        Route::post('/two-factor-challenge', [Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::class, 'store'])->middleware(ThrottleRequestsWithRedis::using(GlobalRateLimit::TWO_FACTOR))->name('two-factor.login.store');
+
         // Registration
         Route::get('/register', [App\Http\Controllers\Auth\RegisteredUserController::class, 'create'])->name('registration.create');
         Route::post('/register', [App\Http\Controllers\Auth\RegisteredUserController::class, 'store'])->middleware(ThrottleRequestsWithRedis::using(GlobalRateLimit::REGISTER))->name('registration.store');
@@ -90,6 +83,9 @@ Route::middleware(SetLanguage::class)->group(function (): void {
         Route::get('/email/verify', [App\Http\Controllers\Auth\EmailVerificationController::class, 'create'])->name('verification.notice');
         Route::get('/email/verify/{id}/{hash}', [App\Http\Controllers\Auth\EmailVerificationController::class, 'show'])->middleware(ValidateSignature::class)->name('verification.verify');
         Route::post('/email/verification-notification', [App\Http\Controllers\Auth\EmailVerificationController::class, 'store'])->middleware(ThrottleRequestsWithRedis::using(GlobalRateLimit::EMAIL_VERIFICATION))->name('verification.send');
+
+        // Logout
+        Route::post('/logout', [Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::class, 'destroy'])->name('logout');
     });
 
     /*


### PR DESCRIPTION
Instead of overwriting the existing routes. This way we can disable the route generation altogether. Currently by default it creates routes we do not use.