### PR TITLE
(Fix) Use torrent_id in WarningFactory

### DIFF
--- a/database/factories/WarningFactory.php
+++ b/database/factories/WarningFactory.php
@@ -39,7 +39,7 @@ class WarningFactory extends Factory
         return [
             'user_id'    => User::factory(),
             'warned_by'  => User::factory(),
-            'torrent'    => Torrent::factory(),
+            'torrent_id' => Torrent::factory(),
             'reason'     => $this->faker->text(),
             'expires_on' => $this->faker->dateTime(),
             'active'     => $this->faker->boolean(),


### PR DESCRIPTION
The `warnings.torrent` column was renamed to `torrent_id` in migration `2025_11_08_094209_rename_warnings_torrent_to_torrent_id`, but `WarningFactory` still populated the old `torrent` key.

As a result `Warning::factory()->create()` throws:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'torrent' in 'field list'
```

which is why the tests relying on it are currently marked `markTestIncomplete`. This one-line change aligns the factory with the renamed column so the factory (and the tests built on it) work again.