### PR TITLE
(Fix) Two factor auth recovery codes broken with csp

### DIFF
--- a/resources/views/livewire/two-factor-auth-form.blade.php
+++ b/resources/views/livewire/two-factor-auth-form.blade.php
@@ -2,7 +2,7 @@
     <header class="panel__header">
         <h2 class="panel__heading">{{ __('Two Factor Authentication') }}</h2>
     </header>
-    <div class="panel__body">
+    <div class="panel__body" x-data="clipboardButton">
         @if ($this->enabled)
             @if ($showingConfirmation)
                 <span class="text-warning">
@@ -74,11 +74,7 @@
                         {{ __('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.') }}
                     </span>
                     {{-- format-ignore-start --}}
-                    <pre>
-                        @foreach (json_decode(decrypt($this->user->two_factor_recovery_codes), true) as $code)
-                            <div>{{ $code }}</div>
-                        @endforeach
-                    </pre>
+                    <pre><code>{{ implode("\n", json_decode(decrypt($this->user->two_factor_recovery_codes), true)) }}</code></pre>
                     {{-- format-ignore-end --}}
                 </div>
             @endif
@@ -101,37 +97,8 @@
                     >
                         {{ __('Regenerate Recovery Codes') }}
                     </button>
-                    @script
-                        <script
-                            nonce="{{ HDVinnie\SecureHeaders\SecureHeaders::nonce('script') }}"
-                        >
-                            Alpine.data('recovery_codes', () => ({
-                                copy() {
-                                    navigator.clipboard.writeText(
-                                        JSON.parse(
-                                            atob(
-                                                '{{ base64_encode(decrypt($this->user->two_factor_recovery_codes)) }}',
-                                            ),
-                                        ).join('\n'),
-                                    );
-                                    Swal.fire({
-                                        toast: true,
-                                        position: 'top-end',
-                                        showConfirmButton: false,
-                                        timer: 3000,
-                                        icon: 'success',
-                                        title: 'Copied to clipboard!',
-                                    });
-                                },
-                            }));
-                        </script>
-                    @endscript
 
-                    <button
-                        class="form__button form__button--filled"
-                        x-data="recovery_codes"
-                        x-on:click.stop="copy"
-                    >
+                    <button class="form__button form__button--filled" x-bind="button">
                         {{ __('Copy Recovery Codes') }}
                     </button>
                 @elseif ($showingConfirmation)


### PR DESCRIPTION
Seems livewire's @script tag isn't supported by alpine's csp version. Move the component definition to be global instead.