### PR TITLE
(Remove) `paragonie/constant_time_encoding` direct dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "maennchen/zipstream-php": "^3.2.1",
         "marcreichel/igdb-laravel": "^5.3.1",
         "meilisearch/meilisearch-php": "^1.16.1",
-        "paragonie/constant_time_encoding": "^2.8.2",
         "spatie/laravel-backup": "^9.3.7",
         "spatie/ssl-certificate": "^2.6.10",
         "symfony/dom-crawler": "^6.4.25",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "972fcb3262056d8eb96903b3f60beb42",
+    "content-hash": "a4520fb1b8fa2c0249689cf4fae27f28",
     "packages": [
         {
             "name": "assada/laravel-achievements",
@@ -4143,24 +4143,26 @@
         },
         {
             "name": "paragonie/constant_time_encoding",
-            "version": "v2.8.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/constant_time_encoding.git",
-                "reference": "e30811f7bc69e4b5b6d5783e712c06c8eabf0226"
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/e30811f7bc69e4b5b6d5783e712c06c8eabf0226",
-                "reference": "e30811f7bc69e4b5b6d5783e712c06c8eabf0226",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
                 "shasum": ""
             },
             "require": {
-                "php": "^7|^8"
+                "php": "^8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6|^7|^8|^9",
-                "vimeo/psalm": "^1|^2|^3|^4"
+                "infection/infection": "^0",
+                "nikic/php-fuzzer": "^0",
+                "phpunit/phpunit": "^9|^10|^11",
+                "vimeo/psalm": "^4|^5|^6"
             },
             "type": "library",
             "autoload": {
@@ -4206,7 +4208,7 @@
                 "issues": "https://github.com/paragonie/constant_time_encoding/issues",
                 "source": "https://github.com/paragonie/constant_time_encoding"
             },
-            "time": "2025-09-24T15:12:37+00:00"
+            "time": "2025-09-24T15:06:41+00:00"
         },
         {
             "name": "php-http/discovery",


### PR DESCRIPTION
This is a transitive dependency of fortify, not a direct dependency. We don't need this in the root composer.json