### PR TITLE
(Fix) Null-safe ticket comment notifications

### DIFF
--- a/app/Http/Livewire/Comment.php
+++ b/app/Http/Livewire/Comment.php
@@ -163,17 +163,17 @@ class Comment extends Component
                 $ticket = $this->model;
 
                 if ($this->user->id !== $ticket->staff_id && $ticket->staff_id !== null) {
-                    User::query()->find($ticket->staff_id)->notify(new NewComment($this->model, $reply));
+                    User::query()->find($ticket->staff_id)?->notify(new NewComment($this->model, $reply));
                     $this->model->update(['staff_read' => false]);
                 }
 
                 if ($this->user->id !== $ticket->user_id) {
-                    User::query()->find($ticket->user_id)->notify(new NewComment($this->model, $reply));
+                    User::query()->find($ticket->user_id)?->notify(new NewComment($this->model, $reply));
                     $this->model->update(['user_read' => false]);
                 }
 
                 if (!\in_array($this->comment->user_id, [$ticket->staff_id, $ticket->user_id, $this->user->id])) {
-                    User::query()->find($this->comment->user_id)->notify(new NewComment($this->model, $reply));
+                    User::query()->find($this->comment->user_id)?->notify(new NewComment($this->model, $reply));
                 }
 
                 break;


### PR DESCRIPTION
Comment::postReply() notifies ticket participants with User::query()->find($id)->notify(...) for the staff_id, user_id and prior commenter. User uses SoftDeletes, so find() returns null for a deleted account and replying to the ticket fatals with "notify() on null", so the reply fails to post.

Added the null-safe operator so a deleted participant is skipped. The sibling Torrent/Article/Playlist/Request cases in the same method, and the ticket case in Comments.php, already use ?->notify (all introduced in d128cd523); only these three lines were missed.