### PR TITLE
(Fix) Correct stale columns in Rss/Wish/UserSetting factories

### DIFF
--- a/database/factories/RssFactory.php
+++ b/database/factories/RssFactory.php
@@ -40,7 +40,6 @@ class RssFactory extends Factory
             'is_private'   => $this->faker->boolean(),
             'is_torrent'   => $this->faker->boolean(),
             'json_torrent' => $this->faker->word(),
-            'staff_id'     => User::factory(),
         ];
     }
 }

--- a/database/factories/UserSettingFactory.php
+++ b/database/factories/UserSettingFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\User;
 use App\Models\UserSetting;
 
 /**
@@ -25,17 +26,16 @@ class UserSettingFactory extends Factory
     public function definition(): array
     {
         return [
-            'censor'              => $this->faker->boolean(),
-            'chat_hidden'         => $this->faker->boolean(),
-            'hidden'              => $this->faker->boolean(),
-            'style'               => $this->faker->boolean(),
-            'torrent_layout'      => $this->faker->boolean(),
-            'torrent_filters'     => $this->faker->boolean(),
-            'custom_css'          => $this->faker->word(),
-            'standalone_css'      => $this->faker->word(),
-            'show_poster'         => $this->faker->boolean(),
-            'private_profile'     => $this->faker->boolean(),
-            'block_notifications' => $this->faker->boolean(),
+            'user_id'                           => User::factory(),
+            'censor'                            => $this->faker->boolean(),
+            'style'                             => $this->faker->boolean(),
+            'torrent_layout'                    => $this->faker->boolean(),
+            'torrent_filters'                   => $this->faker->boolean(),
+            'custom_css'                        => $this->faker->word(),
+            'standalone_css'                    => $this->faker->word(),
+            'show_poster'                       => $this->faker->boolean(),
+            'unbookmark_torrents_on_completion' => $this->faker->boolean(),
+            'torrent_sort_field'                => 'bumped_at',
         ];
     }
 }

--- a/database/factories/WishFactory.php
+++ b/database/factories/WishFactory.php
@@ -34,11 +34,9 @@ class WishFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => User::factory(),
-            'title'   => $this->faker->sentence(),
-            'tmdb'    => $this->faker->word(),
-            'type'    => $this->faker->word(),
-            'source'  => $this->faker->word(),
+            'user_id'       => User::factory(),
+            'title'         => $this->faker->sentence(),
+            'tmdb_movie_id' => $this->faker->randomNumber(),
         ];
     }
 }


### PR DESCRIPTION
Several factories reference columns that later migrations renamed, relocated or dropped, so ->create() throws "Unknown column" and any test using them fails.

RssFactory: drop staff_id (removed in 2023_02_03_094806_update_rss_table).
WishFactory: replace tmdb/type/source with tmdb_movie_id (the tmdb column was split into tmdb_movie_id/tmdb_tv_id; type/source were dropped).
UserSettingFactory: drop chat_hidden (dropped), hidden and private_profile (moved to user_privacy), block_notifications (moved to user_notifications); add the required user_id, unbookmark_torrents_on_completion and torrent_sort_field so the factory can persist.

Verified each with a live ->create(), plus Pint and Larastan. Same class of bug as #5508.