### PR TITLE
(Remove) Unused `mockery/mockery` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "jasonmccreary/laravel-test-assertions": "^2.8.0",
         "laravel/pint": "^1.29.1",
         "laravel/sail": "^1.51.0",
-        "mockery/mockery": "^1.6.12",
         "nunomaduro/collision": "^8.8.3",
         "pestphp/pest": "^4.3.2",
         "pestphp/pest-plugin-laravel": "^4.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9c1fdf661d8d96a5fabb5551f80a75b",
+    "content-hash": "7022d7ffcd65cd9dcb9ccd903c232466",
     "packages": [
         {
             "name": "assada/laravel-achievements",


### PR DESCRIPTION
This dependency isn't used at all.