### PR TITLE
(Remove) Chatbox reconnection logic

### DIFF
--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -105,15 +105,6 @@ const channelHandler = {
                 const messageTimeout = setTimeout(() => context.activePeer.delete(username), 15000);
                 context.activePeer.set(username, messageTimeout);
             });
-
-        context.channel.error((error) => {
-            console.error('Socket error:', error);
-            context.state.ui.error = 'Connection lost. Trying to reconnect...';
-
-            setTimeout(() => {
-                this.setupRoom(context.state.chat.room, context);
-            }, 5000);
-        });
     },
 };
 


### PR DESCRIPTION
If a user has chatbox open, signs out in another tab, this reconnection logic will go in loops repeatedly calling /broadcasting/auth, triggering the `web` rate limiter which only allows 8 req/min/ip when logged out. This prevents the user from signing in again on the same ip as all the requests will be used up by the other tab with chatbox loaded. Remove the reconnection logic to prevent this from happening. PusherJS already contains reconnection logic of its own anyways at a lower level.