### PR TITLE
(Update) Two factor confirm checks session timestamp too

### DIFF
--- a/app/Http/Controllers/Auth/ConfirmableTwoFactorController.php
+++ b/app/Http/Controllers/Auth/ConfirmableTwoFactorController.php
@@ -18,6 +18,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Date;
 use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
 
 class ConfirmableTwoFactorController extends Controller
@@ -36,6 +37,8 @@ class ConfirmableTwoFactorController extends Controller
     public function store(Request $request, ConfirmTwoFactorAuthentication $confirm): \Illuminate\Http\RedirectResponse
     {
         $confirm($request->user(), $request->input('code'));
+
+        $request->session()->put('auth.two_factor_confirmed_at', Date::now()->unix());
 
         return redirect()->intended();
     }

--- a/app/Http/Middleware/ConfirmTwoFactor.php
+++ b/app/Http/Middleware/ConfirmTwoFactor.php
@@ -35,7 +35,10 @@ class ConfirmTwoFactor
     {
         if (
             $request->user()->two_factor_confirmed_at !== null
-            && $request->user()->two_factor_confirmed_at < now()->subSeconds(300)
+            && (
+                $request->user()->two_factor_confirmed_at < now()->subSeconds(300)
+                || $request->session()->get('auth.two_factor_confirmed_at', 0) < now()->subSeconds(300)->unix()
+            )
         ) {
             return $this->responseFactory->redirectGuest($this->urlGenerator->route('two-factor.confirm'));
         }

--- a/tests/Feature/Http/Controllers/User/EmailControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/EmailControllerTest.php
@@ -40,7 +40,10 @@ test('edit returns an ok response', function (): void {
     $user = User::factory(['two_factor_confirmed_at' => now()])->create();
 
     $response = $this->actingAs($user)
-        ->withSession(['auth.password_confirmed_at' => now()->unix()])
+        ->withSession([
+            'auth.password_confirmed_at'   => now()->unix(),
+            'auth.two_factor_confirmed_at' => now()->unix(),
+        ])
         ->get(route('users.email.edit', [$user]));
 
     $response->assertOk();
@@ -61,7 +64,10 @@ test('edit aborts with a 403', function (): void {
     ]);
 
     $response = $this->actingAs($authUser)
-        ->withSession(['auth.password_confirmed_at' => now()->unix()])
+        ->withSession([
+            'auth.password_confirmed_at'   => now()->unix(),
+            'auth.two_factor_confirmed_at' => now()->unix(),
+        ])
         ->get(route('users.email.edit', [$user]));
 
     $response->assertForbidden();
@@ -89,7 +95,10 @@ test('update returns an ok response', function (): void {
     $user = User::factory(['two_factor_confirmed_at' => now()])->create();
 
     $response = $this->actingAs($user)
-        ->withSession(['auth.password_confirmed_at' => now()->unix()])
+        ->withSession([
+            'auth.password_confirmed_at'   => now()->unix(),
+            'auth.two_factor_confirmed_at' => now()->unix(),
+        ])
         ->patch(route('users.email.update', [$user]), [
             'email' => fake()->unique()->freeEmail,
         ]);
@@ -111,7 +120,10 @@ test('update aborts with a 403', function (): void {
     ]);
 
     $response = $this->actingAs($authUser)
-        ->withSession(['auth.password_confirmed_at' => now()->unix()])
+        ->withSession([
+            'auth.password_confirmed_at'   => now()->unix(),
+            'auth.two_factor_confirmed_at' => now()->unix(),
+        ])
         ->patch(route('users.email.update', [$user]));
 
     $response->assertForbidden();


### PR DESCRIPTION
To ensure the same session is used for the confirmation and the action afterwards.