### PR TITLE
(Refactor) Remove parentheses from `@csrf()`

### DIFF
--- a/resources/views/user/buttons/user.blade.php
+++ b/resources/views/user/buttons/user.blade.php
@@ -313,7 +313,7 @@
                         method="POST"
                         style="display: contents"
                     >
-                        @csrf()
+                        @csrf
                         @method('DELETE')
                         <button class="nav-tab__link" type="submit">
                             {{ __('staff.flush-ghost-peers') }}


### PR DESCRIPTION
Parentheses aren't supposed to be here.