### PR TITLE
(Refactor) `String` -> `string`

### DIFF
--- a/app/Http/Livewire/PostSearch.php
+++ b/app/Http/Livewire/PostSearch.php
@@ -28,7 +28,7 @@ class PostSearch extends Component
     #TODO: Update URL attributes once Livewire 3 fixes upstream bug. See: https://github.com/livewire/livewire/discussions/7746
 
     #[Url(history: true)]
-    public String $search = '';
+    public string $search = '';
 
     final public function updatingSearch(): void
     {


### PR DESCRIPTION
Some rust-isms that slipped through.