### PR TITLE
(Refactor) Bounty foreign key `requests_id` -> `request_id`

### DIFF
--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -146,10 +146,10 @@ class RequestController extends Controller
         ]);
 
         TorrentRequestBounty::query()->create([
-            'user_id'     => $user->id,
-            'seedbonus'   => $request->bounty,
-            'requests_id' => $torrentRequest->id,
-            'anon'        => $request->anon,
+            'user_id'    => $user->id,
+            'seedbonus'  => $request->bounty,
+            'request_id' => $torrentRequest->id,
+            'anon'       => $request->anon,
         ]);
 
         // Auto Shout

--- a/app/Models/TorrentRequest.php
+++ b/app/Models/TorrentRequest.php
@@ -230,7 +230,7 @@ final class TorrentRequest extends Model
      */
     public function bounties(): HasMany
     {
-        return $this->hasMany(TorrentRequestBounty::class, 'requests_id', 'id');
+        return $this->hasMany(TorrentRequestBounty::class, 'request_id');
     }
 
     /**

--- a/app/Models/TorrentRequestBounty.php
+++ b/app/Models/TorrentRequestBounty.php
@@ -28,7 +28,7 @@ use AllowDynamicProperties;
  * @property int                             $id
  * @property int                             $user_id
  * @property string                          $seedbonus
- * @property int                             $requests_id
+ * @property int                             $request_id
  * @property bool                            $anon
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -88,6 +88,6 @@ final class TorrentRequestBounty extends Model
      */
     public function request(): BelongsTo
     {
-        return $this->belongsTo(TorrentRequest::class, 'requests_id');
+        return $this->belongsTo(TorrentRequest::class);
     }
 }

--- a/app/Notifications/NewRequestBounty.php
+++ b/app/Notifications/NewRequestBounty.php
@@ -78,7 +78,7 @@ class NewRequestBounty extends Notification implements ShouldQueue
         return [
             'title' => ($this->bounty->anon ? 'Anonymous' : $this->bounty->user->username).' added a bounty of '.$this->bounty->seedbonus.' to a requested torrent',
             'body'  => ($this->bounty->anon ? 'Anonymous' : $this->bounty->user->username).' added a bounty to one of your requested torrents: '.$this->bounty->request->name,
-            'url'   => route('requests.show', ['torrentRequest' => $this->bounty->requests_id], false),
+            'url'   => route('requests.show', ['torrentRequest' => $this->bounty->request_id], false),
         ];
     }
 }

--- a/database/factories/TorrentRequestBountyFactory.php
+++ b/database/factories/TorrentRequestBountyFactory.php
@@ -35,11 +35,10 @@ class TorrentRequestBountyFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id'     => User::factory(),
-            'seedbonus'   => $this->faker->randomFloat(),
-            'requests_id' => $this->faker->randomDigitNotNull(),
-            'anon'        => $this->faker->boolean(),
-            'request_id'  => TorrentRequest::factory(),
+            'user_id'    => User::factory(),
+            'seedbonus'  => $this->faker->randomFloat(),
+            'anon'       => $this->faker->boolean(),
+            'request_id' => TorrentRequest::factory(),
         ];
     }
 }

--- a/database/migrations/2026_06_27_065215_rename_bounty_requests_id.php
+++ b/database/migrations/2026_06_27_065215_rename_bounty_requests_id.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('request_bounty', function (Blueprint $table): void {
+            $table->renameColumn('requests_id', 'request_id');
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -1440,14 +1440,14 @@ CREATE TABLE `request_bounty` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `user_id` int unsigned NOT NULL,
   `seedbonus` decimal(12,2) NOT NULL DEFAULT '0.00',
-  `requests_id` int unsigned NOT NULL,
+  `request_id` int unsigned NOT NULL,
   `anon` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `request_bounty_user_id_foreign` (`user_id`),
-  KEY `request_bounty_requests_id_foreign` (`requests_id`),
-  CONSTRAINT `request_bounty_requests_id_foreign` FOREIGN KEY (`requests_id`) REFERENCES `requests` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  KEY `request_bounty_requests_id_foreign` (`request_id`),
+  CONSTRAINT `request_bounty_requests_id_foreign` FOREIGN KEY (`request_id`) REFERENCES `requests` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `request_bounty_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `check_request_bounty_seedbonus` CHECK ((`seedbonus` >= 0))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -3133,3 +3133,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (378,'2026_02_18_02
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (379,'2026_03_10_033755_migrate_request_bounty_created_at_to_updated_at',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (380,'2026_04_22_061705_add_pinned_column_to_posts',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (381,'2026_06_26_132559_update_history_indexes',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (382,'2026_06_27_065215_rename_bounty_requests_id',1);

--- a/tests/Feature/Notifications/NewRequestBountyNotificationTest.php
+++ b/tests/Feature/Notifications/NewRequestBountyNotificationTest.php
@@ -68,8 +68,8 @@ test('add bounty to request creates a notification for the requester', function 
     ]);
 
     $this->assertDatabaseHas('request_bounty', [
-        'requests_id' => $torrentRequest->id,
-        'seedbonus'   => $bounty,
+        'request_id' => $torrentRequest->id,
+        'seedbonus'  => $bounty,
     ]);
 
     Notification::assertSentTo(
@@ -124,8 +124,8 @@ test('add bounty to request creates a notification for the requester when bounty
     ]);
 
     $this->assertDatabaseHas('request_bounty', [
-        'requests_id' => $torrentRequest->id,
-        'seedbonus'   => $bounty,
+        'request_id' => $torrentRequest->id,
+        'seedbonus'  => $bounty,
     ]);
 
     Notification::assertSentTo(
@@ -178,8 +178,8 @@ test('add bounty to request does not create a notification for the requester whe
     ]);
 
     $this->assertDatabaseHas('request_bounty', [
-        'requests_id' => $torrentRequest->id,
-        'seedbonus'   => $bounty,
+        'request_id' => $torrentRequest->id,
+        'seedbonus'  => $bounty,
     ]);
 
     Notification::assertCount(0);
@@ -228,8 +228,8 @@ test('add bounty to request does not create a notification for the requester whe
     ]);
 
     $this->assertDatabaseHas('request_bounty', [
-        'requests_id' => $torrentRequest->id,
-        'seedbonus'   => $bounty,
+        'request_id' => $torrentRequest->id,
+        'seedbonus'  => $bounty,
     ]);
 
     Notification::assertCount(0);
@@ -279,8 +279,8 @@ test('add bounty to request does not create a notification for the requester whe
     ]);
 
     $this->assertDatabaseHas('request_bounty', [
-        'requests_id' => $torrentRequest->id,
-        'seedbonus'   => $bounty,
+        'request_id' => $torrentRequest->id,
+        'seedbonus'  => $bounty,
     ]);
 
     Notification::assertCount(0);


### PR DESCRIPTION
Use standard Laravel naming conventions.