### PR TITLE
(Update) Show maintenance 503 error when database is in read-only state

### DIFF
--- a/.cspell/laravel.txt
+++ b/.cspell/laravel.txt
@@ -16,6 +16,7 @@ mysql
 ordoesnthave
 pgsql
 queueable
+renderable
 sasl
 sslmode
 sqlite

--- a/.cspell/mysql.txt
+++ b/.cspell/mysql.txt
@@ -4,5 +4,6 @@ inet6_ntoa
 innodb
 mysqld
 mysqldump
+sqlstate
 timestampadd
 timestampdiff

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Throwable;
 
@@ -55,7 +56,22 @@ class Handler extends ExceptionHandler
      */
     public function register(): void
     {
-        $this->reportable(function (Throwable $e): void {
+        $this->reportable(fn (QueryException $e): bool => ! self::isReadOnlyError($e));
+
+        $this->renderable(function (QueryException $e): \Illuminate\Http\Response|bool {
+            if (self::isReadOnlyError($e)) {
+                return response()->view('errors.503', [], 503);
+            }
+
+            return false;
         });
+    }
+
+    private static function isReadOnlyError(QueryException $e): bool
+    {
+        return 1 === preg_match(
+            '/SQLSTATE\[HY000\]: General error: 1290 The (MySQL|MariaDB) server is running with the --read-only option so it cannot execute this statement/',
+            $e->getMessage(),
+        );
     }
 }


### PR DESCRIPTION
Allows the site to stay online while the database is read only, while not unneccessarily filling up the logs.