### PR TITLE
(Update) Reject logins with `@` in their username

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -66,6 +66,7 @@
                             autocomplete="username"
                             autofocus
                             name="username"
+                            pattern="[^@]*"
                             required
                             type="text"
                             value="{{ old('username') }}"


### PR DESCRIPTION
Prevents users from blocking themselves when their autofill saved their email instead of username