### PR TITLE
(Fix) Delete orphaned people

### DIFF
--- a/app/Console/Commands/DeleteOrphanedPeople.php
+++ b/app/Console/Commands/DeleteOrphanedPeople.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Console\Commands;
+
+use App\Models\TmdbPerson;
+use Illuminate\Console\Command;
+
+class DeleteOrphanedPeople extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auto:delete_orphaned_people';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Deletes people who aren\'t credited';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $start = now();
+
+        $deletedPeople = TmdbPerson::query()->whereDoesntHave('credits')->delete();
+
+        $elapsed = (int) now()->diffInSeconds($start, true);
+
+        $this->info("Deleted {$deletedPeople} people in {$elapsed} seconds");
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -53,6 +53,7 @@ use App\Console\Commands\AutoUpsertAnnounces;
 use App\Console\Commands\AutoUpsertHistories;
 use App\Console\Commands\AutoUpsertPeers;
 use App\Console\Commands\AutoWarning;
+use App\Console\Commands\DeleteOrphanedPeople;
 use App\Console\Commands\DeleteUnparticipatedConversations;
 use App\Console\Commands\EmailBlacklistUpdate;
 use App\Console\Commands\SyncPeers;
@@ -102,6 +103,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(AutoDisableInactiveUsers::class)->daily();
         $schedule->command(AutoSoftDeleteDisabledUsers::class)->daily();
         $schedule->command(AutoRecycleClaimedTorrentRequests::class)->daily();
+        $schedule->command(DeleteOrphanedPeople::class)->daily();
         $schedule->command(DeleteUnparticipatedConversations::class)->daily();
         $schedule->command(AutoCorrectHistory::class)->daily();
         $schedule->command(EmailBlacklistUpdate::class)->weekends();


### PR DESCRIPTION
Often, tmdb merges different people, and the credits have their id updated to the deduplicated person, but the dupe person is still in the database undeleted. Delete these orphaned people daily.