### PR TITLE
(Remove) Phpunit direct dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
         "pestphp/pest-plugin-livewire": "^4.1.0",
         "pestphp/pest-plugin-type-coverage": "^4.0.3",
         "phpstan/phpstan": "^2.2.5",
-        "phpunit/phpunit": "^12.5.8",
         "ryoluo/sail-ssl": "^1.4.0",
         "spatie/laravel-ignition": "^2.10.0",
         "tomasvotruba/bladestan": "^0.11.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7244eb4b3746a35de370807cf98ae579",
+    "content-hash": "f3a1311f7c9dbbc604859317419272a2",
     "packages": [
         {
             "name": "assada/laravel-achievements",


### PR DESCRIPTION
This is a transitive dependency of pest, not a direct dependency. We don't need this in the root composer.json.