### PR TITLE
(Remove) Unused optimization

### DIFF
--- a/app/Http/Livewire/UserUploads.php
+++ b/app/Http/Livewire/UserUploads.php
@@ -89,7 +89,6 @@ class UserUploads extends Component
                     ->where('seeder', '=', 1),
             ])
             ->withoutGlobalScope(ApprovedScope::class)
-            ->where('created_at', '>=', $this->user->created_at) // Unneeded, but increases performances
             ->where('user_id', '=', $this->user->id)
             ->when(
                 $this->name,


### PR DESCRIPTION
This optimization only makes sense if trying to reduce the dataset before a large join and where user_id isn't indexed.